### PR TITLE
Type helper cleanup, library reorganizations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 * **BREAKING** Fail generation for types that are not a JSON primitive or that
   do not explicitly supports JSON serialization. 
+  
+* **BREAKING** Removed `can` methods from `TypeHelper`. Return `null` from
+  `(de)serialize` if the provided type is not supported.
    
 * Eliminated all implicit casts in generated code. These would end up being
   runtime checks in most cases.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,10 +1,27 @@
 ## 0.2.0
 
+* **BREAKING** Types are now segmented into their own libraries.
+
+  * `package:json_serializable/generators.dart` contains the `Generator` 
+    implementations.
+  
+  * `package:json_serializable/annotations.dart` contains the annotations.
+    This library should be imported with your target classes.
+    
+  * `package:json_serializable/type_helpers.dart` contains `TypeHelper` classes
+    which allows custom generation for specific types. 
+
 * **BREAKING** Fail generation for types that are not a JSON primitive or that
   do not explicitly supports JSON serialization. 
   
-* **BREAKING** Removed `can` methods from `TypeHelper`. Return `null` from
-  `(de)serialize` if the provided type is not supported.
+* **BREAKING** `TypeHelper`:
+
+  * Removed `can` methods. Return `null` from `(de)serialize` if the provided
+    type is not supported.
+    
+  * Added `(de)serializeNested` arguments to `(de)serialize` methods allowing
+    generic types. This is (now) how support for `Iterable`, `List`, and `Map`
+    is implemented.
    
 * Eliminated all implicit casts in generated code. These would end up being
   runtime checks in most cases.

--- a/analysis_options.yaml
+++ b/analysis_options.yaml
@@ -21,7 +21,7 @@ linter:
     - valid_regexps
 
     # Style
-    #- annotate_overrides
+    - annotate_overrides
     - avoid_init_to_null
     - avoid_return_types_on_setters
     - await_only_futures

--- a/example/example.dart
+++ b/example/example.dart
@@ -2,6 +2,7 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
+// ignore_for_file: annotate_overrides
 library json_serializable.example;
 
 import 'package:json_serializable/annotations.dart';

--- a/example/example.g.dart
+++ b/example/example.g.dart
@@ -7,16 +7,16 @@ part of json_serializable.example;
 // Target: class Person
 // **************************************************************************
 
