### PR TITLE
Add option for `implicitToJson`

### DIFF
--- a/json_serializable/CHANGELOG.md
+++ b/json_serializable/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 * `enum` deserialization now uses helpers provided by `json_annotation`.
 
-* Added `explicit_to_json` configuration option.
+* Added `implicit_to_json` configuration option.
 
 * Small change to how nullable `Map` values are deserialized.
 

--- a/json_serializable/CHANGELOG.md
+++ b/json_serializable/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 * `enum` deserialization now uses helpers provided by `json_annotation`.
 
+* Added `explicit_to_json` configuration option.
+
 * Small change to how nullable `Map` values are deserialized.
 
 * Small whitespace changes to `JsonLiteral` generation to align with `dartfmt`.

--- a/json_serializable/README.md
+++ b/json_serializable/README.md
@@ -83,14 +83,14 @@ targets:
           # Options configure how source code is generated for every
           # `@JsonSerializable`-annotated class in the package.
           #
-          # The default value for each of them: `false`.
+          # The default value for each is shown.
           #
           # For usage information, reference the corresponding field in
           # `JsonSerializableGenerator`.
-          use_wrappers: true
-          any_map: true
-          checked: true
-          explicit_to_json: true
+          use_wrappers: false
+          any_map: false
+          checked: false
+          implicit_to_json: true
 ```
 
 [example]: https://github.com/dart-lang/json_serializable/blob/master/example

--- a/json_serializable/README.md
+++ b/json_serializable/README.md
@@ -90,6 +90,7 @@ targets:
           use_wrappers: true
           any_map: true
           checked: true
+          explicit_to_json: true
 ```
 
 [example]: https://github.com/dart-lang/json_serializable/blob/master/example

