### PR TITLE
Pre-emptively add support for build_config 0.3.0

### DIFF
--- a/json_serializable/pubspec.yaml
+++ b/json_serializable/pubspec.yaml
@@ -8,7 +8,7 @@ environment:
 dependencies:
   analyzer: ^0.32.0
   build: '>=0.9.0 <0.13.0'
-  build_config: ^0.2.6
+  build_config: '>=0.2.6 <0.4.0'
 
   # Use a tight version constraint to ensure that a constraint on
   # `json_annotation`. Properly constrains all features it provides.


### PR DESCRIPTION
build_config depends on this package, so we need this to be published before we can publish. There are no breaking changes to the build.yaml format.