### PR TITLE
Introduced ignore attribute to JsonKey. When set to true the generato…

### DIFF
--- a/json_annotation/CHANGELOG.md
+++ b/json_annotation/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.2.3
+
+* Added `ignore` field to `JsonKey` class annotation
+
 ## 0.2.2
 
 * Added a helper class – `$JsonMapWrapper` – and helper functions – `$wrapMap`, 

--- a/json_annotation/lib/src/json_serializable.dart
+++ b/json_annotation/lib/src/json_serializable.dart
@@ -65,10 +65,16 @@ class JsonKey {
   /// enclosing class.
   final bool includeIfNull;
 
+  /// `true` if the generator should ignore this field completely
+  ///
+  /// If `null` or `false`, the generator includes the field if it is not
+  /// sorted out by another condition.
+  final bool ignore;
+
   /// Creates a new [JsonKey].
   ///
   /// Only required when the default behavior is not desired.
-  const JsonKey({this.name, this.nullable, this.includeIfNull});
+  const JsonKey({this.name, this.nullable, this.includeIfNull, this.ignore});
 }
 
 // TODO(kevmoo): Add documentation

--- a/json_annotation/lib/src/json_serializable.dart
+++ b/json_annotation/lib/src/json_serializable.dart
@@ -65,10 +65,10 @@ class JsonKey {
   /// enclosing class.
   final bool includeIfNull;
 
-  /// `true` if the generator should ignore this field completely
+  /// `true` if the generator should ignore this field completely.
   ///
-  /// If `null` or `false`, the generator includes the field if it is not
-  /// sorted out by another condition.
+  /// If `null` (the default) or `false`, the field will be considered for
+  /// serialization.
   final bool ignore;
 
   /// Creates a new [JsonKey].

--- a/json_annotation/pubspec.yaml
+++ b/json_annotation/pubspec.yaml
@@ -1,5 +1,5 @@
 name: json_annotation
-version: 0.2.2
+version: 0.2.3-dev
 description: Annotations for the json_serializable package
 homepage: https://github.com/dart-lang/json_serializable
 author: Dart Team <misc@dartlang.org>

--- a/json_serializable/CHANGELOG.md
+++ b/json_serializable/CHANGELOG.md
@@ -6,6 +6,10 @@
   `DeserializeContext` is now readonly. This would potentially break code that
   extends these classes – which is not expected. 
 
+* Private and ignored fields are now excluded when generating serialization and deserialization code.
+
+* Throw an exception if a private field, or an ignored field is referenced by a required constructor argument.
+
 ## 0.4.0
 
 * **Potentially Breaking** Inherited fields are now processed and used

--- a/json_serializable/lib/src/json_serializable_generator.dart
+++ b/json_serializable/lib/src/json_serializable_generator.dart
@@ -353,7 +353,7 @@ void $toJsonMapHelperName(String key, dynamic value) {
 
       if (field == null) {
         if (arg.parameterKind == ParameterKind.REQUIRED) {
-          var additionalInfo = "";
+          var additionalInfo = '';
           var ignoredField = ignoredFields[arg.name];
           if (ignoredField != null) {
             if (_jsonKeyFor(ignoredField).ignore == true) {

--- a/json_serializable/pubspec.yaml
+++ b/json_serializable/pubspec.yaml
@@ -13,7 +13,7 @@ dependencies:
 
   # Use a tight version constraint to ensure that a constraint on
   # `json_annotation`. Properly constrains all features it provides.
-  json_annotation: '>=0.2.2 <0.2.3'
+  json_annotation: '>=0.2.3 <0.2.4'
   path: ^1.3.2
   source_gen: ^0.7.5
 dev_dependencies:

--- a/json_serializable/pubspec.yaml
+++ b/json_serializable/pubspec.yaml
@@ -6,7 +6,7 @@ homepage: https://github.com/dart-lang/json_serializable
 environment:
   sdk: '>=2.0.0-dev.9 <2.0.0'
 dependencies:
-  analyzer: '>=0.29.10 <0.31.2-alpha.1'
+  analyzer: '>=0.29.10 <0.32.0'
   build: '>=0.9.0 <0.13.0'
   build_config: ^0.2.1
   cli_util: ^0.1.0

--- a/json_serializable/pubspec.yaml
+++ b/json_serializable/pubspec.yaml
@@ -6,7 +6,7 @@ homepage: https://github.com/dart-lang/json_serializable
 environment:
   sdk: '>=2.0.0-dev.9 <2.0.0'
 dependencies:
-  analyzer: '>=0.29.10 <0.32.0'
+  analyzer: '>=0.29.10 <0.31.2-alpha.1'
   build: '>=0.9.0 <0.13.0'
   build_config: ^0.2.1
   cli_util: ^0.1.0

--- a/json_serializable/pubspec.yaml
+++ b/json_serializable/pubspec.yaml
@@ -22,3 +22,7 @@ dev_dependencies:
   collection: ^1.14.0
   dart_style: ^1.0.0
   test: ^0.12.3
+
+dependency_overrides:
+  json_annotation:
+    path: ../json_annotation

--- a/json_serializable/test/json_serializable_test.dart
+++ b/json_serializable/test/json_serializable_test.dart
@@ -125,6 +125,23 @@ void _registerTests(JsonSerializableGenerator generator) {
     expect(generateResult, contains('Map<String, dynamic> toJson()'));
   });
 
+  if (!generator.useWrappers) {
+    test('includes final field in toJson when set in ctor', () async {
+      var generateResult = await runForElementNamed('FinalFields');
+      expect(generateResult, contains('new FinalFields(json[\'a\'] as int);'));
+      expect(
+          generateResult, contains('toJson() => <String, dynamic>{\'a\': a};'));
+    });
+
+    test('excludes final field in toJson when not set in ctor', () async {
+      var generateResult = await runForElementNamed('FinalFieldsNotSetInCtor');
+      expect(generateResult,
+          isNot(contains('new FinalFields(json[\'a\'] as int);')));
+      expect(generateResult,
+          isNot(contains('toJson() => <String, dynamic>{\'a\': a};')));
+    });
+  }
+
   group('valid inputs', () {
     if (!generator.useWrappers) {
       test('class with no ctor params', () async {
@@ -230,6 +247,16 @@ abstract class _$OrderSerializerMixin {
 
         expect(output, contains("'h': height,"));
         expect(output, contains("..height = json['h']"));
+      });
+    }
+
+    if (!generator.useWrappers) {
+      test('works to ignore a field', () async {
+        var output = await runForElementNamed('IgnoredFieldClass');
+
+        expect(output, contains("'ignoredFalseField': ignoredFalseField,"));
+        expect(output, contains("'ignoredNullField': ignoredNullField"));
+        expect(output, isNot(contains("'ignoredTrueField': ignoredTrueField")));
       });
     }
 

--- a/json_serializable/test/json_serializable_test.dart
+++ b/json_serializable/test/json_serializable_test.dart
@@ -260,6 +260,29 @@ abstract class _$OrderSerializerMixin {
       });
     }
 
+    if (!generator.useWrappers) {
+      test('fails if ignored field is referenced by ctor', () async {
+        expect(
+            () => runForElementNamed('IgnoredFieldCtorClass'),
+            throwsA(new FeatureMatcher<UnsupportedError>(
+                'message',
+                (e) => e.message,
+                'Cannot populate the required constructor argument: '
+                'ignoredTrueField. It it assigns to an ignored field.')));
+      });
+    }
+    if (!generator.useWrappers) {
+      test('fails if private field is referenced by ctor', () async {
+        expect(
+            () => runForElementNamed('PrivateFieldCtorClass'),
+            throwsA(new FeatureMatcher<UnsupportedError>(
+                'message',
+                (e) => e.message,
+                'Cannot populate the required constructor argument: '
+                '_privateField. It it assigns to a non public field.')));
+      });
+    }
+
     test('fails if name duplicates existing field', () async {
       expect(
           () => runForElementNamed('KeyDupesField'),

--- a/json_serializable/test/src/json_serializable_test_input.dart
+++ b/json_serializable/test/src/json_serializable_test_input.dart
@@ -181,6 +181,7 @@ class IgnoredFieldCtorClass {
 
 @JsonSerializable()
 class PrivateFieldCtorClass {
+  // ignore: unused_field
   int _privateField;
   PrivateFieldCtorClass(this._privateField);
 }

--- a/json_serializable/test/src/json_serializable_test_input.dart
+++ b/json_serializable/test/src/json_serializable_test_input.dart
@@ -173,6 +173,19 @@ class IgnoredFieldClass {
 }
 
 @JsonSerializable()
+class IgnoredFieldCtorClass {
+  @JsonKey(ignore: true)
+  int ignoredTrueField;
+  IgnoredFieldCtorClass(this.ignoredTrueField);
+}
+
+@JsonSerializable()
+class PrivateFieldCtorClass {
+  int _privateField;
+  PrivateFieldCtorClass(this._privateField);
+}
+
+@JsonSerializable()
 class SubType extends SuperType {
   final int subTypeViaCtor;
   int subTypeReadWrite;

--- a/json_serializable/test/src/json_serializable_test_input.dart
+++ b/json_serializable/test/src/json_serializable_test_input.dart
@@ -42,6 +42,13 @@ class FinalFields {
 }
 
 @JsonSerializable()
+class FinalFieldsNotSetInCtor {
+  final int a = 1;
+
+  FinalFieldsNotSetInCtor();
+}
+
+@JsonSerializable()
 class FromJsonOptionalParameters {
   final ChildWithFromJson child;
 
@@ -152,6 +159,17 @@ class DupeKeys {
 
   @JsonKey(name: 'a')
   String str;
+}
+
+@JsonSerializable(createFactory: false)
+class IgnoredFieldClass {
+  @JsonKey(ignore: true)
+  int ignoredTrueField;
+
+  @JsonKey(ignore: false)
+  int ignoredFalseField;
+
+  int ignoredNullField;
 }
 
 @JsonSerializable()

--- a/json_serializable/test/test_files/json_test_example.dart
+++ b/json_serializable/test/test_files/json_test_example.dart
@@ -49,6 +49,13 @@ class Order extends Object with _$OrderSerializerMixin {
   Platform platform;
   Map<String, Platform> altPlatforms;
 
+  @JsonKey(ignore: true)
+  String get platformValue => platform?.description;
+
+  set platformValue(String value) {
+    throw 'not impld';
+  }
+
   int get price => items.fold(0, (total, item) => item.price + total);
 
   Order(this.category, [Iterable<Item> items])

--- a/json_serializable/test/test_files/json_test_example.dart
+++ b/json_serializable/test/test_files/json_test_example.dart
@@ -53,7 +53,7 @@ class Order extends Object with _$OrderSerializerMixin {
   String get platformValue => platform?.description;
 
   set platformValue(String value) {
-    throw 'not impld';
+    throw new UnimplementedError('not impld');
   }
 
   int get price => items.fold(0, (total, item) => item.price + total);

--- a/json_serializable/test/test_files/json_test_example.non_nullable.dart
+++ b/json_serializable/test/test_files/json_test_example.non_nullable.dart
@@ -59,7 +59,7 @@ class Order extends Object with _$OrderSerializerMixin {
   String get platformValue => platform?.description;
 
   set platformValue(String value) {
-    throw 'not impld';
+    throw new UnimplementedError('not impld');
   }
 
   int get price => items.fold(0, (total, item) => item.price + total);

--- a/json_serializable/test/test_files/json_test_example.non_nullable.dart
+++ b/json_serializable/test/test_files/json_test_example.non_nullable.dart
@@ -55,6 +55,13 @@ class Order extends Object with _$OrderSerializerMixin {
   Platform platform;
   Map<String, Platform> altPlatforms;
 
+  @JsonKey(ignore: true)
+  String get platformValue => platform?.description;
+
+  set platformValue(String value) {
+    throw 'not impld';
+  }
+
   int get price => items.fold(0, (total, item) => item.price + total);
 
   Order(this.category, [Iterable<Item> items])

--- a/json_serializable/test/test_files/json_test_example.non_nullable.wrapped.dart
+++ b/json_serializable/test/test_files/json_test_example.non_nullable.wrapped.dart
@@ -61,6 +61,13 @@ class Order extends Object with _$OrderSerializerMixin {
   Platform platform;
   Map<String, Platform> altPlatforms;
 
+  @JsonKey(ignore: true)
+  String get platformValue => platform?.description;
+
+  set platformValue(String value) {
+    throw 'not impld';
+  }
+
   int get price => items.fold(0, (total, item) => item.price + total);
 
   Order(this.category, [Iterable<Item> items])

--- a/json_serializable/test/test_files/json_test_example.non_nullable.wrapped.dart
+++ b/json_serializable/test/test_files/json_test_example.non_nullable.wrapped.dart
@@ -65,7 +65,7 @@ class Order extends Object with _$OrderSerializerMixin {
   String get platformValue => platform?.description;
 
   set platformValue(String value) {
-    throw 'not impld';
+    throw new UnimplementedError('not impld');
   }
 
   int get price => items.fold(0, (total, item) => item.price + total);

--- a/json_serializable/test/test_files/json_test_example.wrapped.dart
+++ b/json_serializable/test/test_files/json_test_example.wrapped.dart
@@ -59,7 +59,7 @@ class Order extends Object with _$OrderSerializerMixin {
   String get platformValue => platform?.description;
 
   set platformValue(String value) {
-    throw 'not impld';
+    throw new UnimplementedError('not impld');
   }
 
   int get price => items.fold(0, (total, item) => item.price + total);

--- a/json_serializable/test/test_files/json_test_example.wrapped.dart
+++ b/json_serializable/test/test_files/json_test_example.wrapped.dart
@@ -55,6 +55,13 @@ class Order extends Object with _$OrderSerializerMixin {
   Platform platform;
   Map<String, Platform> altPlatforms;
 
+  @JsonKey(ignore: true)
+  String get platformValue => platform?.description;
+
+  set platformValue(String value) {
+    throw 'not impld';
+  }
+
   int get price => items.fold(0, (total, item) => item.price + total);
 
   Order(this.category, [Iterable<Item> items])


### PR DESCRIPTION
Hello Kevin Moore, from all the serialization libraries for dart out there, yours was always my favorite. But for me, it was a major feature: an ignore annotation. 

This pull request is for the ignore attribute for JsonKey. When set to true the generator excludes the field.

```dart
@JsonSerializable(includeIfNull: false, nullable: false)
class Column extends _$ColumnSerializerMixin {
// [...]
// ColumnSettings is serializable
ColumnSettings settings = new ColumnSettings();

// ColumnSettings is already serializable and includes witdh.
// Without 'ignore' the generator would generate the same field for ColumnSettings and Column 
@JsonKey(ignore: true)
num get width => settings.width;
set width (num value) =>settings.width = value;
// [...]
}
```

What is also does is:
- exclude private fields
- refactored _writeFactory to return the fields that it used to generate the factory instead of those which are not set by it.
- adds a test "works to ignore a field"
- adds a test 'includes final field in toJson when set in ctor' which ensures the final field 'a' that is set in the constructor is included in the factory and in toJson.
- adds a test 'excludes final field in toJson when not set in ctor' which ensures that the same field is excluded in factory and toJson if it isn't set in the constructor.