--- a/json_serializable/lib/builder.dart
+++ b/json_serializable/lib/builder.dart
@@ -26,10 +26,12 @@ Builder jsonSerializable(BuilderOptions options) {
   var optionsMap = new Map<String, dynamic>.from(options.config);
 
   var builder = jsonPartBuilder(
-      header: optionsMap.remove('header') as String,
-      useWrappers: optionsMap.remove('use_wrappers') as bool,
-      checked: optionsMap.remove('checked') as bool,
-      anyMap: optionsMap.remove('any_map') as bool);
+    header: optionsMap.remove('header') as String,
+    useWrappers: optionsMap.remove('use_wrappers') as bool,
+    checked: optionsMap.remove('checked') as bool,
+    anyMap: optionsMap.remove('any_map') as bool,
+    explicitToJson: optionsMap.remove('explicit_to_json') as bool,
+  );
 
   if (optionsMap.isNotEmpty) {
     if (log == null) {

--- a/json_serializable/lib/builder.dart
+++ b/json_serializable/lib/builder.dart
@@ -30,7 +30,7 @@ Builder jsonSerializable(BuilderOptions options) {
     useWrappers: optionsMap.remove('use_wrappers') as bool,
     checked: optionsMap.remove('checked') as bool,
     anyMap: optionsMap.remove('any_map') as bool,
-    explicitToJson: optionsMap.remove('explicit_to_json') as bool,
+    implicitToJson: optionsMap.remove('implicit_to_json') as bool,
   );
 
   if (optionsMap.isNotEmpty) {

--- a/json_serializable/lib/src/json_part_builder.dart
+++ b/json_serializable/lib/src/json_part_builder.dart
@@ -20,15 +20,21 @@ import 'json_serializable_generator.dart';
 ///
 /// For details on [useWrappers], [anyMap], and [checked] see
 /// [JsonSerializableGenerator].
-Builder jsonPartBuilder(
-    {String header,
-    String formatOutput(String code),
-    bool useWrappers: false,
-    bool anyMap: false,
-    bool checked: false}) {
+Builder jsonPartBuilder({
+  String header,
+  String formatOutput(String code),
+  bool useWrappers: false,
+  bool anyMap: false,
+  bool checked: false,
+  bool explicitToJson: false,
+}) {
   return new PartBuilder([
     new JsonSerializableGenerator(
-        useWrappers: useWrappers, anyMap: anyMap, checked: checked),
+      useWrappers: useWrappers,
+      anyMap: anyMap,
+      checked: checked,
+      explicitToJson: explicitToJson,
+    ),
     const JsonLiteralGenerator()
   ], header: header, formatOutput: formatOutput);
 }

--- a/json_serializable/lib/src/json_part_builder.dart
+++ b/json_serializable/lib/src/json_part_builder.dart
@@ -26,14 +26,14 @@ Builder jsonPartBuilder({
   bool useWrappers: false,
   bool anyMap: false,
   bool checked: false,
-  bool explicitToJson: false,
+  bool implicitToJson: true,
 }) {
   return new PartBuilder([
     new JsonSerializableGenerator(
       useWrappers: useWrappers,
       anyMap: anyMap,
       checked: checked,
-      explicitToJson: explicitToJson,
+      implicitToJson: implicitToJson,
     ),
     const JsonLiteralGenerator()
   ], header: header, formatOutput: formatOutput);

--- a/json_serializable/lib/src/json_serializable_generator.dart
+++ b/json_serializable/lib/src/json_serializable_generator.dart
@@ -66,6 +66,26 @@ class JsonSerializableGenerator
   /// [CheckedFromJsonException] is thrown.
   final bool checked;
 
+  /// If `true`, generated `toJson` methods will explicitly call `toJson` on
+  /// nested objects.
+  ///
+  /// When using JSON encoding support in `dart:convert`, `toJson` is
+  /// automatically called on objects, so the default behavior
+  /// (`explicitToJson: false`) is to omit the `toJson` call.
+  ///
+  /// Example of `explicitToJson: false` (default)
+  ///
+  /// ```dart
+  /// Map<String, dynamic> toJson() => {'child': child};
+  /// ```
+  ///
+  /// Example of `explicitToJson: true`
+  ///
+  /// ```dart
+  /// Map<String, dynamic> toJson() => {'child': child?.toJson()};
+  /// ```
+  final bool explicitToJson;
+
   /// Creates an instance of [JsonSerializableGenerator].
   ///
   /// If [typeHelpers] is not provided, two built-in helpers are used:
@@ -75,9 +95,11 @@ class JsonSerializableGenerator
     bool useWrappers: false,
     bool anyMap: false,
     bool checked: false,
+    bool explicitToJson: false,
   })  : this.useWrappers = useWrappers ?? false,
         this.anyMap = anyMap ?? false,
         this.checked = checked ?? false,
+        this.explicitToJson = explicitToJson ?? false,
         this._typeHelpers = typeHelpers ?? _defaultHelpers;
 
   /// Creates an instance of [JsonSerializableGenerator].

--- a/json_serializable/lib/src/json_serializable_generator.dart
+++ b/json_serializable/lib/src/json_serializable_generator.dart
@@ -66,25 +66,25 @@ class JsonSerializableGenerator
   /// [CheckedFromJsonException] is thrown.
   final bool checked;
 
-  /// If `true`, generated `toJson` methods will explicitly call `toJson` on
+  /// If `false`, generated `toJson` methods will explicitly call `toJson` on
   /// nested objects.
   ///
   /// When using JSON encoding support in `dart:convert`, `toJson` is
   /// automatically called on objects, so the default behavior
-  /// (`explicitToJson: false`) is to omit the `toJson` call.
+  /// (`implicitToJson: true`) is to omit the `toJson` call.
   ///
-  /// Example of `explicitToJson: false` (default)
+  /// Example of `implicitToJson: true` (default)
   ///
   /// ```dart
   /// Map<String, dynamic> toJson() => {'child': child};
   /// ```
   ///
-  /// Example of `explicitToJson: true`
+  /// Example of `implicitToJson: false`
   ///
   /// ```dart
   /// Map<String, dynamic> toJson() => {'child': child?.toJson()};
   /// ```
-  final bool explicitToJson;
+  final bool implicitToJson;
 
   /// Creates an instance of [JsonSerializableGenerator].
   ///
@@ -95,11 +95,11 @@ class JsonSerializableGenerator
     bool useWrappers: false,
     bool anyMap: false,
     bool checked: false,
-    bool explicitToJson: false,
+    bool implicitToJson: true,
   })  : this.useWrappers = useWrappers ?? false,
         this.anyMap = anyMap ?? false,
         this.checked = checked ?? false,
-        this.explicitToJson = explicitToJson ?? false,
+        this.implicitToJson = implicitToJson ?? true,
         this._typeHelpers = typeHelpers ?? _defaultHelpers;
 
   /// Creates an instance of [JsonSerializableGenerator].

