### PR TITLE
example: cleanup

### DIFF
--- a/example/README.md
+++ b/example/README.md
@@ -1,3 +1,8 @@
+*This example assumes you're using a recent version of the Dart or Flutter SDK.*
+
+* Dart: you need a [v2 pre-release](https://www.dartlang.org/dart-2).
+* Flutter: at least 0.0.23 (Feb 5, 2018).
+
 To use [package:json_serializable][json_serializable] in your package, add these
 dependencies to your `pubspec.yaml`.
 
@@ -6,7 +11,7 @@ dependencies:
   json_annotation: ^0.2.2
 
 dev_dependencies:
-  build_runner: ^0.7.0
+  build_runner: ^0.7.6
   json_serializable: ^0.3.1
 ```
 

--- a/example/build.yaml
+++ b/example/build.yaml
@@ -1,6 +1,6 @@
 # Read about `build.yaml` at https://pub.dartlang.org/packages/build_config
 targets:
-  example:
+  $default:
     builders:
       json_serializable:
         options:

--- a/example/pubspec.yaml
+++ b/example/pubspec.yaml
@@ -8,7 +8,7 @@ dependencies:
   json_annotation: ^0.2.2
 
 dev_dependencies:
-  build_runner: ^0.7.0
+  build_runner: ^0.7.6
   json_serializable: ^0.3.1
 
   # Used by tests. Not required to use `json_serializable`.

--- a/example/test/readme_test.dart
+++ b/example/test/readme_test.dart
@@ -23,6 +23,6 @@ dependencies:
   json_annotation: ^0.2.2
 
 dev_dependencies:
-  build_runner: ^0.7.0
+  build_runner: ^0.7.6
   json_serializable: ^0.3.1
 ''';

--- a/json_serializable/lib/src/json_part_builder.dart
+++ b/json_serializable/lib/src/json_part_builder.dart
@@ -53,5 +53,7 @@ Builder jsonPartBuilder(
   return new PartBuilder([
     new JsonSerializableGenerator(useWrappers: useWrappers),
     const JsonLiteralGenerator()
-  ], header: header, requireLibraryDirective: requireLibraryDirective);
+  ], header: header,
+      // ignore: deprecated_member_use
+      requireLibraryDirective: requireLibraryDirective);
 }

--- a/json_serializable/lib/src/json_part_builder.dart
+++ b/json_serializable/lib/src/json_part_builder.dart
@@ -53,7 +53,8 @@ Builder jsonPartBuilder(
   return new PartBuilder([
     new JsonSerializableGenerator(useWrappers: useWrappers),
     const JsonLiteralGenerator()
-  ], header: header,
+  ],
+      header: header,
       // ignore: deprecated_member_use
       requireLibraryDirective: requireLibraryDirective);
 }


### PR DESCRIPTION
updated minimum build_runner version - allows $default in build.yaml
Add notes about required SDKs in the readme