-Person _$PersonFromJson(Map<String, dynamic> json) => new Person(
-    json['firstName'] as String, json['lastName'] as String,
-    middleName: json['middleName'] as String,
-    dateOfBirth: json['date-of-birth'] == null
-        ? null
-        : DateTime.parse(json['date-of-birth'] as String))
-  ..orders = (json['orders'] as List)
-      ?.map((v0) =>
-          v0 == null ? null : new Order.fromJson(v0 as Map<String, dynamic>))
-      ?.toList();
+Person _$PersonFromJson(Map<String, dynamic> json) =>
+    new Person(json['firstName'] as String, json['lastName'] as String,
+        middleName: json['middleName'] as String,
+        dateOfBirth: json['date-of-birth'] == null
+            ? null
+            : DateTime.parse(json['date-of-birth'] as String))
+      ..orders = (json['orders'] as List)
+          ?.map((e) =>
+              e == null ? null : new Order.fromJson(e as Map<String, dynamic>))
+          ?.toList();
 
 abstract class _$PersonSerializerMixin {
   String get firstName;

--- a/lib/generators.dart
+++ b/lib/generators.dart
@@ -2,8 +2,7 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
-export 'src/json_literal.dart';
+/// Generator classes.
+
 export 'src/json_literal_generator.dart';
-export 'src/json_serializable.dart';
 export 'src/json_serializable_generator.dart';
-export 'src/type_helper.dart';

--- a/lib/src/json_serializable_generator.dart
+++ b/lib/src/json_serializable_generator.dart
@@ -12,16 +12,25 @@ import 'package:source_gen/source_gen.dart';
 
 import 'json_serializable.dart';
 import 'type_helper.dart';
+import 'type_helpers/date_time_helper.dart';
+import 'type_helpers/iterable_helper.dart';
+import 'type_helpers/json_helper.dart';
+import 'type_helpers/map_helper.dart';
+import 'type_helpers/value_helper.dart';
 import 'utils.dart';
-
-final _substitute = "e";
 
 // TODO: toJson option to omit null/empty values
 class JsonSerializableGenerator
     extends GeneratorForAnnotation<JsonSerializable> {
+  static const _coreHelpers = const [
+    const IterableHelper(),
+    const MapHelper(),
+    const ValueHelper()
+  ];
+
   static const _defaultHelpers = const [
     const JsonHelper(),
-    const DateTimeHelper()
+    const DateTimeHelper(),
   ];
 
   final List<TypeHelper> _typeHelpers;
@@ -115,8 +124,8 @@ class JsonSerializableGenerator
       fields.forEach((fieldName, field) {
         try {
           pairs.add("'${_fieldToJsonMapKey(fieldName, field)}': "
-              "${_fieldToJsonMapValue(fieldName, field.type)}");
-        } on _UnsupportedTypeError {
+              "${_serialize(field.type, fieldName )}");
+        } on UnsupportedTypeError {
           throw new InvalidGenerationSourceError(
               "Could not generate `toJson` code for `${friendlyNameForElement(field)}`.",
               todo: "Make sure all of the types are serializable.");
@@ -200,7 +209,7 @@ class JsonSerializableGenerator
         .writeln('$className ${prefix}FromJson(Map<String, dynamic> json) =>');
     buffer.write('    new $className(');
     buffer.writeAll(
-        ctorArguments.map((paramElement) => _jsonMapAccessToField(
+        ctorArguments.map((paramElement) => _deserializeForField(
             paramElement.name, fields[paramElement.name],
             ctorParam: paramElement)),
         ', ');
@@ -210,7 +219,7 @@ class JsonSerializableGenerator
     buffer.writeAll(
         ctorNamedArguments.map((paramElement) =>
             '${paramElement.name}: ' +
-            _jsonMapAccessToField(paramElement.name, fields[paramElement.name],
+            _deserializeForField(paramElement.name, fields[paramElement.name],
                 ctorParam: paramElement)),
         ', ');
 
@@ -221,7 +230,7 @@ class JsonSerializableGenerator
       fieldsToSet.forEach((name, field) {
         buffer.writeln();
         buffer.write("      ..${name} = ");
-        buffer.write(_jsonMapAccessToField(name, field));
+        buffer.write(_deserializeForField(name, field));
       });
       buffer.writeln(';');
     }
@@ -230,190 +239,35 @@ class JsonSerializableGenerator
     return finalFields;
   }
 
+  Iterable<TypeHelper> get _allHelpers =>
+      [_typeHelpers, _coreHelpers].expand((e) => e);
+
   /// [expression] may be just the name of the field or it may an expression
   /// representing the serialization of a value.
-  String _fieldToJsonMapValue(String expression, DartType fieldType) {
-    var result = _typeHelpers
-        .map((th) => th.serialize(fieldType, expression))
-        .firstWhere((t) => t != null, orElse: () => null);
+  String _serialize(DartType targetType, String expression) => _allHelpers
+      .map((h) => h.serialize(targetType, expression, _serialize))
+      .firstWhere((r) => r != null,
+          orElse: () => throw new UnsupportedTypeError(targetType, expression));
 
-    if (result != null) {
-      return result;
-    }
-
-    if (fieldType.isDynamic ||
-        fieldType.isObject ||
-        _stringBoolNumChecker.isAssignableFromType(fieldType)) {
-      return expression;
-    }
-
-    if (_coreIterableChecker.isAssignableFromType(fieldType)) {
-      return _listFieldToJsonMapValue(expression, fieldType);
-    }
-
-    if (_coreMapChecker.isAssignableFromType(fieldType)) {
-      return _mapFieldToJsonMapValue(expression, fieldType);
-    }
-
-    throw new _UnsupportedTypeError(fieldType, expression);
-  }
-
-  String _listFieldToJsonMapValue(String expression, DartType fieldType) {
-    assert(_coreIterableChecker.isAssignableFromType(fieldType));
-
-    // This block will yield a regular list, which works fine for JSON
-    // Although it's possible that child elements may be marked unsafe
-
-    var isList = _coreListChecker.isAssignableFromType(fieldType);
-    var subFieldValue =
-        _fieldToJsonMapValue(_substitute, _getIterableGenericType(fieldType));
-
-    // In the case of trivial JSON types (int, String, etc), `subFieldValue`
-    // will be identical to `substitute` – so no explicit mapping is needed.
-    // If they are not equal, then we to write out the substitution.
-    if (subFieldValue != _substitute) {
-      // TODO: the type could be imported from a library with a prefix!
-      expression = "${expression}?.map(($_substitute) => $subFieldValue)";
-
-      // expression now represents an Iterable (even if it started as a List
-      // ...resetting `isList` to `false`.
-      isList = false;
-    }
-
-    if (!isList) {
-      // If the static type is not a List, generate one.
-      expression += "?.toList()";
-    }
-
-    return expression;
-  }
-
-  String _mapFieldToJsonMapValue(String expression, DartType fieldType) {
-    assert(_coreMapChecker.isAssignableFromType(fieldType));
-    var args = _getTypeArguments(fieldType, _coreMapChecker);
-    assert(args.length == 2);
-
-    var keyArg = args.first;
-    var valueType = args.last;
-
-    // We're not going to handle converting key types at the moment
-    // So the only safe types for key are dynamic/Object/String
-    var safeKey = keyArg.isDynamic ||
-        keyArg.isObject ||
-        _coreStringChecker.isExactlyType(keyArg);
-
-    var safeValue = valueType.isDynamic ||
-        valueType.isObject ||
-        _stringBoolNumChecker.isAssignableFromType(valueType);
-
-    if (safeKey) {
-      if (safeValue) {
-        return expression;
-      }
-
-      var subFieldValue = _fieldToJsonMapValue(_substitute, valueType);
-
-      return "$expression == null ? null :"
-          "new Map<String, dynamic>.fromIterables("
-          "$expression.keys,"
-          "$expression.values.map(($_substitute) => $subFieldValue))";
-    }
-    throw new _UnsupportedTypeError(fieldType, expression);
-  }
-
-  String _jsonMapAccessToField(String name, FieldElement field,
+  String _deserializeForField(String name, FieldElement field,
       {ParameterElement ctorParam}) {
     name = _fieldToJsonMapKey(name, field);
-    var result = "json['$name']";
 
     var targetType = ctorParam?.type ?? field.type;
 
     try {
-      return _writeAccessToJsonValue(result, targetType);
-    } on _UnsupportedTypeError {
+      return _deserialize(targetType, "json['$name']");
+    } on UnsupportedTypeError {
       throw new InvalidGenerationSourceError(
           "Could not generate fromJson code for `${friendlyNameForElement(field)}`.",
           todo: "Make sure all of the types are serializable.");
     }
   }
 
-  String _writeAccessToJsonValue(String varExpression, DartType searchType) {
-    var result = _typeHelpers
-        .map((th) => th.deserialize(searchType, varExpression))
-        .firstWhere((t) => t != null, orElse: () => null);
-
-    if (result != null) {
-      return "$varExpression == null ? null : $result";
-    }
-
-    if (_coreIterableChecker.isAssignableFromType(searchType)) {
-      var iterableGenericType = _getIterableGenericType(searchType);
-
-      var itemSubVal =
-          _writeAccessToJsonValue(_substitute, iterableGenericType);
-
-      // If `itemSubVal` is the same, then we don't need to do anything fancy
-      if (_substitute == itemSubVal) {
-        return '$varExpression as List';
-      }
-
-      var output =
-          "($varExpression as List)?.map(($_substitute) => $itemSubVal)";
-
-      if (_coreListChecker.isAssignableFromType(searchType)) {
-        output += "?.toList()";
-      }
-
-      return output;
-    } else if (_coreMapChecker.isAssignableFromType(searchType)) {
-      // Just pass through if
-      //    key:   dynamic, Object, String
-      //    value: dynamic, Object
-      var typeArgs = _getTypeArguments(searchType, _coreMapChecker);
-      assert(typeArgs.length == 2);
-      var keyArg = typeArgs.first;
-      var valueArg = typeArgs.last;
-
-      // We're not going to handle converting key types at the moment
-      // So the only safe types for key are dynamic/Object/String
-      var safeKey = keyArg.isDynamic ||
-          keyArg.isObject ||
-          _coreStringChecker.isExactlyType(keyArg);
-
-      if (!safeKey) {
-        throw new _UnsupportedTypeError(keyArg, varExpression);
-      }
-
-      // this is the trivial case. Do a runtime cast to the known type of JSON
-      // map values - `Map<String, dynamic>`
-      if (valueArg.isDynamic || valueArg.isObject) {
-        return "$varExpression as Map<String, dynamic>";
-      }
-
-      if (_stringBoolNumChecker.isAssignableFromType(valueArg)) {
-        // No mapping of the values is required!
-        return "$varExpression == null ? null :"
-            "new Map<String, $valueArg>.from($varExpression as Map)";
-      }
-
-      // In this case, we're going to create a new Map with matching reified
-      // types.
-
-      var itemSubVal = _writeAccessToJsonValue(_substitute, valueArg);
-
-      return "$varExpression == null ? null :"
-          "new Map<String, $valueArg>.fromIterables("
-          "($varExpression as Map<String, dynamic>).keys,"
-          "($varExpression as Map).values.map(($_substitute) => $itemSubVal))";
-    } else if (searchType.isDynamic || searchType.isObject) {
-      // just return it as-is. We'll hope it's safe.
-      return varExpression;
-    } else if (_stringBoolNumChecker.isAssignableFromType(searchType)) {
-      return "$varExpression as $searchType";
-    }
-
-    throw new _UnsupportedTypeError(searchType, varExpression);
-  }
+  String _deserialize(DartType targetType, String expression) => _allHelpers
+      .map((th) => th.deserialize(targetType, expression, _deserialize))
+      .firstWhere((r) => r != null,
+          orElse: () => throw new UnsupportedTypeError(targetType, expression));
 }
 
 /// Returns the JSON map `key` to be used when (de)serializing [field].
@@ -428,55 +282,4 @@ String _fieldToJsonMapKey(String fieldName, FieldElement field) {
     return jsonName;
   }
   return fieldName;
-}
-
-DartType _getIterableGenericType(DartType type) =>
-    _getTypeArguments(type, _coreIterableChecker).single;
-
-List<DartType> _getTypeArguments(DartType type, TypeChecker checker) {
-  var iterableImplementation =
-      _getImplementationType(type, checker) as InterfaceType;
-
-  return iterableImplementation?.typeArguments;
-}
-
-DartType _getImplementationType(DartType type, TypeChecker checker) {
-  if (checker.isExactlyType(type)) return type;
-
-  if (type is InterfaceType) {
-    var match = [type.interfaces, type.mixins]
-        .expand((e) => e)
-        .map((type) => _getImplementationType(type, checker))
-        .firstWhere((value) => value != null, orElse: () => null);
-
-    if (match != null) {
-      return match;
-    }
-
-    if (type.superclass != null) {
-      return _getImplementationType(type.superclass, checker);
-    }
-  }
-  return null;
-}
-
-final _coreIterableChecker = const TypeChecker.fromUrl('dart:core#Iterable');
-
-final _coreListChecker = const TypeChecker.fromUrl('dart:core#List');
-
-final _coreMapChecker = const TypeChecker.fromUrl('dart:core#Map');
-
-final _coreStringChecker = const TypeChecker.fromUrl('dart:core#String');
-
-final _stringBoolNumChecker = new TypeChecker.any([
-  _coreStringChecker,
-  new TypeChecker.fromUrl('dart:core#bool'),
-  new TypeChecker.fromUrl('dart:core#num')
-]);
-
-class _UnsupportedTypeError extends Error {
-  final String expression;
-  final DartType type;
-
-  _UnsupportedTypeError(this.type, this.expression);
 }

--- a/lib/src/json_serializable_generator.dart
+++ b/lib/src/json_serializable_generator.dart
@@ -233,10 +233,12 @@ class JsonSerializableGenerator
   /// [expression] may be just the name of the field or it may an expression
   /// representing the serialization of a value.
   String _fieldToJsonMapValue(String expression, DartType fieldType) {
-    for (var helper in _typeHelpers) {
-      if (helper.canSerialize(fieldType)) {
-        return helper.serialize(fieldType, expression);
-      }
+    var result = _typeHelpers
+        .map((th) => th.serialize(fieldType, expression))
+        .firstWhere((t) => t != null, orElse: () => null);
+
+    if (result != null) {
+      return result;
     }
 
     if (fieldType.isDynamic ||
@@ -336,11 +338,12 @@ class JsonSerializableGenerator
   }
 
   String _writeAccessToJsonValue(String varExpression, DartType searchType) {
-    for (var helper in _typeHelpers) {
-      if (helper.canDeserialize(searchType)) {
-        return "$varExpression == null ? null : "
-            "${helper.deserialize(searchType, varExpression)}";
-      }
+    var result = _typeHelpers
+        .map((th) => th.deserialize(searchType, varExpression))
+        .firstWhere((t) => t != null, orElse: () => null);
+
+    if (result != null) {
+      return "$varExpression == null ? null : $result";
     }
 
     if (_coreIterableChecker.isAssignableFromType(searchType)) {

--- a/lib/src/type_helper.dart
+++ b/lib/src/type_helper.dart
@@ -83,12 +83,12 @@ class JsonHelper extends TypeHelper {
     return false;
   }
 
-  /// Simply returns the [name] provided.
+  /// Simply returns the [expression] provided.
   ///
   /// By default, JSON encoding in from `dart:convert` calls `toJson` on
   /// provided objects.
   @override
-  String serialize(DartType targetType, String name) => name;
+  String serialize(DartType targetType, String expression) => expression;
 
   @override
   String deserialize(DartType targetType, String expression) {
@@ -111,8 +111,8 @@ class DateTimeHelper extends TypeHelper {
       const TypeChecker.fromUrl('dart:core#DateTime').isExactlyType(type);
 
   @override
-  String serialize(DartType targetType, String name) =>
-      "$name?.toIso8601String()";
+  String serialize(DartType targetType, String expression) =>
+      "$expression?.toIso8601String()";
 
   @override
   String deserialize(DartType targetType, String expression) =>

--- a/lib/src/type_helper.dart
+++ b/lib/src/type_helper.dart
@@ -2,10 +2,18 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
-import 'package:analyzer/dart/element/element.dart';
 import 'package:analyzer/dart/element/type.dart';
-
 import 'package:source_gen/source_gen.dart' show TypeChecker;
+
+/// If [type] is the [Type] or implements the [Type] represented by [checker],
+/// returns the generic arguments to the [checker] [Type] if there are any.
+///
+/// If the [checker] [Type] doesn't have generic arguments, `null` is returned.
+List<DartType> typeArgumentsOf(DartType type, TypeChecker checker) {
+  var implementation = _getImplementationType(type, checker) as InterfaceType;
+
+  return implementation?.typeArguments;
+}
 
 abstract class TypeHelper {
   const TypeHelper();
@@ -25,7 +33,9 @@ abstract class TypeHelper {
   /// String serialize(DartType targetType, String expression) =>
   ///   "$expression.id";
   /// ```.
-  String serialize(DartType targetType, String expression);
+  // TODO(kevmoo) – document `serializeNested`
+  String serialize(DartType targetType, String expression,
+      String serializeNested(DartType t, String e));
 
   /// Returns Dart code that deserializes an [expression] representing a JSON
   /// literal to into [targetType].
@@ -50,72 +60,41 @@ abstract class TypeHelper {
   /// String deserialize(DartType targetType, String expression) =>
   ///   "new ${targetType.name}.fromInt($expression)";
   /// ```.
-  String deserialize(DartType targetType, String expression);
+  // TODO(kevmoo) – document `deserializeNested`
+  String deserialize(DartType targetType, String expression,
+      String deserializeNested(DartType t, String e));
 }
 
-class JsonHelper extends TypeHelper {
-  const JsonHelper();
+/// A [TypeChecker] for [String], [bool] and [num].
+const simpleJsonTypeChecker = const TypeChecker.any(const [
+  const TypeChecker.fromRuntime(String),
+  const TypeChecker.fromRuntime(bool),
+  const TypeChecker.fromRuntime(num)
+]);
 
-  bool _canDeserialize(DartType type) {
-    if (type is! InterfaceType) return false;
+class UnsupportedTypeError extends Error {
+  final String expression;
+  final DartType type;
 
-    var classElement = type.element as ClassElement;
-
-    for (var ctor in classElement.constructors) {
-      if (ctor.name == 'fromJson') {
-        // TODO: validate that there are the right number and type of arguments
-        return true;
-      }
-    }
-
-    return false;
-  }
-
-  /// Simply returns the [expression] provided.
-  ///
-  /// By default, JSON encoding in from `dart:convert` calls `toJson` on
-  /// provided objects.
-  @override
-  String serialize(DartType targetType, String expression) {
-    // TODO(kevmoo): This should be checking for toJson method, but toJson might
-    //   be gone during generation, so we'll have to check for the annotation.
-    // In the mean time, just assume the `canSerialize` logic will work most of
-    //   the time.
-    if (!_canDeserialize(targetType)) {
-      return null;
-    }
-
-    return expression;
-  }
-
-  @override
-  String deserialize(DartType targetType, String expression) {
-    if (!_canDeserialize(targetType)) {
-      return null;
-    }
-
-    // TODO: the type could be imported from a library with a prefix!
-    // github.com/dart-lang/json_serializable/issues/19
-    return "new ${targetType.name}.fromJson($expression as Map<String, dynamic>)";
-  }
+  UnsupportedTypeError(this.type, this.expression);
 }
 
-class DateTimeHelper extends TypeHelper {
-  const DateTimeHelper();
+DartType _getImplementationType(DartType type, TypeChecker checker) {
+  if (checker.isExactlyType(type)) return type;
 
-  bool _matchesType(DartType type) =>
-      const TypeChecker.fromUrl('dart:core#DateTime').isExactlyType(type);
+  if (type is InterfaceType) {
+    var match = [type.interfaces, type.mixins]
+        .expand((e) => e)
+        .map((type) => _getImplementationType(type, checker))
+        .firstWhere((value) => value != null, orElse: () => null);
 
-  @override
-  String serialize(DartType targetType, String expression) =>
-      _matchesType(targetType) ? "$expression?.toIso8601String()" : null;
+    if (match != null) {
+      return match;
+    }
 
-  @override
-  String deserialize(DartType targetType, String expression) =>
-      _matchesType(targetType)
-          ?
-          // TODO(kevmoo) `String` here is ignoring
-          // github.com/dart-lang/json_serializable/issues/19
-          "DateTime.parse($expression as String)"
-          : null;
+    if (type.superclass != null) {
+      return _getImplementationType(type.superclass, checker);
+    }
+  }
+  return null;
 }

--- a/lib/src/type_helper.dart
+++ b/lib/src/type_helper.dart
@@ -104,6 +104,7 @@ class DateTimeHelper extends TypeHelper {
   @override
   bool canSerialize(DartType type) => _matchesType(type);
 
+  @override
   bool canDeserialize(DartType type) => _matchesType(type);
 
   bool _matchesType(DartType type) =>

--- a/lib/src/type_helpers/date_time_helper.dart
+++ b/lib/src/type_helpers/date_time_helper.dart
@@ -1,0 +1,23 @@
+import 'package:analyzer/dart/element/type.dart';
+import 'package:source_gen/source_gen.dart' show TypeChecker;
+import '../type_helper.dart';
+
+class DateTimeHelper extends TypeHelper {
+  const DateTimeHelper();
+
+  @override
+  String serialize(DartType targetType, String expression, _) =>
+      _matchesType(targetType) ? "$expression?.toIso8601String()" : null;
+
+  @override
+  String deserialize(DartType targetType, String expression, _) =>
+      _matchesType(targetType)
+          ?
+          // TODO(kevmoo) `String` here is ignoring
+          // github.com/dart-lang/json_serializable/issues/19
+          "$expression == null ? null : DateTime.parse($expression as String)"
+          : null;
+}
+
+bool _matchesType(DartType type) =>
+    const TypeChecker.fromUrl('dart:core#DateTime').isExactlyType(type);

--- a/lib/src/type_helpers/iterable_helper.dart
+++ b/lib/src/type_helpers/iterable_helper.dart
@@ -1,0 +1,76 @@
+import 'package:analyzer/dart/element/type.dart';
+import 'package:source_gen/source_gen.dart' show TypeChecker;
+import '../type_helper.dart';
+
+/// Name used for closure argument when generating calls to `map`.
+final _closureArg = "e";
+
+class IterableHelper extends TypeHelper {
+  const IterableHelper();
+
+  @override
+  String serialize(DartType targetType, String expression,
+      String serializeNested(DartType dartType, String expression)) {
+    if (!_coreIterableChecker.isAssignableFromType(targetType)) {
+      return null;
+    }
+
+    // This block will yield a regular list, which works fine for JSON
+    // Although it's possible that child elements may be marked unsafe
+
+    var isList = _coreListChecker.isAssignableFromType(targetType);
+    var subFieldValue =
+        serializeNested(_getIterableGenericType(targetType), _closureArg);
+
+    // In the case of trivial JSON types (int, String, etc), `subFieldValue`
+    // will be identical to `substitute` – so no explicit mapping is needed.
+    // If they are not equal, then we to write out the substitution.
+    if (subFieldValue != _closureArg) {
+      // TODO: the type could be imported from a library with a prefix!
+      expression = "${expression}?.map(($_closureArg) => $subFieldValue)";
+
+      // expression now represents an Iterable (even if it started as a List
+      // ...resetting `isList` to `false`.
+      isList = false;
+    }
+
+    if (!isList) {
+      // If the static type is not a List, generate one.
+      expression += "?.toList()";
+    }
+
+    return expression;
+  }
+
+  @override
+  String deserialize(DartType targetType, String expression,
+      String deserializeNested(DartType t, String e)) {
+    if (!_coreIterableChecker.isAssignableFromType(targetType)) {
+      return null;
+    }
+
+    var iterableGenericType = _getIterableGenericType(targetType);
+
+    var itemSubVal = deserializeNested(iterableGenericType, _closureArg);
+
+    // If `itemSubVal` is the same, then we don't need to do anything fancy
+    if (_closureArg == itemSubVal) {
+      return '$expression as List';
+    }
+
+    var output = "($expression as List)?.map(($_closureArg) => $itemSubVal)";
+
+    if (_coreListChecker.isAssignableFromType(targetType)) {
+      output += "?.toList()";
+    }
+
+    return output;
+  }
+}
+
+DartType _getIterableGenericType(DartType type) =>
+    typeArgumentsOf(type, _coreIterableChecker).single;
+
+final _coreIterableChecker = const TypeChecker.fromUrl('dart:core#Iterable');
+
+final _coreListChecker = const TypeChecker.fromUrl('dart:core#List');

--- a/lib/src/type_helpers/json_helper.dart
+++ b/lib/src/type_helpers/json_helper.dart
@@ -1,0 +1,50 @@
+import 'package:analyzer/dart/element/element.dart';
+import 'package:analyzer/dart/element/type.dart';
+import '../type_helper.dart';
+
+class JsonHelper extends TypeHelper {
+  const JsonHelper();
+
+  /// Simply returns the [expression] provided.
+  ///
+  /// By default, JSON encoding in from `dart:convert` calls `toJson` on
+  /// provided objects.
+  @override
+  String serialize(DartType targetType, String expression, _) {
+    // TODO(kevmoo): This should be checking for toJson method, but toJson might
+    //   be gone during generation, so we'll have to check for the annotation.
+    // In the mean time, just assume the `canSerialize` logic will work most of
+    //   the time.
+    if (!_canDeserialize(targetType)) {
+      return null;
+    }
+
+    return expression;
+  }
+
+  @override
+  String deserialize(DartType targetType, String expression, _) {
+    if (!_canDeserialize(targetType)) {
+      return null;
+    }
+
+    // TODO: the type could be imported from a library with a prefix!
+    // github.com/dart-lang/json_serializable/issues/19
+    return "$expression == null ? null : new ${targetType.name}.fromJson($expression as Map<String, dynamic>)";
+  }
+}
+
+bool _canDeserialize(DartType type) {
+  if (type is! InterfaceType) return false;
+
+  var classElement = type.element as ClassElement;
+
+  for (var ctor in classElement.constructors) {
+    if (ctor.name == 'fromJson') {
+      // TODO: validate that there are the right number and type of arguments
+      return true;
+    }
+  }
+
+  return false;
+}

--- a/lib/src/type_helpers/map_helper.dart
+++ b/lib/src/type_helpers/map_helper.dart
@@ -1,0 +1,98 @@
+import 'package:analyzer/dart/element/type.dart';
+import 'package:source_gen/source_gen.dart' show TypeChecker;
+import '../type_helper.dart';
+
+/// Name used for closure argument when generating calls to `map`.
+final _closureArg = "e";
+
+class MapHelper extends TypeHelper {
+  const MapHelper();
+
+  @override
+  String serialize(DartType targetType, String expression,
+      String serializeNested(DartType t, String e)) {
+    if (!_coreMapChecker.isAssignableFromType(targetType)) {
+      return null;
+    }
+    var args = typeArgumentsOf(targetType, _coreMapChecker);
+    assert(args.length == 2);
+
+    var keyArg = args.first;
+    var valueType = args.last;
+
+    // We're not going to handle converting key types at the moment
+    // So the only safe types for key are dynamic/Object/String
+    var safeKey = keyArg.isDynamic ||
+        keyArg.isObject ||
+        _stringTypeChecker.isExactlyType(keyArg);
+
+    var safeValue = valueType.isDynamic ||
+        valueType.isObject ||
+        simpleJsonTypeChecker.isAssignableFromType(valueType);
+
+    if (safeKey) {
+      if (safeValue) {
+        return expression;
+      }
+
+      var subFieldValue = serializeNested(valueType, _closureArg);
+
+      return "$expression == null ? null :"
+          "new Map<String, dynamic>.fromIterables("
+          "$expression.keys,"
+          "$expression.values.map(($_closureArg) => $subFieldValue))";
+    }
+    throw new UnsupportedTypeError(targetType, expression);
+  }
+
+  @override
+  String deserialize(DartType targetType, String expression,
+      String deserializeNested(DartType t, String e)) {
+    if (!_coreMapChecker.isAssignableFromType(targetType)) {
+      return null;
+    }
+
+    // Just pass through if
+    //    key:   dynamic, Object, String
+    //    value: dynamic, Object
+    var typeArgs = typeArgumentsOf(targetType, _coreMapChecker);
+    assert(typeArgs.length == 2);
+    var keyArg = typeArgs.first;
+    var valueArg = typeArgs.last;
+
+    // We're not going to handle converting key types at the moment
+    // So the only safe types for key are dynamic/Object/String
+    var safeKey = keyArg.isDynamic ||
+        keyArg.isObject ||
+        _stringTypeChecker.isExactlyType(keyArg);
+
+    if (!safeKey) {
+      throw new UnsupportedTypeError(keyArg, expression);
+    }
+
+    // this is the trivial case. Do a runtime cast to the known type of JSON
+    // map values - `Map<String, dynamic>`
+    if (valueArg.isDynamic || valueArg.isObject) {
+      return "$expression as Map<String, dynamic>";
+    }
+
+    if (simpleJsonTypeChecker.isAssignableFromType(valueArg)) {
+      // No mapping of the values is required!
+      return "$expression == null ? null :"
+          "new Map<String, $valueArg>.from($expression as Map)";
+    }
+
+    // In this case, we're going to create a new Map with matching reified
+    // types.
+
+    var itemSubVal = deserializeNested(valueArg, _closureArg);
+
+    return "$expression == null ? null :"
+        "new Map<String, $valueArg>.fromIterables("
+        "($expression as Map<String, dynamic>).keys,"
+        "($expression as Map).values.map(($_closureArg) => $itemSubVal))";
+  }
+}
+
+final _coreMapChecker = const TypeChecker.fromUrl('dart:core#Map');
+final _stringTypeChecker = const TypeChecker.fromRuntime(String);

--- a/lib/src/type_helpers/value_helper.dart
+++ b/lib/src/type_helpers/value_helper.dart
@@ -1,0 +1,31 @@
+import 'package:analyzer/dart/element/type.dart';
+import '../type_helper.dart';
+
+class ValueHelper extends TypeHelper {
+  const ValueHelper();
+
+  @override
+  String serialize(DartType targetType, String expression,
+      String Function(DartType, String) serializeNested) {
+    if (targetType.isDynamic ||
+        targetType.isObject ||
+        simpleJsonTypeChecker.isAssignableFromType(targetType)) {
+      return expression;
+    }
+
+    return null;
+  }
+
+  @override
+  String deserialize(DartType targetType, String expression,
+      String Function(DartType, String) deserializeNested) {
+    if (targetType.isDynamic || targetType.isObject) {
+      // just return it as-is. We'll hope it's safe.
+      return expression;
+    } else if (simpleJsonTypeChecker.isAssignableFromType(targetType)) {
+      return "$expression as $targetType";
+    }
+
+    return null;
+  }
+}

--- a/lib/type_helper.dart
+++ b/lib/type_helper.dart
@@ -2,7 +2,6 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
-/// Use these annotations on members you'd like to enable source generation on.
-
-export 'src/json_literal.dart';
-export 'src/json_serializable.dart';
+export 'src/type_helper.dart';
+export 'src/type_helpers/date_time_helper.dart';
+export 'src/type_helpers/json_helper.dart';

--- a/test/json_serializable_test.dart
+++ b/test/json_serializable_test.dart
@@ -139,7 +139,7 @@ void main() {
       var output = await _runForElementNamed('Person');
 
       expect(output,
-          contains("json['listOfInts'] as List)?.map((v0) => v0 as int)"));
+          contains("json['listOfInts'] as List)?.map((e) => e as int)"));
     });
   });
 

--- a/test/json_serializable_test.dart
+++ b/test/json_serializable_test.dart
@@ -9,7 +9,7 @@ import 'dart:async';
 
 import 'package:analyzer/dart/ast/ast.dart';
 import 'package:analyzer/src/string_source.dart';
-import 'package:json_serializable/json_serializable.dart';
+import 'package:json_serializable/generators.dart';
 import 'package:path/path.dart' as p;
 import 'package:test/test.dart';
 
@@ -179,7 +179,7 @@ Future<CompilationUnit> _getCompilationUnitForString(String projectPath) async {
 CompilationUnit _compUnit;
 
 const _testSource = r'''
-import 'package:json_serializable/json_serializable.dart';
+import 'package:json_serializable/annotations.dart';
 
 @JsonSerializable()
 const theAnswer = 42;

--- a/test/json_serializable_test.dart
+++ b/test/json_serializable_test.dart
@@ -18,6 +18,10 @@ import 'src/io.dart';
 import 'test_utils.dart';
 
 void main() {
+  setUpAll(() async {
+    _compUnit = await _getCompilationUnitForString(getPackagePath());
+  });
+
   group('non-classes', () {
     test('const field', () async {
       expect(
@@ -154,9 +158,6 @@ void main() {
 const _generator = const JsonSerializableGenerator();
 
 Future<String> _runForElementNamed(String name) async {
-  if (_compUnit == null) {
-    _compUnit = await _getCompilationUnitForString(getPackagePath());
-  }
   var library = _compUnit.element.library;
   var element =
       getElementsFromLibraryElement(library).singleWhere((e) => e.name == name);

--- a/test/test_files/json_test_example.dart
+++ b/test/test_files/json_test_example.dart
@@ -2,6 +2,7 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
+// ignore_for_file: annotate_overrides
 library json_serializable.test.example;
 
 import 'dart:collection';

--- a/test/test_files/json_test_example.g.dart
+++ b/test/test_files/json_test_example.g.dart
@@ -11,15 +11,15 @@ KitchenSink _$KitchenSinkFromJson(Map<String, dynamic> json) => new KitchenSink(
     iterable: json['iterable'] as List,
     dynamicIterable: json['dynamicIterable'] as List,
     objectIterable: json['objectIterable'] as List,
-    intIterable: (json['intIterable'] as List)?.map((v0) => v0 as int),
+    intIterable: (json['intIterable'] as List)?.map((e) => e as int),
     dateTimeIterable: (json['dateTimeIterable'] as List)
-        ?.map((v0) => v0 == null ? null : DateTime.parse(v0 as String)))
+        ?.map((e) => e == null ? null : DateTime.parse(e as String)))
   ..list = json['list'] as List
   ..dynamicList = json['dynamicList'] as List
   ..objectList = json['objectList'] as List
-  ..intList = (json['intList'] as List)?.map((v0) => v0 as int)?.toList()
+  ..intList = (json['intList'] as List)?.map((e) => e as int)?.toList()
   ..dateTimeList = (json['dateTimeList'] as List)
-      ?.map((v0) => v0 == null ? null : DateTime.parse(v0 as String))
+      ?.map((e) => e == null ? null : DateTime.parse(e as String))
       ?.toList()
   ..map = json['map'] as Map<String, dynamic>
   ..stringStringMap = json['stringStringMap'] == null
@@ -34,15 +34,15 @@ KitchenSink _$KitchenSinkFromJson(Map<String, dynamic> json) => new KitchenSink(
           (json['stringDateTimeMap'] as Map<String, dynamic>).keys,
           (json['stringDateTimeMap'] as Map)
               .values
-              .map((v0) => v0 == null ? null : DateTime.parse(v0 as String)))
+              .map((e) => e == null ? null : DateTime.parse(e as String)))
   ..crazyComplex = (json['crazyComplex'] as List)
-      ?.map((v0) => v0 == null
+      ?.map((e) => e == null
           ? null
           : new Map<String, Map<String, List<List<DateTime>>>>.fromIterables(
-              (v0 as Map<String, dynamic>).keys,
-              (v0 as Map).values.map((v1) => v1 == null
+              (e as Map<String, dynamic>).keys,
+              (e as Map).values.map((e) => e == null
                   ? null
-                  : new Map<String, List<List<DateTime>>>.fromIterables((v1 as Map<String, dynamic>).keys, (v1 as Map).values.map((v2) => (v2 as List)?.map((v3) => (v3 as List)?.map((v4) => v4 == null ? null : DateTime.parse(v4 as String))?.toList())?.toList())))))
+                  : new Map<String, List<List<DateTime>>>.fromIterables((e as Map<String, dynamic>).keys, (e as Map).values.map((e) => (e as List)?.map((e) => (e as List)?.map((e) => e == null ? null : DateTime.parse(e as String))?.toList())?.toList())))))
       ?.toList();
 
 abstract class _$KitchenSinkSerializerMixin {
@@ -67,32 +67,32 @@ abstract class _$KitchenSinkSerializerMixin {
         'objectIterable': objectIterable?.toList(),
         'intIterable': intIterable?.toList(),
         'dateTimeIterable':
-            dateTimeIterable?.map((v0) => v0?.toIso8601String())?.toList(),
+            dateTimeIterable?.map((e) => e?.toIso8601String())?.toList(),
         'list': list,
         'dynamicList': dynamicList,
         'objectList': objectList,
         'intList': intList,
         'dateTimeList':
-            dateTimeList?.map((v0) => v0?.toIso8601String())?.toList(),
+            dateTimeList?.map((e) => e?.toIso8601String())?.toList(),
         'map': map,
         'stringStringMap': stringStringMap,
         'stringIntMap': stringIntMap,
         'stringDateTimeMap': stringDateTimeMap == null
             ? null
             : new Map<String, dynamic>.fromIterables(stringDateTimeMap.keys,
-                stringDateTimeMap.values.map((v0) => v0?.toIso8601String())),
+                stringDateTimeMap.values.map((e) => e?.toIso8601String())),
         'crazyComplex': crazyComplex
-            ?.map((v0) => v0 == null
+            ?.map((e) => e == null
                 ? null
                 : new Map<String, dynamic>.fromIterables(
-                    v0.keys,
-                    v0.values.map((v1) => v1 == null
+                    e.keys,
+                    e.values.map((e) => e == null
                         ? null
                         : new Map<String, dynamic>.fromIterables(
-                            v1.keys,
-                            v1.values.map((v2) => v2
-                                ?.map((v3) => v3
-                                    ?.map((v4) => v4?.toIso8601String())
+                            e.keys,
+                            e.values.map((e) => e
+                                ?.map((e) => e
+                                    ?.map((e) => e?.toIso8601String())
                                     ?.toList())
                                 ?.toList())))))
             ?.toList()
@@ -130,8 +130,8 @@ abstract class _$PersonSerializerMixin {
 // **************************************************************************
 
 Order _$OrderFromJson(Map<String, dynamic> json) =>
-    new Order((json['items'] as List)?.map((v0) =>
-        v0 == null ? null : new Item.fromJson(v0 as Map<String, dynamic>)))
+    new Order((json['items'] as List)?.map(
+        (e) => e == null ? null : new Item.fromJson(e as Map<String, dynamic>)))
       ..count = json['count'] as int
       ..isRushed = json['isRushed'] as bool;
 
@@ -151,9 +151,9 @@ abstract class _$OrderSerializerMixin {
 Item _$ItemFromJson(Map<String, dynamic> json) => new Item(json['price'] as int)
   ..itemNumber = json['itemNumber'] as int
   ..saleDates = (json['saleDates'] as List)
-      ?.map((v0) => v0 == null ? null : DateTime.parse(v0 as String))
+      ?.map((e) => e == null ? null : DateTime.parse(e as String))
       ?.toList()
-  ..rates = (json['rates'] as List)?.map((v0) => v0 as int)?.toList();
+  ..rates = (json['rates'] as List)?.map((e) => e as int)?.toList();
 
 abstract class _$ItemSerializerMixin {
   int get price;
@@ -163,7 +163,7 @@ abstract class _$ItemSerializerMixin {
   Map<String, dynamic> toJson() => <String, dynamic>{
         'price': price,
         'itemNumber': itemNumber,
-        'saleDates': saleDates?.map((v0) => v0?.toIso8601String())?.toList(),
+        'saleDates': saleDates?.map((e) => e?.toIso8601String())?.toList(),
         'rates': rates
       };
 }

--- a/test/test_utils.dart
+++ b/test/test_utils.dart
@@ -42,6 +42,7 @@ class FeatureMatcher<T> extends CustomMatcher {
   FeatureMatcher(String name, this._feature, matcher)
       : super("`$name`", "`$name`", matcher);
 
+  @override
   featureValueOf(covariant T actual) => _feature(actual);
 }
 

--- a/tool/phases.dart
+++ b/tool/phases.dart
@@ -3,7 +3,7 @@
 // BSD-style license that can be found in the LICENSE file.
 
 import 'package:build_runner/build_runner.dart';
-import 'package:json_serializable/json_serializable.dart';
+import 'package:json_serializable/generators.dart';
 import 'package:source_gen/source_gen.dart';
 
 final PhaseGroup phases = new PhaseGroup.singleAction(


### PR DESCRIPTION
Reorganize libraries so there is one clear import for each use case.
Support nesting in `TypeHelper`.
Cleanup the API for `TypeHelper`
Other misc