--- a/json_serializable/lib/src/type_helper_context.dart
+++ b/json_serializable/lib/src/type_helper_context.dart
@@ -28,6 +28,8 @@ class TypeHelperContext implements SerializeContext, DeserializeContext {
   // Consider exposing it if there is interest
   bool get anyMap => _generator.anyMap;
 
+  bool get explicitToJson => _generator.explicitToJson;
+
   TypeHelperContext(this._generator, this.metadata, this.nullable,
       this.fromJsonData, this.toJsonData);
 

--- a/json_serializable/lib/src/type_helper_context.dart
+++ b/json_serializable/lib/src/type_helper_context.dart
@@ -28,7 +28,7 @@ class TypeHelperContext implements SerializeContext, DeserializeContext {
   // Consider exposing it if there is interest
   bool get anyMap => _generator.anyMap;
 
-  bool get explicitToJson => _generator.explicitToJson;
+  bool get implicitToJson => _generator.implicitToJson;
 
   TypeHelperContext(this._generator, this.metadata, this.nullable,
       this.fromJsonData, this.toJsonData);

--- a/json_serializable/lib/src/type_helpers/json_helper.dart
+++ b/json_serializable/lib/src/type_helpers/json_helper.dart
@@ -21,11 +21,15 @@ class JsonHelper extends TypeHelper {
   /// By default, JSON encoding in from `dart:convert` calls `toJson()` on
   /// provided objects.
   @override
-  String serialize(DartType targetType, String expression, _) {
+  String serialize(
+      DartType targetType, String expression, SerializeContext context) {
     if (!_canSerialize(targetType)) {
       return null;
     }
 
+    if (context is TypeHelperContext && context.explicitToJson) {
+      return '$expression${context.nullable ? '?' : ''}.toJson()';
+    }
     return expression;
   }
 

--- a/json_serializable/lib/src/type_helpers/json_helper.dart
+++ b/json_serializable/lib/src/type_helpers/json_helper.dart
@@ -16,10 +16,10 @@ import '../utils.dart';
 class JsonHelper extends TypeHelper {
   const JsonHelper();
 
-  /// Simply returns the [expression] provided.
+  /// If the builder is configured with `implicit_to_json: true`, simply returns
+  /// the [expression] provided.
   ///
-  /// By default, JSON encoding in from `dart:convert` calls `toJson()` on
-  /// provided objects.
+  /// Otherwise, returns [expression]`.toJson()` with proper `null` handling.
   @override
   String serialize(
       DartType targetType, String expression, SerializeContext context) {
@@ -27,10 +27,13 @@ class JsonHelper extends TypeHelper {
       return null;
     }
 
-    if (context is TypeHelperContext && context.explicitToJson) {
-      return '$expression${context.nullable ? '?' : ''}.toJson()';
+    var ctx = context as TypeHelperContext;
+
+    if (ctx.implicitToJson) {
+      return expression;
     }
-    return expression;
+
+    return '$expression${context.nullable ? '?' : ''}.toJson()';
   }
 
   @override

--- a/json_serializable/test/config_test.dart
+++ b/json_serializable/test/config_test.dart
@@ -100,12 +100,14 @@ const _validConfig = const {
   'header': 'header',
   'use_wrappers': true,
   'any_map': true,
-  'checked': true
+  'checked': true,
+  'explicit_to_json': true
 };
 
 const _invalidConfig = const {
   'header': true,
   'use_wrappers': 42,
   'any_map': 42,
-  'checked': 42
+  'checked': 42,
+  'explicit_to_json': 42
 };

--- a/json_serializable/test/config_test.dart
+++ b/json_serializable/test/config_test.dart
@@ -101,7 +101,7 @@ const _validConfig = const {
   'use_wrappers': true,
   'any_map': true,
   'checked': true,
-  'explicit_to_json': true
+  'implicit_to_json': false
 };
 
 const _invalidConfig = const {
@@ -109,5 +109,5 @@ const _invalidConfig = const {
   'use_wrappers': 42,
   'any_map': 42,
   'checked': 42,
-  'explicit_to_json': 42
+  'implicit_to_json': 42
 };

--- a/json_serializable/test/json_serializable_test.dart
+++ b/json_serializable/test/json_serializable_test.dart
@@ -70,7 +70,7 @@ void _registerTests(JsonSerializableGenerator generator) {
     test('nullable', () async {
       var output = await _runForElementNamed(
           new JsonSerializableGenerator(
-              explicitToJson: true, useWrappers: generator.useWrappers),
+              implicitToJson: false, useWrappers: generator.useWrappers),
           'TrivialNestedNullable');
 
       var expected = generator.useWrappers
@@ -115,7 +115,7 @@ class _$TrivialNestedNullableJsonMapWrapper extends $JsonMapWrapper {
     test('non-nullable', () async {
       var output = await _runForElementNamed(
           new JsonSerializableGenerator(
-              explicitToJson: true, useWrappers: generator.useWrappers),
+              implicitToJson: false, useWrappers: generator.useWrappers),
           'TrivialNestedNonNullable');
 
       var expected = generator.useWrappers

--- a/json_serializable/test/json_serializable_test.dart
+++ b/json_serializable/test/json_serializable_test.dart
@@ -66,7 +66,7 @@ void _registerTests(JsonSerializableGenerator generator) {
         _throwsInvalidGenerationSourceError(messageMatcher, todoMatcher));
   }
 
-  group('explicit toJson', () {
+  group('implicitToJson: false', () {
     test('nullable', () async {
       var output = await _runForElementNamed(
           new JsonSerializableGenerator(

--- a/json_serializable/test/json_serializable_test.dart
+++ b/json_serializable/test/json_serializable_test.dart
@@ -66,6 +66,89 @@ void _registerTests(JsonSerializableGenerator generator) {
         _throwsInvalidGenerationSourceError(messageMatcher, todoMatcher));
   }
 
+  group('explicit toJson', () {
+    test('nullable', () async {
+      var output = await _runForElementNamed(
+          new JsonSerializableGenerator(
+              explicitToJson: true, useWrappers: generator.useWrappers),
+          'TrivialNestedNullable');
+
+      var expected = generator.useWrappers
+          ? r'''abstract class _$TrivialNestedNullableSerializerMixin {
+  TrivialNestedNullable get child;
+  Map<String, dynamic> toJson() =>
+      new _$TrivialNestedNullableJsonMapWrapper(this);
+}
+
+class _$TrivialNestedNullableJsonMapWrapper extends $JsonMapWrapper {
+  final _$TrivialNestedNullableSerializerMixin _v;
+  _$TrivialNestedNullableJsonMapWrapper(this._v);
+
+  @override
+  Iterable<String> get keys => const ['child'];
+
+  @override
+  dynamic operator [](Object key) {
+    if (key is String) {
+      switch (key) {
+        case 'child':
+          return _v.child?.toJson();
+      }
+    }
+    return null;
+  }
+}
+'''
+          : r'''abstract class _$TrivialNestedNullableSerializerMixin {
+  TrivialNestedNullable get child;
+  Map<String, dynamic> toJson() => <String, dynamic>{'child': child?.toJson()};
+}
+''';
+
+      expect(output, expected);
+    });
+    test('non-nullable', () async {
+      var output = await _runForElementNamed(
+          new JsonSerializableGenerator(
+              explicitToJson: true, useWrappers: generator.useWrappers),
+          'TrivialNestedNonNullable');
+
+      var expected = generator.useWrappers
+          ? r'''abstract class _$TrivialNestedNonNullableSerializerMixin {
+  TrivialNestedNonNullable get child;
+  Map<String, dynamic> toJson() =>
+      new _$TrivialNestedNonNullableJsonMapWrapper(this);
+}
+
+class _$TrivialNestedNonNullableJsonMapWrapper extends $JsonMapWrapper {
+  final _$TrivialNestedNonNullableSerializerMixin _v;
+  _$TrivialNestedNonNullableJsonMapWrapper(this._v);
+
+  @override
+  Iterable<String> get keys => const ['child'];
+
+  @override
+  dynamic operator [](Object key) {
+    if (key is String) {
+      switch (key) {
+        case 'child':
+          return _v.child.toJson();
+      }
+    }
+    return null;
+  }
+}
+'''
+          : r'''abstract class _$TrivialNestedNonNullableSerializerMixin {
+  TrivialNestedNonNullable get child;
+  Map<String, dynamic> toJson() => <String, dynamic>{'child': child.toJson()};
+}
+''';
+
+      expect(output, expected);
+    });
+  });
+
   group('non-classes', () {
     test('const field', () {
       expectThrows('theAnswer', 'Generator cannot target `theAnswer`.',

--- a/json_serializable/test/json_serializable_test.dart
+++ b/json_serializable/test/json_serializable_test.dart
@@ -76,6 +76,7 @@ void _registerTests(JsonSerializableGenerator generator) {
       var expected = generator.useWrappers
           ? r'''abstract class _$TrivialNestedNullableSerializerMixin {
   TrivialNestedNullable get child;
+  int get otherField;
   Map<String, dynamic> toJson() =>
       new _$TrivialNestedNullableJsonMapWrapper(this);
 }
@@ -85,7 +86,7 @@ class _$TrivialNestedNullableJsonMapWrapper extends $JsonMapWrapper {
   _$TrivialNestedNullableJsonMapWrapper(this._v);
 
   @override
-  Iterable<String> get keys => const ['child'];
+  Iterable<String> get keys => const ['child', 'otherField'];
 
   @override
   dynamic operator [](Object key) {
@@ -93,6 +94,8 @@ class _$TrivialNestedNullableJsonMapWrapper extends $JsonMapWrapper {
       switch (key) {
         case 'child':
           return _v.child?.toJson();
+        case 'otherField':
+          return _v.otherField;
       }
     }
     return null;
@@ -101,7 +104,9 @@ class _$TrivialNestedNullableJsonMapWrapper extends $JsonMapWrapper {
 '''
           : r'''abstract class _$TrivialNestedNullableSerializerMixin {
   TrivialNestedNullable get child;
-  Map<String, dynamic> toJson() => <String, dynamic>{'child': child?.toJson()};
+  int get otherField;
+  Map<String, dynamic> toJson() =>
+      <String, dynamic>{'child': child?.toJson(), 'otherField': otherField};
 }
 ''';
 
@@ -116,6 +121,7 @@ class _$TrivialNestedNullableJsonMapWrapper extends $JsonMapWrapper {
       var expected = generator.useWrappers
           ? r'''abstract class _$TrivialNestedNonNullableSerializerMixin {
   TrivialNestedNonNullable get child;
+  int get otherField;
   Map<String, dynamic> toJson() =>
       new _$TrivialNestedNonNullableJsonMapWrapper(this);
 }
@@ -125,7 +131,7 @@ class _$TrivialNestedNonNullableJsonMapWrapper extends $JsonMapWrapper {
   _$TrivialNestedNonNullableJsonMapWrapper(this._v);
 
   @override
-  Iterable<String> get keys => const ['child'];
+  Iterable<String> get keys => const ['child', 'otherField'];
 
   @override
   dynamic operator [](Object key) {
@@ -133,6 +139,8 @@ class _$TrivialNestedNonNullableJsonMapWrapper extends $JsonMapWrapper {
       switch (key) {
         case 'child':
           return _v.child.toJson();
+        case 'otherField':
+          return _v.otherField;
       }
     }
     return null;
@@ -141,7 +149,9 @@ class _$TrivialNestedNonNullableJsonMapWrapper extends $JsonMapWrapper {
 '''
           : r'''abstract class _$TrivialNestedNonNullableSerializerMixin {
   TrivialNestedNonNullable get child;
-  Map<String, dynamic> toJson() => <String, dynamic>{'child': child.toJson()};
+  int get otherField;
+  Map<String, dynamic> toJson() =>
+      <String, dynamic>{'child': child.toJson(), 'otherField': otherField};
 }
 ''';
 

--- a/json_serializable/test/src/json_serializable_test_input.dart
+++ b/json_serializable/test/src/json_serializable_test_input.dart
@@ -214,3 +214,13 @@ class SuperType {
   int priceFraction(int other) =>
       superTypeViaCtor == null ? null : superTypeViaCtor ~/ other;
 }
+
+@JsonSerializable(createFactory: false)
+class TrivialNestedNullable {
+  TrivialNestedNullable child;
+}
+
+@JsonSerializable(createFactory: false, nullable: false)
+class TrivialNestedNonNullable {
+  TrivialNestedNonNullable child;
+}

--- a/json_serializable/test/src/json_serializable_test_input.dart
+++ b/json_serializable/test/src/json_serializable_test_input.dart
@@ -218,9 +218,11 @@ class SuperType {
 @JsonSerializable(createFactory: false)
 class TrivialNestedNullable {
   TrivialNestedNullable child;
+  int otherField;
 }
 
 @JsonSerializable(createFactory: false, nullable: false)
 class TrivialNestedNonNullable {
   TrivialNestedNonNullable child;
+  int otherField;
 }


### PR DESCRIPTION
Allows users to opt-in to including `.toJson()` calls on nested
objects in generated `toJson` methods.

This is useful if you want to round-trip the output of toJson without
putting it through jsonEncode and jsonDecode

Fixes #192