### PR TITLE
Throw a more helpful error when a constructor is missing

### DIFF
--- a/json_serializable/CHANGELOG.md
+++ b/json_serializable/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.2.4+1
+
+* Throw a more helpful error when a constructor is missing.
+
 ## 0.2.4
 
 * Moved the annotations in `annotations.dart` to `package:json_annotations`.

--- a/json_serializable/lib/src/json_serializable_generator.dart
+++ b/json_serializable/lib/src/json_serializable_generator.dart
@@ -244,6 +244,10 @@ void $toJsonMapHelperName(String key, dynamic value) {
     // Get the default constructor
     // TODO: allow overriding the ctor used for the factory
     var ctor = classElement.unnamedConstructor;
+    if (ctor == null) {
+      throw new UnsupportedError(
+          'The class `${classElement.name}` has no default constructor.');
+    }
 
     var ctorArguments = <ParameterElement>[];
     var ctorNamedArguments = <ParameterElement>[];

--- a/json_serializable/pubspec.yaml
+++ b/json_serializable/pubspec.yaml
@@ -1,5 +1,5 @@
 name: json_serializable
-version: 0.2.5-dev
+version: 0.2.4+1
 author: Dart Team <misc@dartlang.org>
 description: Generates utilities to aid in serializing to/from JSON.
 homepage: https://github.com/dart-lang/json_serializable

--- a/json_serializable/test/json_serializable_test.dart
+++ b/json_serializable/test/json_serializable_test.dart
@@ -208,6 +208,15 @@ abstract class _$OrderSerializerMixin {
       expect(output, contains("$toJsonMapHelperName('str', str);"));
     });
   });
+
+  test('missing default ctor with a factory', () async {
+    expect(
+        () => _runForElementNamed('NoCtorClass'),
+        throwsA(new FeatureMatcher<UnsupportedError>(
+            'message',
+            (e) => e.message,
+            'The class `NoCtorClass` has no default constructor.')));
+  });
 }
 
 const _generator = const JsonSerializableGenerator();
@@ -348,5 +357,13 @@ class IncludeIfNullOverride {
   @JsonKey(includeIfNull: true)
   int number;
   String str;
+}
+
+// https://github.com/dart-lang/json_serializable/issues/7 regression
+@JsonSerializable()
+class NoCtorClass {
+  final int member;
+  
+  factory TestDoneEvent.fromJson(Map<String, dynamic> json) => null;
 }
 ''';


### PR DESCRIPTION
Fixes https://github.com/dart-lang/json_serializable/issues/7