### PR TITLE
Add `disallowUnrecognizedKeys` option

### DIFF
--- a/json_annotation/CHANGELOG.md
+++ b/json_annotation/CHANGELOG.md
@@ -1,3 +1,15 @@
+## 0.2.7
+
+* Added `JsonSerializable.allowUnrecognizedKeys`.
+  * Defaults to `true` which maintains the previous behavior.
+  * Throws an `UnrecognizedKeysException` if it finds unrecognized keys in any
+    json maps.
+  * Will be captured captured and wrapped in a `CheckedFromJsonException` if
+    `checked` is enabled in `json_serializable`.
+  * Added a helper function to support this option. This function starts with a
+    `$` and should only be referenced by generated code. It is not meant for
+    direct use.
+
 ## 0.2.6
 
 * `CheckedFromJsonException`
@@ -29,7 +41,7 @@
 
 ## 0.2.2
 
-* Added a helper class – `$JsonMapWrapper` – and helper functions – `$wrapMap`, 
+* Added a helper class – `$JsonMapWrapper` – and helper functions – `$wrapMap`,
   `$wrapMapHandleNull`, `$wrapList`, and `$wrapListHandleNull` – to support
   the `useWrappers` option added to `JsonSerializableGenerator` in `v0.3.0` of
   `package:json_serializable`.

--- a/json_annotation/CHANGELOG.md
+++ b/json_annotation/CHANGELOG.md
@@ -1,11 +1,6 @@
 ## 0.2.7
 
 * Added `JsonSerializable.disallowUnrecognizedKeys`.
-  * Defaults to `false` which maintains the previous behavior.
-  * Throws an `UnrecognizedKeysException` if it finds unrecognized keys in the
-    JSON map used to create the annotated object.
-  * Will be captured captured and wrapped in a `CheckedFromJsonException` if
-    `checked` is enabled in `json_serializable`.
   * Added a helper function to support this option. This function starts with a
     `$` and should only be referenced by generated code. It is not meant for
     direct use.

--- a/json_annotation/CHANGELOG.md
+++ b/json_annotation/CHANGELOG.md
@@ -1,6 +1,6 @@
 ## 0.2.7
 
-* Added `JsonSerializable.disallowUnregognizedKeys`.
+* Added `JsonSerializable.disallowUnrecognizedKeys`.
   * Defaults to `false` which maintains the previous behavior.
   * Throws an `UnrecognizedKeysException` if it finds unrecognized keys in the
     JSON map used to create the annotated object.

--- a/json_annotation/CHANGELOG.md
+++ b/json_annotation/CHANGELOG.md
@@ -1,9 +1,9 @@
 ## 0.2.7
 
-* Added `JsonSerializable.allowUnrecognizedKeys`.
-  * Defaults to `true` which maintains the previous behavior.
-  * Throws an `UnrecognizedKeysException` if it finds unrecognized keys in any
-    json maps.
+* Added `JsonSerializable.disallowUnregognizedKeys`.
+  * Defaults to `false` which maintains the previous behavior.
+  * Throws an `UnrecognizedKeysException` if it finds unrecognized keys in the
+    JSON map used to create the annotated object.
   * Will be captured captured and wrapped in a `CheckedFromJsonException` if
     `checked` is enabled in `json_serializable`.
   * Added a helper function to support this option. This function starts with a

--- a/json_annotation/lib/json_annotation.dart
+++ b/json_annotation/lib/json_annotation.dart
@@ -10,6 +10,7 @@
 /// enabled.
 library json_annotation;
 
+export 'src/allowed_keys_helpers.dart';
 export 'src/checked_helpers.dart';
 export 'src/json_literal.dart';
 export 'src/json_serializable.dart';

--- a/json_annotation/lib/src/allowed_keys_helpers.dart
+++ b/json_annotation/lib/src/allowed_keys_helpers.dart
@@ -3,7 +3,7 @@
 // BSD-style license that can be found in the LICENSE file.
 
 /// Helper function used in generated code when
-/// `JsonAnnotation.disallowUnrecognizedKeys` is `true`.
+/// `JsonSerializable.disallowUnrecognizedKeys` is `true`.
 ///
 /// Should not be used directly.
 void $checkAllowedKeys(Map map, Iterable<String> allowedKeys) {

--- a/json_annotation/lib/src/allowed_keys_helpers.dart
+++ b/json_annotation/lib/src/allowed_keys_helpers.dart
@@ -7,6 +7,7 @@
 ///
 /// Should not be used directly.
 void $checkAllowedKeys(Map map, Iterable<String> allowedKeys) {
+  if (map == null) return;
   var invalidKeys = map.keys.where((k) => !allowedKeys.contains(k));
   if (invalidKeys.isNotEmpty) {
     throw new UnrecognizedKeysException(

--- a/json_annotation/lib/src/allowed_keys_helpers.dart
+++ b/json_annotation/lib/src/allowed_keys_helpers.dart
@@ -3,7 +3,7 @@
 // BSD-style license that can be found in the LICENSE file.
 
 /// Helper function used in generated code when
-/// `JsonAnnotation.allowUnrecognizedKeys` is `false`.
+/// `JsonAnnotation.disallowUnregognizedKeys` is `true`.
 ///
 /// Should not be used directly.
 void $checkAllowedKeys(Map map, Iterable<String> allowedKeys) {

--- a/json_annotation/lib/src/allowed_keys_helpers.dart
+++ b/json_annotation/lib/src/allowed_keys_helpers.dart
@@ -3,7 +3,7 @@
 // BSD-style license that can be found in the LICENSE file.
 
 /// Helper function used in generated code when
-/// `JsonAnnotation.disallowUnregognizedKeys` is `true`.
+/// `JsonAnnotation.disallowUnrecognizedKeys` is `true`.
 ///
 /// Should not be used directly.
 void $checkAllowedKeys(Map map, Iterable<String> allowedKeys) {

--- a/json_annotation/lib/src/allowed_keys_helpers.dart
+++ b/json_annotation/lib/src/allowed_keys_helpers.dart
@@ -1,0 +1,35 @@
+// Copyright (c) 2018, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+/// Helper function used in generated code when
+/// `JsonAnnotation.allowUnrecognizedKeys` is `false`.
+///
+/// Should not be used directly.
+void $checkAllowedKeys(Map map, Iterable<String> allowedKeys) {
+  var invalidKeys = map.keys.where((k) => !allowedKeys.contains(k));
+  if (invalidKeys.isNotEmpty) {
+    throw new UnrecognizedKeysException(
+        new List<String>.from(invalidKeys), map, allowedKeys.toList());
+  }
+}
+
+/// Exception thrown if there is an unrecognized key in a json map that was
+/// provided during deserialization.
+class UnrecognizedKeysException implements Exception {
+  /// The allowed keys for [map].
+  final List<String> allowedKeys;
+
+  /// The keys from [map] that were unrecognized.
+  final List<String> unrecognizedKeys;
+
+  /// The source [Map] that the key was found in.
+  final Map map;
+
+  /// A human-readable message corresponding to the error.
+  String get message =>
+      'Unrecognized keys [${unrecognizedKeys.join(', ')}], supported keys  are '
+      '[${allowedKeys.join(', ')}]';
+
+  UnrecognizedKeysException(this.unrecognizedKeys, this.map, this.allowedKeys);
+}

--- a/json_annotation/lib/src/checked_helpers.dart
+++ b/json_annotation/lib/src/checked_helpers.dart
@@ -2,6 +2,8 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
+import 'allowed_keys_helpers.dart';
+
 /// Helper function used in generated code when
 /// `JsonSerializableGenerator.checked` is `true`.
 ///
@@ -76,6 +78,12 @@ class CheckedFromJsonException implements Exception {
       : _className = className,
         message = _getMessage(innerError);
 
-  static String _getMessage(Object error) =>
-      (error is ArgumentError) ? error.message?.toString() : null;
+  static String _getMessage(Object error) {
+    if (error is ArgumentError) {
+      return error.message?.toString();
+    } else if (error is UnrecognizedKeysException) {
+      return error.message;
+    }
+    return null;
+  }
 }

--- a/json_annotation/lib/src/json_serializable.dart
+++ b/json_annotation/lib/src/json_serializable.dart
@@ -8,7 +8,6 @@ class JsonSerializable {
   /// generated FromJson factory will be ignored.
   ///
   /// If `true`, any unrecognized keys will be treated as an error.
-  /// ```
   final bool disallowUnrecognizedKeys;
 
   /// If `true` (the default), a private, static `_$ExampleFromJson` method

--- a/json_annotation/lib/src/json_serializable.dart
+++ b/json_annotation/lib/src/json_serializable.dart
@@ -9,7 +9,7 @@ class JsonSerializable {
   ///
   /// If `true`, any unrecognized keys will be treated as an error.
   /// ```
-  final bool disallowUnregognizedKeys;
+  final bool disallowUnrecognizedKeys;
 
   /// If `true` (the default), a private, static `_$ExampleFromJson` method
   /// is created in the generated part file.
@@ -55,12 +55,12 @@ class JsonSerializable {
 
   /// Creates a new [JsonSerializable] instance.
   const JsonSerializable(
-      {bool disallowUnregognizedKeys: false,
+      {bool disallowUnrecognizedKeys: false,
       bool createFactory: true,
       bool createToJson: true,
       bool includeIfNull: true,
       bool nullable: true})
-      : this.disallowUnregognizedKeys = disallowUnregognizedKeys ?? false,
+      : this.disallowUnrecognizedKeys = disallowUnrecognizedKeys ?? false,
         this.createFactory = createFactory ?? true,
         this.createToJson = createToJson ?? true,
         this.includeIfNull = includeIfNull ?? true,

--- a/json_annotation/lib/src/json_serializable.dart
+++ b/json_annotation/lib/src/json_serializable.dart
@@ -4,12 +4,12 @@
 
 /// An annotation used to specify a class to generate code for.
 class JsonSerializable {
-  /// If `true` (the default), then any unrecognized keys passed to the
+  /// If `false` (the default), then any unrecognized keys passed to the
   /// generated FromJson factory will be ignored.
   ///
-  /// If `false`, any unrecognized keys will be treated as an error.
+  /// If `true`, any unrecognized keys will be treated as an error.
   /// ```
-  final bool allowUnrecognizedKeys;
+  final bool disallowUnregognizedKeys;
 
   /// If `true` (the default), a private, static `_$ExampleFromJson` method
   /// is created in the generated part file.
@@ -55,12 +55,12 @@ class JsonSerializable {
 
   /// Creates a new [JsonSerializable] instance.
   const JsonSerializable(
-      {bool allowUnrecognizedKeys: true,
+      {bool disallowUnregognizedKeys: false,
       bool createFactory: true,
       bool createToJson: true,
       bool includeIfNull: true,
       bool nullable: true})
-      : this.allowUnrecognizedKeys = allowUnrecognizedKeys ?? true,
+      : this.disallowUnregognizedKeys = disallowUnregognizedKeys ?? false,
         this.createFactory = createFactory ?? true,
         this.createToJson = createToJson ?? true,
         this.includeIfNull = includeIfNull ?? true,

--- a/json_annotation/lib/src/json_serializable.dart
+++ b/json_annotation/lib/src/json_serializable.dart
@@ -4,6 +4,13 @@
 
 /// An annotation used to specify a class to generate code for.
 class JsonSerializable {
+  /// If `true` (the default), then any unrecognized keys passed to the
+  /// generated FromJson factory will be ignored.
+  ///
+  /// If `false`, any unrecognized keys will be treated as an error.
+  /// ```
+  final bool allowUnrecognizedKeys;
+
   /// If `true` (the default), a private, static `_$ExampleFromJson` method
   /// is created in the generated part file.
   ///
@@ -48,11 +55,13 @@ class JsonSerializable {
 
   /// Creates a new [JsonSerializable] instance.
   const JsonSerializable(
-      {bool createFactory: true,
+      {bool allowUnrecognizedKeys: true,
+      bool createFactory: true,
       bool createToJson: true,
       bool includeIfNull: true,
       bool nullable: true})
-      : this.createFactory = createFactory ?? true,
+      : this.allowUnrecognizedKeys = allowUnrecognizedKeys ?? true,
+        this.createFactory = createFactory ?? true,
         this.createToJson = createToJson ?? true,
         this.includeIfNull = includeIfNull ?? true,
         this.nullable = nullable ?? true;

--- a/json_annotation/pubspec.yaml
+++ b/json_annotation/pubspec.yaml
@@ -1,5 +1,5 @@
 name: json_annotation
-version: 0.2.6-dev
+version: 0.2.7-dev
 description: >-
   Classes and helper functions that support JSON code generation via the
   `json_serializable` package.

--- a/json_serializable/CHANGELOG.md
+++ b/json_serializable/CHANGELOG.md
@@ -1,6 +1,6 @@
 ## 0.5.6
 
-* Added support for `JsonSerializable.allowUnrecognizedKeys`.
+* Added support for `JsonSerializable.disallowUnregognizedKeys`.
 
 ## 0.5.5
 

--- a/json_serializable/CHANGELOG.md
+++ b/json_serializable/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.5.6
+
+* Added support for `JsonSerializable.allowUnrecognizedKeys`.
+
 ## 0.5.5
 
 * Added support for `JsonKey.defaultValue`.
@@ -35,9 +39,9 @@
 
 * If `JsonKey.fromJson` function parameter is `Iterable` or `Map` with type
    arguments of `dynamic` or `Object`, omit the arguments when generating a
-   cast. 
+   cast.
    `_myHelper(json['key'] as Map)` instead of
-   `_myHelper(json['key'] as Map<dynamic, dynamic>)`.  
+   `_myHelper(json['key'] as Map<dynamic, dynamic>)`.
 
 * `JsonKey.fromJson`/`.toJson` now support functions with optional arguments.
 

--- a/json_serializable/CHANGELOG.md
+++ b/json_serializable/CHANGELOG.md
@@ -1,6 +1,6 @@
 ## 0.5.6
 
-* Added support for `JsonSerializable.disallowUnregognizedKeys`.
+* Added support for `JsonSerializable.disallowUnrecognizedKeys`.
 
 ## 0.5.5
 

--- a/json_serializable/CHANGELOG.md
+++ b/json_serializable/CHANGELOG.md
@@ -1,6 +1,11 @@
 ## 0.5.6
 
 * Added support for `JsonSerializable.disallowUnrecognizedKeys`.
+  * Throws an `UnrecognizedKeysException` if it finds unrecognized keys in the
+    JSON map used to create the annotated object.
+  * Will be captured captured and wrapped in a `CheckedFromJsonException` if
+    `checked` is enabled in `json_serializable`.
+* All `fromJson` constructors now use block syntax instead of fat arrows.
 
 ## 0.5.5
 

--- a/json_serializable/README.md
+++ b/json_serializable/README.md
@@ -41,10 +41,12 @@ Building creates the corresponding part `example.g.dart`:
 ```dart
 part of 'example.dart';
 
-Person _$PersonFromJson(Map<String, dynamic> json) => new Person(
-    firstName: json['firstName'] as String,
-    lastName: json['lastName'] as String,
-    dateOfBirth: DateTime.parse(json['dateOfBirth'] as String));
+Person _$PersonFromJson(Map<String, dynamic> json) {
+  return new Person(
+      firstName: json['firstName'] as String,
+      lastName: json['lastName'] as String,
+      dateOfBirth: DateTime.parse(json['dateOfBirth'] as String));
+}
 
 abstract class _$PersonSerializerMixin {
   String get firstName;

--- a/json_serializable/example/example.g.dart
+++ b/json_serializable/example/example.g.dart
@@ -10,10 +10,12 @@ part of 'example.dart';
 // Generator: JsonSerializableGenerator
 // **************************************************************************
 
-Person _$PersonFromJson(Map<String, dynamic> json) => new Person(
-    firstName: json['firstName'] as String,
-    lastName: json['lastName'] as String,
-    dateOfBirth: DateTime.parse(json['dateOfBirth'] as String));
+Person _$PersonFromJson(Map<String, dynamic> json) {
+  return new Person(
+      firstName: json['firstName'] as String,
+      lastName: json['lastName'] as String,
+      dateOfBirth: DateTime.parse(json['dateOfBirth'] as String));
+}
 
 abstract class _$PersonSerializerMixin {
   String get firstName;

--- a/json_serializable/lib/src/generator_helper.dart
+++ b/json_serializable/lib/src/generator_helper.dart
@@ -170,7 +170,7 @@ class _GeneratorHelper {
 
         fieldsSetByFactory = data.usedCtorParamsAndFields;
 
-        if (_annotation.disallowUnregognizedKeys) {
+        if (_annotation.disallowUnrecognizedKeys) {
           var listLiteral = jsonLiteralAsDart(
               accessibleFields.values.map(_nameAccess).toList(), true);
           _buffer.write('''
@@ -220,7 +220,7 @@ class _GeneratorHelper {
 
         fieldsSetByFactory = data.usedCtorParamsAndFields;
 
-        if (_annotation.disallowUnregognizedKeys) {
+        if (_annotation.disallowUnrecognizedKeys) {
           var listLiteral = jsonLiteralAsDart(
               fieldsSetByFactory
                   .map((k) => _nameAccess(accessibleFields[k]))

--- a/json_serializable/lib/src/generator_helper.dart
+++ b/json_serializable/lib/src/generator_helper.dart
@@ -141,7 +141,7 @@ class _GeneratorHelper {
       var mapType = _generator.anyMap ? 'Map' : 'Map<String, dynamic>';
       _buffer.write('$_targetClassReference '
           '${_prefix}FromJson${_genericClassArguments(true)}'
-          '($mapType json) =>');
+          '($mapType json) {\n');
 
       String deserializeFun(String paramOrFieldName,
               {ParameterElement ctorParam}) =>
@@ -152,10 +152,11 @@ class _GeneratorHelper {
       if (_generator.checked) {
         var classLiteral = escapeDartString(_element.name);
 
-        _buffer.write(''' \$checkedNew(
+        _buffer.write('''
+  return \$checkedNew(
     $classLiteral,
     json,
-    ()''');
+    () {''');
 
         var data = writeConstructorInvocation(
             _element,
@@ -169,34 +170,31 @@ class _GeneratorHelper {
 
         fieldsSetByFactory = data.usedCtorParamsAndFields;
 
-        if (data.fieldsToSet.isEmpty) {
-          // Use simple arrow syntax for the constructor invocation.
-          // There are no fields to set
-          _buffer.write(' => ${data.content}');
-        } else {
-          // If there are fields to set, create a full function body and
-          // create a temporary variable to hold the instance so we can make
-          // wrapped calls to all of the fields value assignments.
-          _buffer.write(''' {
-      var val = ''');
-          _buffer.write(data.content);
-          _buffer.writeln(';');
-
-          for (var field in data.fieldsToSet) {
-            _buffer.writeln();
-            var safeName = _safeNameAccess(accessibleFields[field]);
-            _buffer.write('''
-      \$checkedConvert(json, $safeName, (v) => ''');
-            _buffer.write('val.$field = ');
-            _buffer.write(_deserializeForField(accessibleFields[field],
-                checkedProperty: true));
-            _buffer.write(');');
-          }
-          _buffer.writeln('return val; }');
+        if (!_annotation.allowUnrecognizedKeys) {
+          var listLiteral = jsonLiteralAsDart(
+              accessibleFields.values.map(_nameAccess).toList(), true);
+          _buffer.write('''
+      \$checkAllowedKeys(json, $listLiteral);''');
         }
+        _buffer.write('''
+      var val = ${data.content};''');
+
+        for (var field in data.fieldsToSet) {
+          _buffer.writeln();
+          var safeName = _safeNameAccess(accessibleFields[field]);
+          _buffer.write('''
+      \$checkedConvert(json, $safeName, (v) => ''');
+          _buffer.write('val.$field = ');
+          _buffer.write(_deserializeForField(accessibleFields[field],
+              checkedProperty: true));
+          _buffer.write(');');
+        }
+
+        _buffer.writeln('return val; }');
+
         var fieldKeyMap = new Map.fromEntries(fieldsSetByFactory
             .map((k) => new MapEntry(k, _nameAccess(accessibleFields[k])))
-            .where((me) => me.key != me.value));
+            .where((me) => me.value != me.key));
 
         String fieldKeyMapArg;
         if (fieldKeyMap.isEmpty) {
@@ -206,7 +204,9 @@ class _GeneratorHelper {
           fieldKeyMapArg = ', fieldKeyMap: $mapLiteral';
         }
 
-        _buffer.write('$fieldKeyMapArg)');
+        _buffer.write(fieldKeyMapArg);
+
+        _buffer.write(')');
       } else {
         var data = writeConstructorInvocation(
             _element,
@@ -220,14 +220,25 @@ class _GeneratorHelper {
 
         fieldsSetByFactory = data.usedCtorParamsAndFields;
 
-        _buffer.write(' ${data.content}');
+        if (!_annotation.allowUnrecognizedKeys) {
+          var listLiteral = jsonLiteralAsDart(
+              fieldsSetByFactory
+                  .map((k) => _nameAccess(accessibleFields[k]))
+                  .toList(),
+              true);
+          _buffer.write('''
+  \$checkAllowedKeys(json, $listLiteral);''');
+        }
+
+        _buffer.write('''
+  return ${data.content}''');
         for (var field in data.fieldsToSet) {
           _buffer.writeln();
-          _buffer.write('  ..$field = ');
+          _buffer.write('    ..$field = ');
           _buffer.write(deserializeFun(field));
         }
       }
-      _buffer.writeln(';');
+      _buffer.writeln(';\n}');
       _buffer.writeln();
 
       // If there are fields that are final – that are not set via the generated

--- a/json_serializable/lib/src/generator_helper.dart
+++ b/json_serializable/lib/src/generator_helper.dart
@@ -170,7 +170,7 @@ class _GeneratorHelper {
 
         fieldsSetByFactory = data.usedCtorParamsAndFields;
 
-        if (!_annotation.allowUnrecognizedKeys) {
+        if (_annotation.disallowUnregognizedKeys) {
           var listLiteral = jsonLiteralAsDart(
               accessibleFields.values.map(_nameAccess).toList(), true);
           _buffer.write('''
@@ -194,7 +194,7 @@ class _GeneratorHelper {
 
         var fieldKeyMap = new Map.fromEntries(fieldsSetByFactory
             .map((k) => new MapEntry(k, _nameAccess(accessibleFields[k])))
-            .where((me) => me.value != me.key));
+            .where((me) => me.key != me.value));
 
         String fieldKeyMapArg;
         if (fieldKeyMap.isEmpty) {
@@ -220,7 +220,7 @@ class _GeneratorHelper {
 
         fieldsSetByFactory = data.usedCtorParamsAndFields;
 
-        if (!_annotation.allowUnrecognizedKeys) {
+        if (_annotation.disallowUnregognizedKeys) {
           var listLiteral = jsonLiteralAsDart(
               fieldsSetByFactory
                   .map((k) => _nameAccess(accessibleFields[k]))

--- a/json_serializable/lib/src/utils.dart
+++ b/json_serializable/lib/src/utils.dart
@@ -14,6 +14,8 @@ import 'package:source_gen/source_gen.dart';
 
 JsonSerializable valueForAnnotation(ConstantReader annotation) =>
     new JsonSerializable(
+        allowUnrecognizedKeys:
+            annotation.read('allowUnrecognizedKeys').boolValue,
         createToJson: annotation.read('createToJson').boolValue,
         createFactory: annotation.read('createFactory').boolValue,
         nullable: annotation.read('nullable').boolValue,

--- a/json_serializable/lib/src/utils.dart
+++ b/json_serializable/lib/src/utils.dart
@@ -14,8 +14,8 @@ import 'package:source_gen/source_gen.dart';
 
 JsonSerializable valueForAnnotation(ConstantReader annotation) =>
     new JsonSerializable(
-        disallowUnregognizedKeys:
-            annotation.read('disallowUnregognizedKeys').boolValue,
+        disallowUnrecognizedKeys:
+            annotation.read('disallowUnrecognizedKeys').boolValue,
         createToJson: annotation.read('createToJson').boolValue,
         createFactory: annotation.read('createFactory').boolValue,
         nullable: annotation.read('nullable').boolValue,

--- a/json_serializable/lib/src/utils.dart
+++ b/json_serializable/lib/src/utils.dart
@@ -14,8 +14,8 @@ import 'package:source_gen/source_gen.dart';
 
 JsonSerializable valueForAnnotation(ConstantReader annotation) =>
     new JsonSerializable(
-        allowUnrecognizedKeys:
-            annotation.read('allowUnrecognizedKeys').boolValue,
+        disallowUnregognizedKeys:
+            annotation.read('disallowUnregognizedKeys').boolValue,
         createToJson: annotation.read('createToJson').boolValue,
         createFactory: annotation.read('createFactory').boolValue,
         nullable: annotation.read('nullable').boolValue,

--- a/json_serializable/pubspec.yaml
+++ b/json_serializable/pubspec.yaml
@@ -25,3 +25,7 @@ dev_dependencies:
   logging: ^0.11.3+1
   test: ^0.12.3
   yaml: ^2.1.13
+
+dependency_overrides:
+  json_annotation:
+    path: ../json_annotation

--- a/json_serializable/pubspec.yaml
+++ b/json_serializable/pubspec.yaml
@@ -1,5 +1,5 @@
 name: json_serializable
-version: 0.5.5-dev
+version: 0.5.6-dev
 author: Dart Team <misc@dartlang.org>
 description: Generates utilities to aid in serializing to/from JSON.
 homepage: https://github.com/dart-lang/json_serializable
@@ -12,7 +12,7 @@ dependencies:
 
   # Use a tight version constraint to ensure that a constraint on
   # `json_annotation`. Properly constrains all features it provides.
-  json_annotation: '>=0.2.6 <0.2.7'
+  json_annotation: '>=0.2.7 <0.2.8'
   meta: ^1.1.0
   path: ^1.3.2
   source_gen: '>=0.8.1 <0.9.0'

--- a/json_serializable/test/default_value/default_value.checked.g.dart
+++ b/json_serializable/test/default_value/default_value.checked.g.dart
@@ -10,49 +10,48 @@ part of 'default_value.checked.dart';
 // Generator: JsonSerializableGenerator
 // **************************************************************************
 
-DefaultValue _$DefaultValueFromJson(Map json) =>
-    $checkedNew('DefaultValue', json, () {
-      var val = new DefaultValue();
-
-      $checkedConvert(
-          json, 'fieldBool', (v) => val.fieldBool = v as bool ?? true);
-      $checkedConvert(json, 'fieldString',
-          (v) => val.fieldString = v as String ?? 'string');
-      $checkedConvert(json, 'fieldInt', (v) => val.fieldInt = v as int ?? 42);
-      $checkedConvert(json, 'fieldDouble',
-          (v) => val.fieldDouble = (v as num)?.toDouble() ?? 3.14);
-      $checkedConvert(
-          json, 'fieldListEmpty', (v) => val.fieldListEmpty = v as List ?? []);
-      $checkedConvert(
-          json, 'fieldMapEmpty', (v) => val.fieldMapEmpty = v as Map ?? {});
-      $checkedConvert(
-          json,
-          'fieldListSimple',
-          (v) => val.fieldListSimple =
-              (v as List)?.map((e) => e as int)?.toList() ?? [1, 2, 3]);
-      $checkedConvert(
-          json,
-          'fieldMapSimple',
-          (v) => val.fieldMapSimple =
-              (v as Map)?.map((k, e) => new MapEntry(k as String, e as int)) ??
-                  {'answer': 42});
-      $checkedConvert(
-          json,
-          'fieldMapListString',
-          (v) => val.fieldMapListString = (v as Map)?.map((k, e) =>
-                  new MapEntry(k as String,
-                      (e as List)?.map((e) => e as String)?.toList())) ??
-              {
-                'root': ['child']
-              });
-      $checkedConvert(
-          json,
-          'fieldEnum',
-          (v) => val.fieldEnum =
-              $enumDecodeNullable('Greek', Greek.values, v as String) ??
-                  Greek.beta);
-      return val;
-    });
+DefaultValue _$DefaultValueFromJson(Map json) {
+  return $checkedNew('DefaultValue', json, () {
+    var val = new DefaultValue();
+    $checkedConvert(
+        json, 'fieldBool', (v) => val.fieldBool = v as bool ?? true);
+    $checkedConvert(
+        json, 'fieldString', (v) => val.fieldString = v as String ?? 'string');
+    $checkedConvert(json, 'fieldInt', (v) => val.fieldInt = v as int ?? 42);
+    $checkedConvert(json, 'fieldDouble',
+        (v) => val.fieldDouble = (v as num)?.toDouble() ?? 3.14);
+    $checkedConvert(
+        json, 'fieldListEmpty', (v) => val.fieldListEmpty = v as List ?? []);
+    $checkedConvert(
+        json, 'fieldMapEmpty', (v) => val.fieldMapEmpty = v as Map ?? {});
+    $checkedConvert(
+        json,
+        'fieldListSimple',
+        (v) => val.fieldListSimple =
+            (v as List)?.map((e) => e as int)?.toList() ?? [1, 2, 3]);
+    $checkedConvert(
+        json,
+        'fieldMapSimple',
+        (v) => val.fieldMapSimple =
+            (v as Map)?.map((k, e) => new MapEntry(k as String, e as int)) ??
+                {'answer': 42});
+    $checkedConvert(
+        json,
+        'fieldMapListString',
+        (v) => val.fieldMapListString = (v as Map)?.map((k, e) => new MapEntry(
+                k as String, (e as List)?.map((e) => e as String)?.toList())) ??
+            {
+              'root': ['child']
+            });
+    $checkedConvert(
+        json,
+        'fieldEnum',
+        (v) => val.fieldEnum =
+            $enumDecodeNullable('Greek', Greek.values, v as String) ??
+                Greek.beta);
+    return val;
+  });
+}
 
 abstract class _$DefaultValueSerializerMixin {
   bool get fieldBool;

--- a/json_serializable/test/default_value/default_value.g.dart
+++ b/json_serializable/test/default_value/default_value.g.dart
@@ -10,30 +10,30 @@ part of 'default_value.dart';
 // Generator: JsonSerializableGenerator
 // **************************************************************************
 
-DefaultValue _$DefaultValueFromJson(Map<String, dynamic> json) =>
-    new DefaultValue()
-      ..fieldBool = json['fieldBool'] as bool ?? true
-      ..fieldString = json['fieldString'] as String ?? 'string'
-      ..fieldInt = json['fieldInt'] as int ?? 42
-      ..fieldDouble = (json['fieldDouble'] as num)?.toDouble() ?? 3.14
-      ..fieldListEmpty = json['fieldListEmpty'] as List ?? []
-      ..fieldMapEmpty = json['fieldMapEmpty'] as Map<String, dynamic> ?? {}
-      ..fieldListSimple =
-          (json['fieldListSimple'] as List)?.map((e) => e as int)?.toList() ??
-              [1, 2, 3]
-      ..fieldMapSimple = (json['fieldMapSimple'] as Map<String, dynamic>)
-              ?.map((k, e) => new MapEntry(k, e as int)) ??
-          {'answer': 42}
-      ..fieldMapListString =
-          (json['fieldMapListString'] as Map<String, dynamic>)?.map((k, e) =>
-                  new MapEntry(
-                      k, (e as List)?.map((e) => e as String)?.toList())) ??
-              {
-                'root': ['child']
-              }
-      ..fieldEnum = $enumDecodeNullable(
-              'Greek', Greek.values, json['fieldEnum'] as String) ??
-          Greek.beta;
+DefaultValue _$DefaultValueFromJson(Map<String, dynamic> json) {
+  return new DefaultValue()
+    ..fieldBool = json['fieldBool'] as bool ?? true
+    ..fieldString = json['fieldString'] as String ?? 'string'
+    ..fieldInt = json['fieldInt'] as int ?? 42
+    ..fieldDouble = (json['fieldDouble'] as num)?.toDouble() ?? 3.14
+    ..fieldListEmpty = json['fieldListEmpty'] as List ?? []
+    ..fieldMapEmpty = json['fieldMapEmpty'] as Map<String, dynamic> ?? {}
+    ..fieldListSimple =
+        (json['fieldListSimple'] as List)?.map((e) => e as int)?.toList() ??
+            [1, 2, 3]
+    ..fieldMapSimple = (json['fieldMapSimple'] as Map<String, dynamic>)
+            ?.map((k, e) => new MapEntry(k, e as int)) ??
+        {'answer': 42}
+    ..fieldMapListString = (json['fieldMapListString'] as Map<String, dynamic>)
+            ?.map((k, e) => new MapEntry(
+                k, (e as List)?.map((e) => e as String)?.toList())) ??
+        {
+          'root': ['child']
+        }
+    ..fieldEnum = $enumDecodeNullable(
+            'Greek', Greek.values, json['fieldEnum'] as String) ??
+        Greek.beta;
+}
 
 abstract class _$DefaultValueSerializerMixin {
   bool get fieldBool;

--- a/json_serializable/test/generic_files/generic_class.g.dart
+++ b/json_serializable/test/generic_files/generic_class.g.dart
@@ -11,23 +11,24 @@ part of 'generic_class.dart';
 // **************************************************************************
 
 GenericClass<T, S> _$GenericClassFromJson<T extends num, S>(
-        Map<String, dynamic> json) =>
-    new GenericClass<T, S>()
-      ..fieldObject = json['fieldObject'] == null
-          ? null
-          : _dataFromJson(json['fieldObject'] as Map<String, dynamic>)
-      ..fieldDynamic = json['fieldDynamic'] == null
-          ? null
-          : _dataFromJson(json['fieldDynamic'] as Map<String, dynamic>)
-      ..fieldInt = json['fieldInt'] == null
-          ? null
-          : _dataFromJson(json['fieldInt'] as Map<String, dynamic>)
-      ..fieldT = json['fieldT'] == null
-          ? null
-          : _dataFromJson(json['fieldT'] as Map<String, dynamic>)
-      ..fieldS = json['fieldS'] == null
-          ? null
-          : _dataFromJson(json['fieldS'] as Map<String, dynamic>);
+    Map<String, dynamic> json) {
+  return new GenericClass<T, S>()
+    ..fieldObject = json['fieldObject'] == null
+        ? null
+        : _dataFromJson(json['fieldObject'] as Map<String, dynamic>)
+    ..fieldDynamic = json['fieldDynamic'] == null
+        ? null
+        : _dataFromJson(json['fieldDynamic'] as Map<String, dynamic>)
+    ..fieldInt = json['fieldInt'] == null
+        ? null
+        : _dataFromJson(json['fieldInt'] as Map<String, dynamic>)
+    ..fieldT = json['fieldT'] == null
+        ? null
+        : _dataFromJson(json['fieldT'] as Map<String, dynamic>)
+    ..fieldS = json['fieldS'] == null
+        ? null
+        : _dataFromJson(json['fieldS'] as Map<String, dynamic>);
+}
 
 abstract class _$GenericClassSerializerMixin<T extends num, S> {
   Object get fieldObject;

--- a/json_serializable/test/generic_files/generic_class.wrapped.g.dart
+++ b/json_serializable/test/generic_files/generic_class.wrapped.g.dart
@@ -11,23 +11,24 @@ part of 'generic_class.wrapped.dart';
 // **************************************************************************
 
 GenericClass<T, S> _$GenericClassFromJson<T extends num, S>(
-        Map<String, dynamic> json) =>
-    new GenericClass<T, S>()
-      ..fieldObject = json['fieldObject'] == null
-          ? null
-          : _dataFromJson(json['fieldObject'] as Map<String, dynamic>)
-      ..fieldDynamic = json['fieldDynamic'] == null
-          ? null
-          : _dataFromJson(json['fieldDynamic'] as Map<String, dynamic>)
-      ..fieldInt = json['fieldInt'] == null
-          ? null
-          : _dataFromJson(json['fieldInt'] as Map<String, dynamic>)
-      ..fieldT = json['fieldT'] == null
-          ? null
-          : _dataFromJson(json['fieldT'] as Map<String, dynamic>)
-      ..fieldS = json['fieldS'] == null
-          ? null
-          : _dataFromJson(json['fieldS'] as Map<String, dynamic>);
+    Map<String, dynamic> json) {
+  return new GenericClass<T, S>()
+    ..fieldObject = json['fieldObject'] == null
+        ? null
+        : _dataFromJson(json['fieldObject'] as Map<String, dynamic>)
+    ..fieldDynamic = json['fieldDynamic'] == null
+        ? null
+        : _dataFromJson(json['fieldDynamic'] as Map<String, dynamic>)
+    ..fieldInt = json['fieldInt'] == null
+        ? null
+        : _dataFromJson(json['fieldInt'] as Map<String, dynamic>)
+    ..fieldT = json['fieldT'] == null
+        ? null
+        : _dataFromJson(json['fieldT'] as Map<String, dynamic>)
+    ..fieldS = json['fieldS'] == null
+        ? null
+        : _dataFromJson(json['fieldS'] as Map<String, dynamic>);
+}
 
 abstract class _$GenericClassSerializerMixin<T extends num, S> {
   Object get fieldObject;

--- a/json_serializable/test/json_serializable_test.dart
+++ b/json_serializable/test/json_serializable_test.dart
@@ -154,17 +154,18 @@ void _registerTests(JsonSerializableGenerator generator) {
     if (!generator.useWrappers) {
       test('class with no ctor params', () async {
         var output = await runForElementNamed('Person');
-        expect(output,
-            r'''Person _$PersonFromJson(Map<String, dynamic> json) => new Person()
-  ..firstName = json['firstName'] as String
-  ..lastName = json['lastName'] as String
-  ..height = json['h'] as int
-  ..dateOfBirth = json['dateOfBirth'] == null
-      ? null
-      : DateTime.parse(json['dateOfBirth'] as String)
-  ..dynamicType = json['dynamicType']
-  ..varType = json['varType']
-  ..listOfInts = (json['listOfInts'] as List)?.map((e) => e as int)?.toList();
+        expect(output, r'''Person _$PersonFromJson(Map<String, dynamic> json) {
+  return new Person()
+    ..firstName = json['firstName'] as String
+    ..lastName = json['lastName'] as String
+    ..height = json['h'] as int
+    ..dateOfBirth = json['dateOfBirth'] == null
+        ? null
+        : DateTime.parse(json['dateOfBirth'] as String)
+    ..dynamicType = json['dynamicType']
+    ..varType = json['varType']
+    ..listOfInts = (json['listOfInts'] as List)?.map((e) => e as int)?.toList();
+}
 
 abstract class _$PersonSerializerMixin {
   String get firstName;
@@ -189,14 +190,13 @@ abstract class _$PersonSerializerMixin {
 
       test('class with ctor params', () async {
         var output = await runForElementNamed('Order');
-        expect(output,
-            r'''Order _$OrderFromJson(Map<String, dynamic> json) => new Order(
-    json['height'] as int,
-    json['firstName'] as String,
-    json['lastName'] as String)
-  ..dateOfBirth = json['dateOfBirth'] == null
-      ? null
-      : DateTime.parse(json['dateOfBirth'] as String);
+        expect(output, r'''Order _$OrderFromJson(Map<String, dynamic> json) {
+  return new Order(json['height'] as int, json['firstName'] as String,
+      json['lastName'] as String)
+    ..dateOfBirth = json['dateOfBirth'] == null
+        ? null
+        : DateTime.parse(json['dateOfBirth'] as String);
+}
 
 abstract class _$OrderSerializerMixin {
   String get firstName;
@@ -402,17 +402,18 @@ abstract class _$OrderSerializerMixin {
         var output = await runForElementNamed('FromDynamicCollection');
         expect(output, r'''
 FromDynamicCollection _$FromDynamicCollectionFromJson(
-        Map<String, dynamic> json) =>
-    new FromDynamicCollection()
-      ..mapField = json['mapField'] == null
-          ? null
-          : _fromDynamicMap(json['mapField'] as Map)
-      ..listField = json['listField'] == null
-          ? null
-          : _fromDynamicList(json['listField'] as List)
-      ..iterableField = json['iterableField'] == null
-          ? null
-          : _fromDynamicIterable(json['iterableField'] as List);
+    Map<String, dynamic> json) {
+  return new FromDynamicCollection()
+    ..mapField = json['mapField'] == null
+        ? null
+        : _fromDynamicMap(json['mapField'] as Map)
+    ..listField = json['listField'] == null
+        ? null
+        : _fromDynamicList(json['listField'] as List)
+    ..iterableField = json['iterableField'] == null
+        ? null
+        : _fromDynamicIterable(json['iterableField'] as List);
+}
 ''');
       });
       test('OkayOneNormalOptionalPositional', () async {
@@ -446,18 +447,18 @@ FromDynamicCollection _$FromDynamicCollectionFromJson(
     var expected = generator.useWrappers
         ? r'''
 GenericClass<T, S> _$GenericClassFromJson<T extends num, S>(
-        Map<String, dynamic> json) =>
-    new GenericClass<T, S>()
-      ..fieldObject = json['fieldObject'] == null
-          ? null
-          : _dataFromJson(json['fieldObject'])
-      ..fieldDynamic = json['fieldDynamic'] == null
-          ? null
-          : _dataFromJson(json['fieldDynamic'])
-      ..fieldInt =
-          json['fieldInt'] == null ? null : _dataFromJson(json['fieldInt'])
-      ..fieldT = json['fieldT'] == null ? null : _dataFromJson(json['fieldT'])
-      ..fieldS = json['fieldS'] == null ? null : _dataFromJson(json['fieldS']);
+    Map<String, dynamic> json) {
+  return new GenericClass<T, S>()
+    ..fieldObject =
+        json['fieldObject'] == null ? null : _dataFromJson(json['fieldObject'])
+    ..fieldDynamic = json['fieldDynamic'] == null
+        ? null
+        : _dataFromJson(json['fieldDynamic'])
+    ..fieldInt =
+        json['fieldInt'] == null ? null : _dataFromJson(json['fieldInt'])
+    ..fieldT = json['fieldT'] == null ? null : _dataFromJson(json['fieldT'])
+    ..fieldS = json['fieldS'] == null ? null : _dataFromJson(json['fieldS']);
+}
 
 abstract class _$GenericClassSerializerMixin<T extends num, S> {
   Object get fieldObject;
@@ -498,18 +499,18 @@ class _$GenericClassJsonMapWrapper<T extends num, S> extends $JsonMapWrapper {
 '''
         : r'''
 GenericClass<T, S> _$GenericClassFromJson<T extends num, S>(
-        Map<String, dynamic> json) =>
-    new GenericClass<T, S>()
-      ..fieldObject = json['fieldObject'] == null
-          ? null
-          : _dataFromJson(json['fieldObject'])
-      ..fieldDynamic = json['fieldDynamic'] == null
-          ? null
-          : _dataFromJson(json['fieldDynamic'])
-      ..fieldInt =
-          json['fieldInt'] == null ? null : _dataFromJson(json['fieldInt'])
-      ..fieldT = json['fieldT'] == null ? null : _dataFromJson(json['fieldT'])
-      ..fieldS = json['fieldS'] == null ? null : _dataFromJson(json['fieldS']);
+    Map<String, dynamic> json) {
+  return new GenericClass<T, S>()
+    ..fieldObject =
+        json['fieldObject'] == null ? null : _dataFromJson(json['fieldObject'])
+    ..fieldDynamic = json['fieldDynamic'] == null
+        ? null
+        : _dataFromJson(json['fieldDynamic'])
+    ..fieldInt =
+        json['fieldInt'] == null ? null : _dataFromJson(json['fieldInt'])
+    ..fieldT = json['fieldT'] == null ? null : _dataFromJson(json['fieldT'])
+    ..fieldS = json['fieldS'] == null ? null : _dataFromJson(json['fieldS']);
+}
 
 abstract class _$GenericClassSerializerMixin<T extends num, S> {
   Object get fieldObject;
@@ -535,10 +536,12 @@ abstract class _$GenericClassSerializerMixin<T extends num, S> {
 
     var expected = generator.useWrappers
         ? r'''
-SubType _$SubTypeFromJson(Map<String, dynamic> json) => new SubType(
-    json['subTypeViaCtor'] as int, json['super-type-via-ctor'] as int)
-  ..superTypeReadWrite = json['superTypeReadWrite'] as int
-  ..subTypeReadWrite = json['subTypeReadWrite'] as int;
+SubType _$SubTypeFromJson(Map<String, dynamic> json) {
+  return new SubType(
+      json['subTypeViaCtor'] as int, json['super-type-via-ctor'] as int)
+    ..superTypeReadWrite = json['superTypeReadWrite'] as int
+    ..subTypeReadWrite = json['subTypeReadWrite'] as int;
+}
 
 abstract class _$SubTypeSerializerMixin {
   int get superTypeViaCtor;
@@ -581,10 +584,12 @@ class _$SubTypeJsonMapWrapper extends $JsonMapWrapper {
 }
 '''
         : r'''
-SubType _$SubTypeFromJson(Map<String, dynamic> json) => new SubType(
-    json['subTypeViaCtor'] as int, json['super-type-via-ctor'] as int)
-  ..superTypeReadWrite = json['superTypeReadWrite'] as int
-  ..subTypeReadWrite = json['subTypeReadWrite'] as int;
+SubType _$SubTypeFromJson(Map<String, dynamic> json) {
+  return new SubType(
+      json['subTypeViaCtor'] as int, json['super-type-via-ctor'] as int)
+    ..superTypeReadWrite = json['superTypeReadWrite'] as int
+    ..subTypeReadWrite = json['subTypeReadWrite'] as int;
+}
 
 abstract class _$SubTypeSerializerMixin {
   int get superTypeViaCtor;

--- a/json_serializable/test/kitchen_sink/kitchen_sink.dart
+++ b/json_serializable/test/kitchen_sink/kitchen_sink.dart
@@ -7,12 +7,14 @@ import 'package:json_annotation/json_annotation.dart';
 
 import 'kitchen_sink_interface.dart' as k;
 import 'simple_object.dart';
+import 'strict_keys_object.dart';
 
 part 'kitchen_sink.g.dart';
 
 List<T> _defaultList<T>() => null;
 Map _defaultMap() => null;
 SimpleObject _defaultSimpleObject() => null;
+StrictKeysObject _defaultStrictKeysObject() => null;
 
 k.KitchenSink testFactory(
         {int ctorValidatedNo42,
@@ -108,6 +110,8 @@ class KitchenSink extends Object
   String string;
 
   SimpleObject simpleObject = _defaultSimpleObject();
+
+  StrictKeysObject strictKeysObject = _defaultStrictKeysObject();
 
   int _validatedPropertyNo42;
   int get validatedPropertyNo42 => _validatedPropertyNo42;

--- a/json_serializable/test/kitchen_sink/kitchen_sink.g.dart
+++ b/json_serializable/test/kitchen_sink/kitchen_sink.g.dart
@@ -10,40 +10,44 @@ part of 'kitchen_sink.dart';
 // Generator: JsonSerializableGenerator
 // **************************************************************************
 
-KitchenSink _$KitchenSinkFromJson(Map json) => new KitchenSink(
-    ctorValidatedNo42: json['no-42'] as int,
-    iterable: json['iterable'] as List,
-    dynamicIterable: json['dynamicIterable'] as List,
-    objectIterable: json['objectIterable'] as List,
-    intIterable: (json['intIterable'] as List)?.map((e) => e as int),
-    dateTimeIterable: (json['datetime-iterable'] as List)
-        ?.map((e) => e == null ? null : DateTime.parse(e as String)))
-  ..dateTime = json['dateTime'] == null
-      ? null
-      : DateTime.parse(json['dateTime'] as String)
-  ..list = json['list'] as List
-  ..dynamicList = json['dynamicList'] as List
-  ..objectList = json['objectList'] as List
-  ..intList = (json['intList'] as List)?.map((e) => e as int)?.toList()
-  ..dateTimeList = (json['dateTimeList'] as List)
-      ?.map((e) => e == null ? null : DateTime.parse(e as String))
-      ?.toList()
-  ..map = json['map'] as Map
-  ..stringStringMap = (json['stringStringMap'] as Map)
-      ?.map((k, e) => new MapEntry(k as String, e as String))
-  ..dynamicIntMap =
-      (json['dynamicIntMap'] as Map)?.map((k, e) => new MapEntry(k, e as int))
-  ..objectDateTimeMap = (json['objectDateTimeMap'] as Map)?.map(
-      (k, e) => new MapEntry(k, e == null ? null : DateTime.parse(e as String)))
-  ..crazyComplex = (json['crazyComplex'] as List)
-      ?.map((e) => (e as Map)?.map((k, e) => new MapEntry(
-          k as String, (e as Map)?.map((k, e) => new MapEntry(k as String, (e as List)?.map((e) => (e as List)?.map((e) => e == null ? null : DateTime.parse(e as String))?.toList())?.toList())))))
-      ?.toList()
-  ..val = (json['val'] as Map)?.map((k, e) => new MapEntry(k as String, e as bool))
-  ..writeNotNull = json['writeNotNull'] as bool
-  ..string = json[r'$string'] as String
-  ..simpleObject = json['simpleObject'] == null ? null : new SimpleObject.fromJson(json['simpleObject'] as Map)
-  ..validatedPropertyNo42 = json['validatedPropertyNo42'] as int;
+KitchenSink _$KitchenSinkFromJson(Map json) {
+  return new KitchenSink(
+      ctorValidatedNo42: json['no-42'] as int,
+      iterable: json['iterable'] as List,
+      dynamicIterable: json['dynamicIterable'] as List,
+      objectIterable: json['objectIterable'] as List,
+      intIterable: (json['intIterable'] as List)?.map((e) => e as int),
+      dateTimeIterable: (json['datetime-iterable'] as List)
+          ?.map((e) => e == null ? null : DateTime.parse(e as String)))
+    ..dateTime = json['dateTime'] == null
+        ? null
+        : DateTime.parse(json['dateTime'] as String)
+    ..list = json['list'] as List
+    ..dynamicList = json['dynamicList'] as List
+    ..objectList = json['objectList'] as List
+    ..intList = (json['intList'] as List)?.map((e) => e as int)?.toList()
+    ..dateTimeList = (json['dateTimeList'] as List)
+        ?.map((e) => e == null ? null : DateTime.parse(e as String))
+        ?.toList()
+    ..map = json['map'] as Map
+    ..stringStringMap = (json['stringStringMap'] as Map)
+        ?.map((k, e) => new MapEntry(k as String, e as String))
+    ..dynamicIntMap =
+        (json['dynamicIntMap'] as Map)?.map((k, e) => new MapEntry(k, e as int))
+    ..objectDateTimeMap = (json['objectDateTimeMap'] as Map)?.map((k, e) =>
+        new MapEntry(k, e == null ? null : DateTime.parse(e as String)))
+    ..crazyComplex = (json['crazyComplex'] as List)
+        ?.map((e) => (e as Map)?.map((k, e) => new MapEntry(
+            k as String,
+            (e as Map)?.map((k, e) =>
+                new MapEntry(k as String, (e as List)?.map((e) => (e as List)?.map((e) => e == null ? null : DateTime.parse(e as String))?.toList())?.toList())))))
+        ?.toList()
+    ..val = (json['val'] as Map)?.map((k, e) => new MapEntry(k as String, e as bool))
+    ..writeNotNull = json['writeNotNull'] as bool
+    ..string = json[r'$string'] as String
+    ..simpleObject = json['simpleObject'] == null ? null : new SimpleObject.fromJson(json['simpleObject'] as Map)
+    ..validatedPropertyNo42 = json['validatedPropertyNo42'] as int;
+}
 
 abstract class _$KitchenSinkSerializerMixin {
   int get ctorValidatedNo42;

--- a/json_serializable/test/kitchen_sink/kitchen_sink.g.dart
+++ b/json_serializable/test/kitchen_sink/kitchen_sink.g.dart
@@ -46,6 +46,7 @@ KitchenSink _$KitchenSinkFromJson(Map json) {
     ..writeNotNull = json['writeNotNull'] as bool
     ..string = json[r'$string'] as String
     ..simpleObject = json['simpleObject'] == null ? null : new SimpleObject.fromJson(json['simpleObject'] as Map)
+    ..strictKeysObject = json['strictKeysObject'] == null ? null : new StrictKeysObject.fromJson(json['strictKeysObject'] as Map)
     ..validatedPropertyNo42 = json['validatedPropertyNo42'] as int;
 }
 
@@ -71,6 +72,7 @@ abstract class _$KitchenSinkSerializerMixin {
   bool get writeNotNull;
   String get string;
   SimpleObject get simpleObject;
+  StrictKeysObject get strictKeysObject;
   int get validatedPropertyNo42;
   Map<String, dynamic> toJson() {
     var val = <String, dynamic>{
@@ -117,6 +119,7 @@ abstract class _$KitchenSinkSerializerMixin {
     val['writeNotNull'] = this.writeNotNull;
     val[r'$string'] = string;
     val['simpleObject'] = simpleObject;
+    val['strictKeysObject'] = strictKeysObject;
     val['validatedPropertyNo42'] = validatedPropertyNo42;
     return val;
   }

--- a/json_serializable/test/kitchen_sink/kitchen_sink.non_nullable.checked.dart
+++ b/json_serializable/test/kitchen_sink/kitchen_sink.non_nullable.checked.dart
@@ -19,12 +19,14 @@ import 'package:json_annotation/json_annotation.dart';
 
 import 'kitchen_sink_interface.dart' as k;
 import 'simple_object.dart';
+import 'strict_keys_object.dart';
 
 part 'kitchen_sink.non_nullable.checked.g.dart';
 
 List<T> _defaultList<T>() => <T>[];
 Map<String, T> _defaultMap<T>() => <String, T>{};
 SimpleObject _defaultSimpleObject() => new SimpleObject(42);
+StrictKeysObject _defaultStrictKeysObject() => new StrictKeysObject(10, 'cool');
 
 k.KitchenSink testFactory(
         {int ctorValidatedNo42,
@@ -120,6 +122,8 @@ class KitchenSink extends Object
   String string;
 
   SimpleObject simpleObject = _defaultSimpleObject();
+
+  StrictKeysObject strictKeysObject = _defaultStrictKeysObject();
 
   int _validatedPropertyNo42;
   int get validatedPropertyNo42 => _validatedPropertyNo42;

--- a/json_serializable/test/kitchen_sink/kitchen_sink.non_nullable.checked.g.dart
+++ b/json_serializable/test/kitchen_sink/kitchen_sink.non_nullable.checked.g.dart
@@ -10,71 +10,70 @@ part of 'kitchen_sink.non_nullable.checked.dart';
 // Generator: JsonSerializableGenerator
 // **************************************************************************
 
-KitchenSink _$KitchenSinkFromJson(Map json) =>
-    $checkedNew('KitchenSink', json, () {
-      var val = new KitchenSink(
-          ctorValidatedNo42: $checkedConvert(json, 'no-42', (v) => v as int),
-          iterable: $checkedConvert(json, 'iterable', (v) => v as List),
-          dynamicIterable:
-              $checkedConvert(json, 'dynamicIterable', (v) => v as List),
-          objectIterable:
-              $checkedConvert(json, 'objectIterable', (v) => v as List),
-          intIterable: $checkedConvert(
-              json, 'intIterable', (v) => (v as List).map((e) => e as int)),
-          dateTimeIterable: $checkedConvert(json, 'datetime-iterable',
-              (v) => (v as List).map((e) => DateTime.parse(e as String))));
-
-      $checkedConvert(
-          json, 'dateTime', (v) => val.dateTime = DateTime.parse(v as String));
-      $checkedConvert(json, 'list', (v) => val.list = v as List);
-      $checkedConvert(json, 'dynamicList', (v) => val.dynamicList = v as List);
-      $checkedConvert(json, 'objectList', (v) => val.objectList = v as List);
-      $checkedConvert(json, 'intList',
-          (v) => val.intList = (v as List).map((e) => e as int).toList());
-      $checkedConvert(
-          json,
-          'dateTimeList',
-          (v) => val.dateTimeList =
-              (v as List).map((e) => DateTime.parse(e as String)).toList());
-      $checkedConvert(json, 'map', (v) => val.map = v as Map);
-      $checkedConvert(json, 'stringStringMap',
-          (v) => val.stringStringMap = new Map<String, String>.from(v as Map));
-      $checkedConvert(json, 'dynamicIntMap',
-          (v) => val.dynamicIntMap = new Map<String, int>.from(v as Map));
-      $checkedConvert(
-          json,
-          'objectDateTimeMap',
-          (v) => val.objectDateTimeMap = (v as Map)
-              .map((k, e) => new MapEntry(k, DateTime.parse(e as String))));
-      $checkedConvert(
-          json,
-          'crazyComplex',
-          (v) => val.crazyComplex = (v as List)
-              .map((e) => (e as Map).map((k, e) => new MapEntry(
-                  k as String,
-                  (e as Map).map((k, e) => new MapEntry(
-                      k as String,
-                      (e as List)
-                          .map((e) => (e as List)
-                              .map((e) => DateTime.parse(e as String))
-                              .toList())
-                          .toList())))))
-              .toList());
-      $checkedConvert(
-          json, 'val', (v) => val.val = new Map<String, bool>.from(v as Map));
-      $checkedConvert(
-          json, 'writeNotNull', (v) => val.writeNotNull = v as bool);
-      $checkedConvert(json, r'$string', (v) => val.string = v as String);
-      $checkedConvert(json, 'simpleObject',
-          (v) => val.simpleObject = new SimpleObject.fromJson(v as Map));
-      $checkedConvert(json, 'validatedPropertyNo42',
-          (v) => val.validatedPropertyNo42 = v as int);
-      return val;
-    }, fieldKeyMap: const {
-      'ctorValidatedNo42': 'no-42',
-      'dateTimeIterable': 'datetime-iterable',
-      'string': r'$string'
-    });
+KitchenSink _$KitchenSinkFromJson(Map json) {
+  return $checkedNew('KitchenSink', json, () {
+    var val = new KitchenSink(
+        ctorValidatedNo42: $checkedConvert(json, 'no-42', (v) => v as int),
+        iterable: $checkedConvert(json, 'iterable', (v) => v as List),
+        dynamicIterable:
+            $checkedConvert(json, 'dynamicIterable', (v) => v as List),
+        objectIterable:
+            $checkedConvert(json, 'objectIterable', (v) => v as List),
+        intIterable: $checkedConvert(
+            json, 'intIterable', (v) => (v as List).map((e) => e as int)),
+        dateTimeIterable: $checkedConvert(json, 'datetime-iterable',
+            (v) => (v as List).map((e) => DateTime.parse(e as String))));
+    $checkedConvert(
+        json, 'dateTime', (v) => val.dateTime = DateTime.parse(v as String));
+    $checkedConvert(json, 'list', (v) => val.list = v as List);
+    $checkedConvert(json, 'dynamicList', (v) => val.dynamicList = v as List);
+    $checkedConvert(json, 'objectList', (v) => val.objectList = v as List);
+    $checkedConvert(json, 'intList',
+        (v) => val.intList = (v as List).map((e) => e as int).toList());
+    $checkedConvert(
+        json,
+        'dateTimeList',
+        (v) => val.dateTimeList =
+            (v as List).map((e) => DateTime.parse(e as String)).toList());
+    $checkedConvert(json, 'map', (v) => val.map = v as Map);
+    $checkedConvert(json, 'stringStringMap',
+        (v) => val.stringStringMap = new Map<String, String>.from(v as Map));
+    $checkedConvert(json, 'dynamicIntMap',
+        (v) => val.dynamicIntMap = new Map<String, int>.from(v as Map));
+    $checkedConvert(
+        json,
+        'objectDateTimeMap',
+        (v) => val.objectDateTimeMap = (v as Map)
+            .map((k, e) => new MapEntry(k, DateTime.parse(e as String))));
+    $checkedConvert(
+        json,
+        'crazyComplex',
+        (v) => val.crazyComplex = (v as List)
+            .map((e) => (e as Map).map((k, e) => new MapEntry(
+                k as String,
+                (e as Map).map((k, e) => new MapEntry(
+                    k as String,
+                    (e as List)
+                        .map((e) => (e as List)
+                            .map((e) => DateTime.parse(e as String))
+                            .toList())
+                        .toList())))))
+            .toList());
+    $checkedConvert(
+        json, 'val', (v) => val.val = new Map<String, bool>.from(v as Map));
+    $checkedConvert(json, 'writeNotNull', (v) => val.writeNotNull = v as bool);
+    $checkedConvert(json, r'$string', (v) => val.string = v as String);
+    $checkedConvert(json, 'simpleObject',
+        (v) => val.simpleObject = new SimpleObject.fromJson(v as Map));
+    $checkedConvert(json, 'validatedPropertyNo42',
+        (v) => val.validatedPropertyNo42 = v as int);
+    return val;
+  }, fieldKeyMap: const {
+    'ctorValidatedNo42': 'no-42',
+    'dateTimeIterable': 'datetime-iterable',
+    'string': r'$string'
+  });
+}
 
 abstract class _$KitchenSinkSerializerMixin {
   int get ctorValidatedNo42;

--- a/json_serializable/test/kitchen_sink/kitchen_sink.non_nullable.checked.g.dart
+++ b/json_serializable/test/kitchen_sink/kitchen_sink.non_nullable.checked.g.dart
@@ -65,6 +65,8 @@ KitchenSink _$KitchenSinkFromJson(Map json) {
     $checkedConvert(json, r'$string', (v) => val.string = v as String);
     $checkedConvert(json, 'simpleObject',
         (v) => val.simpleObject = new SimpleObject.fromJson(v as Map));
+    $checkedConvert(json, 'strictKeysObject',
+        (v) => val.strictKeysObject = new StrictKeysObject.fromJson(v as Map));
     $checkedConvert(json, 'validatedPropertyNo42',
         (v) => val.validatedPropertyNo42 = v as int);
     return val;
@@ -97,6 +99,7 @@ abstract class _$KitchenSinkSerializerMixin {
   bool get writeNotNull;
   String get string;
   SimpleObject get simpleObject;
+  StrictKeysObject get strictKeysObject;
   int get validatedPropertyNo42;
   Map<String, dynamic> toJson() => <String, dynamic>{
         'no-42': ctorValidatedNo42,
@@ -130,6 +133,7 @@ abstract class _$KitchenSinkSerializerMixin {
         'writeNotNull': writeNotNull,
         r'$string': string,
         'simpleObject': simpleObject,
+        'strictKeysObject': strictKeysObject,
         'validatedPropertyNo42': validatedPropertyNo42
       };
 }

--- a/json_serializable/test/kitchen_sink/kitchen_sink.non_nullable.dart
+++ b/json_serializable/test/kitchen_sink/kitchen_sink.non_nullable.dart
@@ -13,12 +13,14 @@ import 'package:json_annotation/json_annotation.dart';
 
 import 'kitchen_sink_interface.dart' as k;
 import 'simple_object.dart';
+import 'strict_keys_object.dart';
 
 part 'kitchen_sink.non_nullable.g.dart';
 
 List<T> _defaultList<T>() => <T>[];
 Map<String, T> _defaultMap<T>() => <String, T>{};
 SimpleObject _defaultSimpleObject() => new SimpleObject(42);
+StrictKeysObject _defaultStrictKeysObject() => new StrictKeysObject(10, 'cool');
 
 k.KitchenSink testFactory(
         {int ctorValidatedNo42,
@@ -114,6 +116,8 @@ class KitchenSink extends Object
   String string;
 
   SimpleObject simpleObject = _defaultSimpleObject();
+
+  StrictKeysObject strictKeysObject = _defaultStrictKeysObject();
 
   int _validatedPropertyNo42;
   int get validatedPropertyNo42 => _validatedPropertyNo42;

--- a/json_serializable/test/kitchen_sink/kitchen_sink.non_nullable.g.dart
+++ b/json_serializable/test/kitchen_sink/kitchen_sink.non_nullable.g.dart
@@ -47,6 +47,7 @@ KitchenSink _$KitchenSinkFromJson(Map json) {
     ..writeNotNull = json['writeNotNull'] as bool
     ..string = json[r'$string'] as String
     ..simpleObject = new SimpleObject.fromJson(json['simpleObject'] as Map)
+    ..strictKeysObject = new StrictKeysObject.fromJson(json['strictKeysObject'] as Map)
     ..validatedPropertyNo42 = json['validatedPropertyNo42'] as int;
 }
 
@@ -72,6 +73,7 @@ abstract class _$KitchenSinkSerializerMixin {
   bool get writeNotNull;
   String get string;
   SimpleObject get simpleObject;
+  StrictKeysObject get strictKeysObject;
   int get validatedPropertyNo42;
   Map<String, dynamic> toJson() => <String, dynamic>{
         'no-42': ctorValidatedNo42,
@@ -105,6 +107,7 @@ abstract class _$KitchenSinkSerializerMixin {
         'writeNotNull': writeNotNull,
         r'$string': string,
         'simpleObject': simpleObject,
+        'strictKeysObject': strictKeysObject,
         'validatedPropertyNo42': validatedPropertyNo42
       };
 }

--- a/json_serializable/test/kitchen_sink/kitchen_sink.non_nullable.g.dart
+++ b/json_serializable/test/kitchen_sink/kitchen_sink.non_nullable.g.dart
@@ -10,39 +10,45 @@ part of 'kitchen_sink.non_nullable.dart';
 // Generator: JsonSerializableGenerator
 // **************************************************************************
 
-KitchenSink _$KitchenSinkFromJson(Map json) => new KitchenSink(
-    ctorValidatedNo42: json['no-42'] as int,
-    iterable: json['iterable'] as List,
-    dynamicIterable: json['dynamicIterable'] as List,
-    objectIterable: json['objectIterable'] as List,
-    intIterable: (json['intIterable'] as List).map((e) => e as int),
-    dateTimeIterable: (json['datetime-iterable'] as List)
-        .map((e) => DateTime.parse(e as String)))
-  ..dateTime = DateTime.parse(json['dateTime'] as String)
-  ..list = json['list'] as List
-  ..dynamicList = json['dynamicList'] as List
-  ..objectList = json['objectList'] as List
-  ..intList = (json['intList'] as List).map((e) => e as int).toList()
-  ..dateTimeList = (json['dateTimeList'] as List)
-      .map((e) => DateTime.parse(e as String))
-      .toList()
-  ..map = json['map'] as Map
-  ..stringStringMap =
-      new Map<String, String>.from(json['stringStringMap'] as Map)
-  ..dynamicIntMap = new Map<String, int>.from(json['dynamicIntMap'] as Map)
-  ..objectDateTimeMap = (json['objectDateTimeMap'] as Map)
-      .map((k, e) => new MapEntry(k, DateTime.parse(e as String)))
-  ..crazyComplex = (json['crazyComplex'] as List)
-      .map((e) => (e as Map).map((k, e) => new MapEntry(
-          k as String,
-          (e as Map).map(
-              (k, e) => new MapEntry(k as String, (e as List).map((e) => (e as List).map((e) => DateTime.parse(e as String)).toList()).toList())))))
-      .toList()
-  ..val = new Map<String, bool>.from(json['val'] as Map)
-  ..writeNotNull = json['writeNotNull'] as bool
-  ..string = json[r'$string'] as String
-  ..simpleObject = new SimpleObject.fromJson(json['simpleObject'] as Map)
-  ..validatedPropertyNo42 = json['validatedPropertyNo42'] as int;
+KitchenSink _$KitchenSinkFromJson(Map json) {
+  return new KitchenSink(
+      ctorValidatedNo42: json['no-42'] as int,
+      iterable: json['iterable'] as List,
+      dynamicIterable: json['dynamicIterable'] as List,
+      objectIterable: json['objectIterable'] as List,
+      intIterable: (json['intIterable'] as List).map((e) => e as int),
+      dateTimeIterable: (json['datetime-iterable'] as List)
+          .map((e) => DateTime.parse(e as String)))
+    ..dateTime = DateTime.parse(json['dateTime'] as String)
+    ..list = json['list'] as List
+    ..dynamicList = json['dynamicList'] as List
+    ..objectList = json['objectList'] as List
+    ..intList = (json['intList'] as List).map((e) => e as int).toList()
+    ..dateTimeList = (json['dateTimeList'] as List)
+        .map((e) => DateTime.parse(e as String))
+        .toList()
+    ..map = json['map'] as Map
+    ..stringStringMap =
+        new Map<String, String>.from(json['stringStringMap'] as Map)
+    ..dynamicIntMap = new Map<String, int>.from(json['dynamicIntMap'] as Map)
+    ..objectDateTimeMap = (json['objectDateTimeMap'] as Map)
+        .map((k, e) => new MapEntry(k, DateTime.parse(e as String)))
+    ..crazyComplex = (json['crazyComplex'] as List)
+        .map((e) => (e as Map).map((k, e) => new MapEntry(
+            k as String,
+            (e as Map).map((k, e) => new MapEntry(
+                k as String,
+                (e as List)
+                    .map(
+                        (e) => (e as List).map((e) => DateTime.parse(e as String)).toList())
+                    .toList())))))
+        .toList()
+    ..val = new Map<String, bool>.from(json['val'] as Map)
+    ..writeNotNull = json['writeNotNull'] as bool
+    ..string = json[r'$string'] as String
+    ..simpleObject = new SimpleObject.fromJson(json['simpleObject'] as Map)
+    ..validatedPropertyNo42 = json['validatedPropertyNo42'] as int;
+}
 
 abstract class _$KitchenSinkSerializerMixin {
   int get ctorValidatedNo42;

--- a/json_serializable/test/kitchen_sink/kitchen_sink.non_nullable.wrapped.dart
+++ b/json_serializable/test/kitchen_sink/kitchen_sink.non_nullable.wrapped.dart
@@ -19,12 +19,14 @@ import 'package:json_annotation/json_annotation.dart';
 
 import 'kitchen_sink_interface.dart' as k;
 import 'simple_object.dart';
+import 'strict_keys_object.dart';
 
 part 'kitchen_sink.non_nullable.wrapped.g.dart';
 
 List<T> _defaultList<T>() => <T>[];
 Map<String, T> _defaultMap<T>() => <String, T>{};
 SimpleObject _defaultSimpleObject() => new SimpleObject(42);
+StrictKeysObject _defaultStrictKeysObject() => new StrictKeysObject(10, 'cool');
 
 k.KitchenSink testFactory(
         {int ctorValidatedNo42,
@@ -120,6 +122,8 @@ class KitchenSink extends Object
   String string;
 
   SimpleObject simpleObject = _defaultSimpleObject();
+
+  StrictKeysObject strictKeysObject = _defaultStrictKeysObject();
 
   int _validatedPropertyNo42;
   int get validatedPropertyNo42 => _validatedPropertyNo42;

--- a/json_serializable/test/kitchen_sink/kitchen_sink.non_nullable.wrapped.g.dart
+++ b/json_serializable/test/kitchen_sink/kitchen_sink.non_nullable.wrapped.g.dart
@@ -47,6 +47,7 @@ KitchenSink _$KitchenSinkFromJson(Map json) {
     ..writeNotNull = json['writeNotNull'] as bool
     ..string = json[r'$string'] as String
     ..simpleObject = new SimpleObject.fromJson(json['simpleObject'] as Map)
+    ..strictKeysObject = new StrictKeysObject.fromJson(json['strictKeysObject'] as Map)
     ..validatedPropertyNo42 = json['validatedPropertyNo42'] as int;
 }
 
@@ -72,6 +73,7 @@ abstract class _$KitchenSinkSerializerMixin {
   bool get writeNotNull;
   String get string;
   SimpleObject get simpleObject;
+  StrictKeysObject get strictKeysObject;
   int get validatedPropertyNo42;
   Map<String, dynamic> toJson() => new _$KitchenSinkJsonMapWrapper(this);
 }
@@ -103,6 +105,7 @@ class _$KitchenSinkJsonMapWrapper extends $JsonMapWrapper {
         'writeNotNull',
         r'$string',
         'simpleObject',
+        'strictKeysObject',
         'validatedPropertyNo42'
       ];
 
@@ -163,6 +166,8 @@ class _$KitchenSinkJsonMapWrapper extends $JsonMapWrapper {
           return _v.string;
         case 'simpleObject':
           return _v.simpleObject;
+        case 'strictKeysObject':
+          return _v.strictKeysObject;
         case 'validatedPropertyNo42':
           return _v.validatedPropertyNo42;
       }

--- a/json_serializable/test/kitchen_sink/kitchen_sink.non_nullable.wrapped.g.dart
+++ b/json_serializable/test/kitchen_sink/kitchen_sink.non_nullable.wrapped.g.dart
@@ -10,39 +10,45 @@ part of 'kitchen_sink.non_nullable.wrapped.dart';
 // Generator: JsonSerializableGenerator
 // **************************************************************************
 
-KitchenSink _$KitchenSinkFromJson(Map json) => new KitchenSink(
-    ctorValidatedNo42: json['no-42'] as int,
-    iterable: json['iterable'] as List,
-    dynamicIterable: json['dynamicIterable'] as List,
-    objectIterable: json['objectIterable'] as List,
-    intIterable: (json['intIterable'] as List).map((e) => e as int),
-    dateTimeIterable: (json['datetime-iterable'] as List)
-        .map((e) => DateTime.parse(e as String)))
-  ..dateTime = DateTime.parse(json['dateTime'] as String)
-  ..list = json['list'] as List
-  ..dynamicList = json['dynamicList'] as List
-  ..objectList = json['objectList'] as List
-  ..intList = (json['intList'] as List).map((e) => e as int).toList()
-  ..dateTimeList = (json['dateTimeList'] as List)
-      .map((e) => DateTime.parse(e as String))
-      .toList()
-  ..map = json['map'] as Map
-  ..stringStringMap =
-      new Map<String, String>.from(json['stringStringMap'] as Map)
-  ..dynamicIntMap = new Map<String, int>.from(json['dynamicIntMap'] as Map)
-  ..objectDateTimeMap = (json['objectDateTimeMap'] as Map)
-      .map((k, e) => new MapEntry(k, DateTime.parse(e as String)))
-  ..crazyComplex = (json['crazyComplex'] as List)
-      .map((e) => (e as Map).map((k, e) => new MapEntry(
-          k as String,
-          (e as Map).map(
-              (k, e) => new MapEntry(k as String, (e as List).map((e) => (e as List).map((e) => DateTime.parse(e as String)).toList()).toList())))))
-      .toList()
-  ..val = new Map<String, bool>.from(json['val'] as Map)
-  ..writeNotNull = json['writeNotNull'] as bool
-  ..string = json[r'$string'] as String
-  ..simpleObject = new SimpleObject.fromJson(json['simpleObject'] as Map)
-  ..validatedPropertyNo42 = json['validatedPropertyNo42'] as int;
+KitchenSink _$KitchenSinkFromJson(Map json) {
+  return new KitchenSink(
+      ctorValidatedNo42: json['no-42'] as int,
+      iterable: json['iterable'] as List,
+      dynamicIterable: json['dynamicIterable'] as List,
+      objectIterable: json['objectIterable'] as List,
+      intIterable: (json['intIterable'] as List).map((e) => e as int),
+      dateTimeIterable: (json['datetime-iterable'] as List)
+          .map((e) => DateTime.parse(e as String)))
+    ..dateTime = DateTime.parse(json['dateTime'] as String)
+    ..list = json['list'] as List
+    ..dynamicList = json['dynamicList'] as List
+    ..objectList = json['objectList'] as List
+    ..intList = (json['intList'] as List).map((e) => e as int).toList()
+    ..dateTimeList = (json['dateTimeList'] as List)
+        .map((e) => DateTime.parse(e as String))
+        .toList()
+    ..map = json['map'] as Map
+    ..stringStringMap =
+        new Map<String, String>.from(json['stringStringMap'] as Map)
+    ..dynamicIntMap = new Map<String, int>.from(json['dynamicIntMap'] as Map)
+    ..objectDateTimeMap = (json['objectDateTimeMap'] as Map)
+        .map((k, e) => new MapEntry(k, DateTime.parse(e as String)))
+    ..crazyComplex = (json['crazyComplex'] as List)
+        .map((e) => (e as Map).map((k, e) => new MapEntry(
+            k as String,
+            (e as Map).map((k, e) => new MapEntry(
+                k as String,
+                (e as List)
+                    .map(
+                        (e) => (e as List).map((e) => DateTime.parse(e as String)).toList())
+                    .toList())))))
+        .toList()
+    ..val = new Map<String, bool>.from(json['val'] as Map)
+    ..writeNotNull = json['writeNotNull'] as bool
+    ..string = json[r'$string'] as String
+    ..simpleObject = new SimpleObject.fromJson(json['simpleObject'] as Map)
+    ..validatedPropertyNo42 = json['validatedPropertyNo42'] as int;
+}
 
 abstract class _$KitchenSinkSerializerMixin {
   int get ctorValidatedNo42;

--- a/json_serializable/test/kitchen_sink/kitchen_sink.wrapped.dart
+++ b/json_serializable/test/kitchen_sink/kitchen_sink.wrapped.dart
@@ -13,12 +13,14 @@ import 'package:json_annotation/json_annotation.dart';
 
 import 'kitchen_sink_interface.dart' as k;
 import 'simple_object.dart';
+import 'strict_keys_object.dart';
 
 part 'kitchen_sink.wrapped.g.dart';
 
 List<T> _defaultList<T>() => null;
 Map _defaultMap() => null;
 SimpleObject _defaultSimpleObject() => null;
+StrictKeysObject _defaultStrictKeysObject() => null;
 
 k.KitchenSink testFactory(
         {int ctorValidatedNo42,
@@ -114,6 +116,8 @@ class KitchenSink extends Object
   String string;
 
   SimpleObject simpleObject = _defaultSimpleObject();
+
+  StrictKeysObject strictKeysObject = _defaultStrictKeysObject();
 
   int _validatedPropertyNo42;
   int get validatedPropertyNo42 => _validatedPropertyNo42;

--- a/json_serializable/test/kitchen_sink/kitchen_sink.wrapped.g.dart
+++ b/json_serializable/test/kitchen_sink/kitchen_sink.wrapped.g.dart
@@ -46,6 +46,7 @@ KitchenSink _$KitchenSinkFromJson(Map json) {
     ..writeNotNull = json['writeNotNull'] as bool
     ..string = json[r'$string'] as String
     ..simpleObject = json['simpleObject'] == null ? null : new SimpleObject.fromJson(json['simpleObject'] as Map)
+    ..strictKeysObject = json['strictKeysObject'] == null ? null : new StrictKeysObject.fromJson(json['strictKeysObject'] as Map)
     ..validatedPropertyNo42 = json['validatedPropertyNo42'] as int;
 }
 
@@ -71,6 +72,7 @@ abstract class _$KitchenSinkSerializerMixin {
   bool get writeNotNull;
   String get string;
   SimpleObject get simpleObject;
+  StrictKeysObject get strictKeysObject;
   int get validatedPropertyNo42;
   Map<String, dynamic> toJson() => new _$KitchenSinkJsonMapWrapper(this);
 }
@@ -112,6 +114,7 @@ class _$KitchenSinkJsonMapWrapper extends $JsonMapWrapper {
     yield 'writeNotNull';
     yield r'$string';
     yield 'simpleObject';
+    yield 'strictKeysObject';
     yield 'validatedPropertyNo42';
   }
 
@@ -176,6 +179,8 @@ class _$KitchenSinkJsonMapWrapper extends $JsonMapWrapper {
           return _v.string;
         case 'simpleObject':
           return _v.simpleObject;
+        case 'strictKeysObject':
+          return _v.strictKeysObject;
         case 'validatedPropertyNo42':
           return _v.validatedPropertyNo42;
       }

--- a/json_serializable/test/kitchen_sink/kitchen_sink.wrapped.g.dart
+++ b/json_serializable/test/kitchen_sink/kitchen_sink.wrapped.g.dart
@@ -10,40 +10,44 @@ part of 'kitchen_sink.wrapped.dart';
 // Generator: JsonSerializableGenerator
 // **************************************************************************
 
-KitchenSink _$KitchenSinkFromJson(Map json) => new KitchenSink(
-    ctorValidatedNo42: json['no-42'] as int,
-    iterable: json['iterable'] as List,
-    dynamicIterable: json['dynamicIterable'] as List,
-    objectIterable: json['objectIterable'] as List,
-    intIterable: (json['intIterable'] as List)?.map((e) => e as int),
-    dateTimeIterable: (json['datetime-iterable'] as List)
-        ?.map((e) => e == null ? null : DateTime.parse(e as String)))
-  ..dateTime = json['dateTime'] == null
-      ? null
-      : DateTime.parse(json['dateTime'] as String)
-  ..list = json['list'] as List
-  ..dynamicList = json['dynamicList'] as List
-  ..objectList = json['objectList'] as List
-  ..intList = (json['intList'] as List)?.map((e) => e as int)?.toList()
-  ..dateTimeList = (json['dateTimeList'] as List)
-      ?.map((e) => e == null ? null : DateTime.parse(e as String))
-      ?.toList()
-  ..map = json['map'] as Map
-  ..stringStringMap = (json['stringStringMap'] as Map)
-      ?.map((k, e) => new MapEntry(k as String, e as String))
-  ..dynamicIntMap =
-      (json['dynamicIntMap'] as Map)?.map((k, e) => new MapEntry(k, e as int))
-  ..objectDateTimeMap = (json['objectDateTimeMap'] as Map)?.map(
-      (k, e) => new MapEntry(k, e == null ? null : DateTime.parse(e as String)))
-  ..crazyComplex = (json['crazyComplex'] as List)
-      ?.map((e) => (e as Map)?.map((k, e) => new MapEntry(
-          k as String, (e as Map)?.map((k, e) => new MapEntry(k as String, (e as List)?.map((e) => (e as List)?.map((e) => e == null ? null : DateTime.parse(e as String))?.toList())?.toList())))))
-      ?.toList()
-  ..val = (json['val'] as Map)?.map((k, e) => new MapEntry(k as String, e as bool))
-  ..writeNotNull = json['writeNotNull'] as bool
-  ..string = json[r'$string'] as String
-  ..simpleObject = json['simpleObject'] == null ? null : new SimpleObject.fromJson(json['simpleObject'] as Map)
-  ..validatedPropertyNo42 = json['validatedPropertyNo42'] as int;
+KitchenSink _$KitchenSinkFromJson(Map json) {
+  return new KitchenSink(
+      ctorValidatedNo42: json['no-42'] as int,
+      iterable: json['iterable'] as List,
+      dynamicIterable: json['dynamicIterable'] as List,
+      objectIterable: json['objectIterable'] as List,
+      intIterable: (json['intIterable'] as List)?.map((e) => e as int),
+      dateTimeIterable: (json['datetime-iterable'] as List)
+          ?.map((e) => e == null ? null : DateTime.parse(e as String)))
+    ..dateTime = json['dateTime'] == null
+        ? null
+        : DateTime.parse(json['dateTime'] as String)
+    ..list = json['list'] as List
+    ..dynamicList = json['dynamicList'] as List
+    ..objectList = json['objectList'] as List
+    ..intList = (json['intList'] as List)?.map((e) => e as int)?.toList()
+    ..dateTimeList = (json['dateTimeList'] as List)
+        ?.map((e) => e == null ? null : DateTime.parse(e as String))
+        ?.toList()
+    ..map = json['map'] as Map
+    ..stringStringMap = (json['stringStringMap'] as Map)
+        ?.map((k, e) => new MapEntry(k as String, e as String))
+    ..dynamicIntMap =
+        (json['dynamicIntMap'] as Map)?.map((k, e) => new MapEntry(k, e as int))
+    ..objectDateTimeMap = (json['objectDateTimeMap'] as Map)?.map((k, e) =>
+        new MapEntry(k, e == null ? null : DateTime.parse(e as String)))
+    ..crazyComplex = (json['crazyComplex'] as List)
+        ?.map((e) => (e as Map)?.map((k, e) => new MapEntry(
+            k as String,
+            (e as Map)?.map((k, e) =>
+                new MapEntry(k as String, (e as List)?.map((e) => (e as List)?.map((e) => e == null ? null : DateTime.parse(e as String))?.toList())?.toList())))))
+        ?.toList()
+    ..val = (json['val'] as Map)?.map((k, e) => new MapEntry(k as String, e as bool))
+    ..writeNotNull = json['writeNotNull'] as bool
+    ..string = json[r'$string'] as String
+    ..simpleObject = json['simpleObject'] == null ? null : new SimpleObject.fromJson(json['simpleObject'] as Map)
+    ..validatedPropertyNo42 = json['validatedPropertyNo42'] as int;
+}
 
 abstract class _$KitchenSinkSerializerMixin {
   int get ctorValidatedNo42;

--- a/json_serializable/test/kitchen_sink/kitchen_sink_test.dart
+++ b/json_serializable/test/kitchen_sink/kitchen_sink_test.dart
@@ -20,6 +20,8 @@ import 'kitchen_sink.wrapped.dart' as wrapped show testFactory, testFromJson;
 import 'kitchen_sink_interface.dart';
 
 final _isATypeError = const isInstanceOf<TypeError>();
+final _isAUnrecognizedKeysEexception =
+    const isInstanceOf<UnrecognizedKeysException>();
 
 void main() {
   test('valid values covers all keys', () {
@@ -239,7 +241,8 @@ Matcher _getMatcher(bool checked, String expectedKey, bool checkedAssignment) {
 
     innerMatcher = _checkedMatcher(expectedKey);
   } else {
-    innerMatcher = anyOf(isACastError, _isATypeError);
+    innerMatcher =
+        anyOf(isACastError, _isATypeError, _isAUnrecognizedKeysEexception);
 
     if (checkedAssignment) {
       switch (expectedKey) {
@@ -248,6 +251,9 @@ Matcher _getMatcher(bool checked, String expectedKey, bool checkedAssignment) {
           break;
         case 'no-42':
           innerMatcher = isArgumentError;
+          break;
+        case 'strictKeysObject':
+          innerMatcher = _isAUnrecognizedKeysEexception;
           break;
         case 'intIterable':
         case 'datetime-iterable':
@@ -284,6 +290,7 @@ final _validValues = const {
   toJsonMapHelperName: null,
   r'$string': null,
   'simpleObject': const {'value': 42},
+  'strictKeysObject': const {'value': 10, 'custom_field': 'cool'},
   'validatedPropertyNo42': 0
 };
 
@@ -309,6 +316,10 @@ final _invalidValueTypes = const {
   toJsonMapHelperName: 42,
   r'$string': true,
   'simpleObject': 42,
+  'strictKeysObject': const {
+    'value': 10,
+    'invalid_key': true,
+  },
   'validatedPropertyNo42': true
 };
 

--- a/json_serializable/test/kitchen_sink/simple_object.g.dart
+++ b/json_serializable/test/kitchen_sink/simple_object.g.dart
@@ -10,8 +10,9 @@ part of 'simple_object.dart';
 // Generator: JsonSerializableGenerator
 // **************************************************************************
 
-SimpleObject _$SimpleObjectFromJson(Map json) =>
-    new SimpleObject(json['value'] as int);
+SimpleObject _$SimpleObjectFromJson(Map json) {
+  return new SimpleObject(json['value'] as int);
+}
 
 abstract class _$SimpleObjectSerializerMixin {
   int get value;

--- a/json_serializable/test/kitchen_sink/strict_keys_object.dart
+++ b/json_serializable/test/kitchen_sink/strict_keys_object.dart
@@ -1,0 +1,22 @@
+// Copyright (c) 2018, the Dart project authors. Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+import 'package:json_annotation/json_annotation.dart';
+
+part 'strict_keys_object.g.dart';
+
+@JsonSerializable(allowUnrecognizedKeys: false)
+class StrictKeysObject extends Object with _$StrictKeysObjectSerializerMixin {
+  @override
+  final int value;
+
+  @override
+  @JsonKey(name: 'custom_field')
+  final String customField;
+
+  StrictKeysObject(this.value, this.customField);
+
+  factory StrictKeysObject.fromJson(Map json) =>
+      _$StrictKeysObjectFromJson(json);
+}

--- a/json_serializable/test/kitchen_sink/strict_keys_object.dart
+++ b/json_serializable/test/kitchen_sink/strict_keys_object.dart
@@ -6,7 +6,7 @@ import 'package:json_annotation/json_annotation.dart';
 
 part 'strict_keys_object.g.dart';
 
-@JsonSerializable(disallowUnregognizedKeys: true)
+@JsonSerializable(disallowUnrecognizedKeys: true)
 class StrictKeysObject extends Object with _$StrictKeysObjectSerializerMixin {
   @override
   final int value;

--- a/json_serializable/test/kitchen_sink/strict_keys_object.dart
+++ b/json_serializable/test/kitchen_sink/strict_keys_object.dart
@@ -6,7 +6,7 @@ import 'package:json_annotation/json_annotation.dart';
 
 part 'strict_keys_object.g.dart';
 
-@JsonSerializable(allowUnrecognizedKeys: false)
+@JsonSerializable(disallowUnregognizedKeys: true)
 class StrictKeysObject extends Object with _$StrictKeysObjectSerializerMixin {
   @override
   final int value;

--- a/json_serializable/test/kitchen_sink/strict_keys_object.g.dart
+++ b/json_serializable/test/kitchen_sink/strict_keys_object.g.dart
@@ -1,0 +1,24 @@
+// Copyright (c) 2018, the Dart project authors. Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+part of 'strict_keys_object.dart';
+
+// **************************************************************************
+// Generator: JsonSerializableGenerator
+// **************************************************************************
+
+StrictKeysObject _$StrictKeysObjectFromJson(Map json) {
+  $checkAllowedKeys(json, const ['value', 'custom_field']);
+  return new StrictKeysObject(
+      json['value'] as int, json['custom_field'] as String);
+}
+
+abstract class _$StrictKeysObjectSerializerMixin {
+  int get value;
+  String get customField;
+  Map<String, dynamic> toJson() =>
+      <String, dynamic>{'value': value, 'custom_field': customField};
+}

--- a/json_serializable/test/test_files/json_test_example.g.dart
+++ b/json_serializable/test/test_files/json_test_example.g.dart
@@ -10,19 +10,20 @@ part of 'json_test_example.dart';
 // Generator: JsonSerializableGenerator
 // **************************************************************************
 
-Person _$PersonFromJson(Map<String, dynamic> json) => new Person(
-    json['firstName'] as String,
-    json['lastName'] as String,
-    $enumDecodeNullable('House', House.values, json[r'$house'] as String),
-    middleName: json['middleName'] as String,
-    dateOfBirth: json['dateOfBirth'] == null
+Person _$PersonFromJson(Map<String, dynamic> json) {
+  return new Person(json['firstName'] as String, json['lastName'] as String,
+      $enumDecodeNullable('House', House.values, json[r'$house'] as String),
+      middleName: json['middleName'] as String,
+      dateOfBirth: json['dateOfBirth'] == null
+          ? null
+          : DateTime.parse(json['dateOfBirth'] as String))
+    ..order = json['order'] == null
         ? null
-        : DateTime.parse(json['dateOfBirth'] as String))
-  ..order = json['order'] == null
-      ? null
-      : new Order.fromJson(json['order'] as Map<String, dynamic>)
-  ..houseMap = (json['houseMap'] as Map<String, dynamic>)?.map((k, e) =>
-      new MapEntry(k, $enumDecodeNullable('House', House.values, e as String)));
+        : new Order.fromJson(json['order'] as Map<String, dynamic>)
+    ..houseMap = (json['houseMap'] as Map<String, dynamic>)?.map((k, e) =>
+        new MapEntry(
+            k, $enumDecodeNullable('House', House.values, e as String)));
+}
 
 abstract class _$PersonSerializerMixin {
   String get firstName;
@@ -44,17 +45,20 @@ abstract class _$PersonSerializerMixin {
       };
 }
 
-Order _$OrderFromJson(Map<String, dynamic> json) => new Order(
-    $enumDecode('Category', Category.values, json['category'] as String),
-    (json['items'] as List)?.map(
-        (e) => e == null ? null : new Item.fromJson(e as Map<String, dynamic>)))
-  ..count = json['count'] as int
-  ..isRushed = json['isRushed'] as bool
-  ..platform = json['platform'] == null
-      ? null
-      : new Platform.fromJson(json['platform'] as String)
-  ..altPlatforms = (json['altPlatforms'] as Map<String, dynamic>)?.map((k, e) =>
-      new MapEntry(k, e == null ? null : new Platform.fromJson(e as String)));
+Order _$OrderFromJson(Map<String, dynamic> json) {
+  return new Order(
+      $enumDecode('Category', Category.values, json['category'] as String),
+      (json['items'] as List)?.map((e) =>
+          e == null ? null : new Item.fromJson(e as Map<String, dynamic>)))
+    ..count = json['count'] as int
+    ..isRushed = json['isRushed'] as bool
+    ..platform = json['platform'] == null
+        ? null
+        : new Platform.fromJson(json['platform'] as String)
+    ..altPlatforms = (json['altPlatforms'] as Map<String, dynamic>)?.map((k,
+            e) =>
+        new MapEntry(k, e == null ? null : new Platform.fromJson(e as String)));
+}
 
 abstract class _$OrderSerializerMixin {
   int get count;
@@ -73,12 +77,14 @@ abstract class _$OrderSerializerMixin {
       };
 }
 
-Item _$ItemFromJson(Map<String, dynamic> json) => new Item(json['price'] as int)
-  ..itemNumber = json['item-number'] as int
-  ..saleDates = (json['saleDates'] as List)
-      ?.map((e) => e == null ? null : DateTime.parse(e as String))
-      ?.toList()
-  ..rates = (json['rates'] as List)?.map((e) => e as int)?.toList();
+Item _$ItemFromJson(Map<String, dynamic> json) {
+  return new Item(json['price'] as int)
+    ..itemNumber = json['item-number'] as int
+    ..saleDates = (json['saleDates'] as List)
+        ?.map((e) => e == null ? null : DateTime.parse(e as String))
+        ?.toList()
+    ..rates = (json['rates'] as List)?.map((e) => e as int)?.toList();
+}
 
 abstract class _$ItemSerializerMixin {
   int get price;
@@ -103,17 +109,19 @@ abstract class _$ItemSerializerMixin {
   }
 }
 
-Numbers _$NumbersFromJson(Map<String, dynamic> json) => new Numbers()
-  ..ints = (json['ints'] as List)?.map((e) => e as int)?.toList()
-  ..nums = (json['nums'] as List)?.map((e) => e as num)?.toList()
-  ..doubles =
-      (json['doubles'] as List)?.map((e) => (e as num)?.toDouble())?.toList()
-  ..nnDoubles =
-      (json['nnDoubles'] as List).map((e) => (e as num).toDouble()).toList()
-  ..duration =
-      json['duration'] == null ? null : _fromJson(json['duration'] as int)
-  ..date =
-      json['date'] == null ? null : _dateTimeFromEpochUs(json['date'] as int);
+Numbers _$NumbersFromJson(Map<String, dynamic> json) {
+  return new Numbers()
+    ..ints = (json['ints'] as List)?.map((e) => e as int)?.toList()
+    ..nums = (json['nums'] as List)?.map((e) => e as num)?.toList()
+    ..doubles =
+        (json['doubles'] as List)?.map((e) => (e as num)?.toDouble())?.toList()
+    ..nnDoubles =
+        (json['nnDoubles'] as List).map((e) => (e as num).toDouble()).toList()
+    ..duration =
+        json['duration'] == null ? null : _fromJson(json['duration'] as int)
+    ..date =
+        json['date'] == null ? null : _dateTimeFromEpochUs(json['date'] as int);
+}
 
 abstract class _$NumbersSerializerMixin {
   List<int> get ints;

--- a/json_serializable/test/test_files/json_test_example.non_nullable.g.dart
+++ b/json_serializable/test/test_files/json_test_example.non_nullable.g.dart
@@ -10,15 +10,15 @@ part of 'json_test_example.non_nullable.dart';
 // Generator: JsonSerializableGenerator
 // **************************************************************************
 
-Person _$PersonFromJson(Map<String, dynamic> json) => new Person(
-    json['firstName'] as String,
-    json['lastName'] as String,
-    $enumDecode('House', House.values, json[r'$house'] as String),
-    middleName: json['middleName'] as String,
-    dateOfBirth: DateTime.parse(json['dateOfBirth'] as String))
-  ..order = new Order.fromJson(json['order'] as Map<String, dynamic>)
-  ..houseMap = (json['houseMap'] as Map<String, dynamic>).map((k, e) =>
-      new MapEntry(k, $enumDecode('House', House.values, e as String)));
+Person _$PersonFromJson(Map<String, dynamic> json) {
+  return new Person(json['firstName'] as String, json['lastName'] as String,
+      $enumDecode('House', House.values, json[r'$house'] as String),
+      middleName: json['middleName'] as String,
+      dateOfBirth: DateTime.parse(json['dateOfBirth'] as String))
+    ..order = new Order.fromJson(json['order'] as Map<String, dynamic>)
+    ..houseMap = (json['houseMap'] as Map<String, dynamic>).map((k, e) =>
+        new MapEntry(k, $enumDecode('House', House.values, e as String)));
+}
 
 abstract class _$PersonSerializerMixin {
   String get firstName;
@@ -40,15 +40,17 @@ abstract class _$PersonSerializerMixin {
       };
 }
 
-Order _$OrderFromJson(Map<String, dynamic> json) => new Order(
-    $enumDecode('Category', Category.values, json['category'] as String),
-    (json['items'] as List)
-        .map((e) => new Item.fromJson(e as Map<String, dynamic>)))
-  ..count = json['count'] as int
-  ..isRushed = json['isRushed'] as bool
-  ..platform = new Platform.fromJson(json['platform'] as String)
-  ..altPlatforms = (json['altPlatforms'] as Map<String, dynamic>)
-      .map((k, e) => new MapEntry(k, new Platform.fromJson(e as String)));
+Order _$OrderFromJson(Map<String, dynamic> json) {
+  return new Order(
+      $enumDecode('Category', Category.values, json['category'] as String),
+      (json['items'] as List)
+          .map((e) => new Item.fromJson(e as Map<String, dynamic>)))
+    ..count = json['count'] as int
+    ..isRushed = json['isRushed'] as bool
+    ..platform = new Platform.fromJson(json['platform'] as String)
+    ..altPlatforms = (json['altPlatforms'] as Map<String, dynamic>)
+        .map((k, e) => new MapEntry(k, new Platform.fromJson(e as String)));
+}
 
 abstract class _$OrderSerializerMixin {
   int get count;
@@ -67,12 +69,14 @@ abstract class _$OrderSerializerMixin {
       };
 }
 
-Item _$ItemFromJson(Map<String, dynamic> json) => new Item(json['price'] as int)
-  ..itemNumber = json['item-number'] as int
-  ..saleDates = (json['saleDates'] as List)
-      .map((e) => DateTime.parse(e as String))
-      .toList()
-  ..rates = (json['rates'] as List).map((e) => e as int).toList();
+Item _$ItemFromJson(Map<String, dynamic> json) {
+  return new Item(json['price'] as int)
+    ..itemNumber = json['item-number'] as int
+    ..saleDates = (json['saleDates'] as List)
+        .map((e) => DateTime.parse(e as String))
+        .toList()
+    ..rates = (json['rates'] as List).map((e) => e as int).toList();
+}
 
 abstract class _$ItemSerializerMixin {
   int get price;
@@ -87,15 +91,17 @@ abstract class _$ItemSerializerMixin {
       };
 }
 
-Numbers _$NumbersFromJson(Map<String, dynamic> json) => new Numbers()
-  ..ints = (json['ints'] as List).map((e) => e as int).toList()
-  ..nums = (json['nums'] as List).map((e) => e as num).toList()
-  ..doubles =
-      (json['doubles'] as List).map((e) => (e as num).toDouble()).toList()
-  ..nnDoubles =
-      (json['nnDoubles'] as List).map((e) => (e as num).toDouble()).toList()
-  ..duration = _fromJson(json['duration'] as int)
-  ..date = _dateTimeFromEpochUs(json['date'] as int);
+Numbers _$NumbersFromJson(Map<String, dynamic> json) {
+  return new Numbers()
+    ..ints = (json['ints'] as List).map((e) => e as int).toList()
+    ..nums = (json['nums'] as List).map((e) => e as num).toList()
+    ..doubles =
+        (json['doubles'] as List).map((e) => (e as num).toDouble()).toList()
+    ..nnDoubles =
+        (json['nnDoubles'] as List).map((e) => (e as num).toDouble()).toList()
+    ..duration = _fromJson(json['duration'] as int)
+    ..date = _dateTimeFromEpochUs(json['date'] as int);
+}
 
 abstract class _$NumbersSerializerMixin {
   List<int> get ints;

--- a/json_serializable/test/test_files/json_test_example.non_nullable.wrapped.g.dart
+++ b/json_serializable/test/test_files/json_test_example.non_nullable.wrapped.g.dart
@@ -10,15 +10,15 @@ part of 'json_test_example.non_nullable.wrapped.dart';
 // Generator: JsonSerializableGenerator
 // **************************************************************************
 
-Person _$PersonFromJson(Map<String, dynamic> json) => new Person(
-    json['firstName'] as String,
-    json['lastName'] as String,
-    $enumDecode('House', House.values, json[r'$house'] as String),
-    middleName: json['middleName'] as String,
-    dateOfBirth: DateTime.parse(json['dateOfBirth'] as String))
-  ..order = new Order.fromJson(json['order'] as Map<String, dynamic>)
-  ..houseMap = (json['houseMap'] as Map<String, dynamic>).map((k, e) =>
-      new MapEntry(k, $enumDecode('House', House.values, e as String)));
+Person _$PersonFromJson(Map<String, dynamic> json) {
+  return new Person(json['firstName'] as String, json['lastName'] as String,
+      $enumDecode('House', House.values, json[r'$house'] as String),
+      middleName: json['middleName'] as String,
+      dateOfBirth: DateTime.parse(json['dateOfBirth'] as String))
+    ..order = new Order.fromJson(json['order'] as Map<String, dynamic>)
+    ..houseMap = (json['houseMap'] as Map<String, dynamic>).map((k, e) =>
+        new MapEntry(k, $enumDecode('House', House.values, e as String)));
+}
 
 abstract class _$PersonSerializerMixin {
   String get firstName;
@@ -71,15 +71,17 @@ class _$PersonJsonMapWrapper extends $JsonMapWrapper {
   }
 }
 
-Order _$OrderFromJson(Map<String, dynamic> json) => new Order(
-    $enumDecode('Category', Category.values, json['category'] as String),
-    (json['items'] as List)
-        .map((e) => new Item.fromJson(e as Map<String, dynamic>)))
-  ..count = json['count'] as int
-  ..isRushed = json['isRushed'] as bool
-  ..platform = new Platform.fromJson(json['platform'] as String)
-  ..altPlatforms = (json['altPlatforms'] as Map<String, dynamic>)
-      .map((k, e) => new MapEntry(k, new Platform.fromJson(e as String)));
+Order _$OrderFromJson(Map<String, dynamic> json) {
+  return new Order(
+      $enumDecode('Category', Category.values, json['category'] as String),
+      (json['items'] as List)
+          .map((e) => new Item.fromJson(e as Map<String, dynamic>)))
+    ..count = json['count'] as int
+    ..isRushed = json['isRushed'] as bool
+    ..platform = new Platform.fromJson(json['platform'] as String)
+    ..altPlatforms = (json['altPlatforms'] as Map<String, dynamic>)
+        .map((k, e) => new MapEntry(k, new Platform.fromJson(e as String)));
+}
 
 abstract class _$OrderSerializerMixin {
   int get count;
@@ -127,12 +129,14 @@ class _$OrderJsonMapWrapper extends $JsonMapWrapper {
   }
 }
 
-Item _$ItemFromJson(Map<String, dynamic> json) => new Item(json['price'] as int)
-  ..itemNumber = json['item-number'] as int
-  ..saleDates = (json['saleDates'] as List)
-      .map((e) => DateTime.parse(e as String))
-      .toList()
-  ..rates = (json['rates'] as List).map((e) => e as int).toList();
+Item _$ItemFromJson(Map<String, dynamic> json) {
+  return new Item(json['price'] as int)
+    ..itemNumber = json['item-number'] as int
+    ..saleDates = (json['saleDates'] as List)
+        .map((e) => DateTime.parse(e as String))
+        .toList()
+    ..rates = (json['rates'] as List).map((e) => e as int).toList();
+}
 
 abstract class _$ItemSerializerMixin {
   int get price;
@@ -168,15 +172,17 @@ class _$ItemJsonMapWrapper extends $JsonMapWrapper {
   }
 }
 
-Numbers _$NumbersFromJson(Map<String, dynamic> json) => new Numbers()
-  ..ints = (json['ints'] as List).map((e) => e as int).toList()
-  ..nums = (json['nums'] as List).map((e) => e as num).toList()
-  ..doubles =
-      (json['doubles'] as List).map((e) => (e as num).toDouble()).toList()
-  ..nnDoubles =
-      (json['nnDoubles'] as List).map((e) => (e as num).toDouble()).toList()
-  ..duration = _fromJson(json['duration'] as int)
-  ..date = _dateTimeFromEpochUs(json['date'] as int);
+Numbers _$NumbersFromJson(Map<String, dynamic> json) {
+  return new Numbers()
+    ..ints = (json['ints'] as List).map((e) => e as int).toList()
+    ..nums = (json['nums'] as List).map((e) => e as num).toList()
+    ..doubles =
+        (json['doubles'] as List).map((e) => (e as num).toDouble()).toList()
+    ..nnDoubles =
+        (json['nnDoubles'] as List).map((e) => (e as num).toDouble()).toList()
+    ..duration = _fromJson(json['duration'] as int)
+    ..date = _dateTimeFromEpochUs(json['date'] as int);
+}
 
 abstract class _$NumbersSerializerMixin {
   List<int> get ints;

--- a/json_serializable/test/test_files/json_test_example.wrapped.g.dart
+++ b/json_serializable/test/test_files/json_test_example.wrapped.g.dart
@@ -10,19 +10,20 @@ part of 'json_test_example.wrapped.dart';
 // Generator: JsonSerializableGenerator
 // **************************************************************************
 
-Person _$PersonFromJson(Map<String, dynamic> json) => new Person(
-    json['firstName'] as String,
-    json['lastName'] as String,
-    $enumDecodeNullable('House', House.values, json[r'$house'] as String),
-    middleName: json['middleName'] as String,
-    dateOfBirth: json['dateOfBirth'] == null
+Person _$PersonFromJson(Map<String, dynamic> json) {
+  return new Person(json['firstName'] as String, json['lastName'] as String,
+      $enumDecodeNullable('House', House.values, json[r'$house'] as String),
+      middleName: json['middleName'] as String,
+      dateOfBirth: json['dateOfBirth'] == null
+          ? null
+          : DateTime.parse(json['dateOfBirth'] as String))
+    ..order = json['order'] == null
         ? null
-        : DateTime.parse(json['dateOfBirth'] as String))
-  ..order = json['order'] == null
-      ? null
-      : new Order.fromJson(json['order'] as Map<String, dynamic>)
-  ..houseMap = (json['houseMap'] as Map<String, dynamic>)?.map((k, e) =>
-      new MapEntry(k, $enumDecodeNullable('House', House.values, e as String)));
+        : new Order.fromJson(json['order'] as Map<String, dynamic>)
+    ..houseMap = (json['houseMap'] as Map<String, dynamic>)?.map((k, e) =>
+        new MapEntry(
+            k, $enumDecodeNullable('House', House.values, e as String)));
+}
 
 abstract class _$PersonSerializerMixin {
   String get firstName;
@@ -75,17 +76,20 @@ class _$PersonJsonMapWrapper extends $JsonMapWrapper {
   }
 }
 
-Order _$OrderFromJson(Map<String, dynamic> json) => new Order(
-    $enumDecode('Category', Category.values, json['category'] as String),
-    (json['items'] as List)?.map(
-        (e) => e == null ? null : new Item.fromJson(e as Map<String, dynamic>)))
-  ..count = json['count'] as int
-  ..isRushed = json['isRushed'] as bool
-  ..platform = json['platform'] == null
-      ? null
-      : new Platform.fromJson(json['platform'] as String)
-  ..altPlatforms = (json['altPlatforms'] as Map<String, dynamic>)?.map((k, e) =>
-      new MapEntry(k, e == null ? null : new Platform.fromJson(e as String)));
+Order _$OrderFromJson(Map<String, dynamic> json) {
+  return new Order(
+      $enumDecode('Category', Category.values, json['category'] as String),
+      (json['items'] as List)?.map((e) =>
+          e == null ? null : new Item.fromJson(e as Map<String, dynamic>)))
+    ..count = json['count'] as int
+    ..isRushed = json['isRushed'] as bool
+    ..platform = json['platform'] == null
+        ? null
+        : new Platform.fromJson(json['platform'] as String)
+    ..altPlatforms = (json['altPlatforms'] as Map<String, dynamic>)?.map((k,
+            e) =>
+        new MapEntry(k, e == null ? null : new Platform.fromJson(e as String)));
+}
 
 abstract class _$OrderSerializerMixin {
   int get count;
@@ -133,12 +137,14 @@ class _$OrderJsonMapWrapper extends $JsonMapWrapper {
   }
 }
 
-Item _$ItemFromJson(Map<String, dynamic> json) => new Item(json['price'] as int)
-  ..itemNumber = json['item-number'] as int
-  ..saleDates = (json['saleDates'] as List)
-      ?.map((e) => e == null ? null : DateTime.parse(e as String))
-      ?.toList()
-  ..rates = (json['rates'] as List)?.map((e) => e as int)?.toList();
+Item _$ItemFromJson(Map<String, dynamic> json) {
+  return new Item(json['price'] as int)
+    ..itemNumber = json['item-number'] as int
+    ..saleDates = (json['saleDates'] as List)
+        ?.map((e) => e == null ? null : DateTime.parse(e as String))
+        ?.toList()
+    ..rates = (json['rates'] as List)?.map((e) => e as int)?.toList();
+}
 
 abstract class _$ItemSerializerMixin {
   int get price;
@@ -181,17 +187,19 @@ class _$ItemJsonMapWrapper extends $JsonMapWrapper {
   }
 }
 
-Numbers _$NumbersFromJson(Map<String, dynamic> json) => new Numbers()
-  ..ints = (json['ints'] as List)?.map((e) => e as int)?.toList()
-  ..nums = (json['nums'] as List)?.map((e) => e as num)?.toList()
-  ..doubles =
-      (json['doubles'] as List)?.map((e) => (e as num)?.toDouble())?.toList()
-  ..nnDoubles =
-      (json['nnDoubles'] as List).map((e) => (e as num).toDouble()).toList()
-  ..duration =
-      json['duration'] == null ? null : _fromJson(json['duration'] as int)
-  ..date =
-      json['date'] == null ? null : _dateTimeFromEpochUs(json['date'] as int);
+Numbers _$NumbersFromJson(Map<String, dynamic> json) {
+  return new Numbers()
+    ..ints = (json['ints'] as List)?.map((e) => e as int)?.toList()
+    ..nums = (json['nums'] as List)?.map((e) => e as num)?.toList()
+    ..doubles =
+        (json['doubles'] as List)?.map((e) => (e as num)?.toDouble())?.toList()
+    ..nnDoubles =
+        (json['nnDoubles'] as List).map((e) => (e as num).toDouble()).toList()
+    ..duration =
+        json['duration'] == null ? null : _fromJson(json['duration'] as int)
+    ..date =
+        json['date'] == null ? null : _dateTimeFromEpochUs(json['date'] as int);
+}
 
 abstract class _$NumbersSerializerMixin {
   List<int> get ints;

--- a/json_serializable/test/yaml/build_config.dart
+++ b/json_serializable/test/yaml/build_config.dart
@@ -18,7 +18,7 @@ class Config extends Object with _$ConfigSerializerMixin {
   factory Config.fromJson(Map map) => _$ConfigFromJson(map);
 }
 
-@JsonSerializable(includeIfNull: false, disallowUnregognizedKeys: true)
+@JsonSerializable(includeIfNull: false, disallowUnrecognizedKeys: true)
 class Builder extends Object with _$BuilderSerializerMixin {
   @JsonKey(nullable: true)
   final String target;

--- a/json_serializable/test/yaml/build_config.dart
+++ b/json_serializable/test/yaml/build_config.dart
@@ -22,13 +22,20 @@ class Config extends Object with _$ConfigSerializerMixin {
 class Builder extends Object with _$BuilderSerializerMixin {
   @JsonKey(nullable: true)
   final String target;
+
   final String import;
 
   @JsonKey(name: 'is_optional')
   final bool isOptional;
 
-  @JsonKey(name: 'auto_apply', toJson: _toJson, fromJson: _fromJson)
+  @JsonKey(
+      name: 'auto_apply',
+      toJson: _autoApplyToJson,
+      fromJson: _autoApplyFromJson)
   final AutoApply autoApply;
+
+  @JsonKey(name: 'build_to', toJson: _buildToToJson, fromJson: _buildToFromJson)
+  final BuildTo buildTo;
 
   final AutoApply defaultEnumTest;
 
@@ -49,6 +56,7 @@ class Builder extends Object with _$BuilderSerializerMixin {
     this.target,
     this.isOptional,
     this.autoApply,
+    this.buildTo,
     this.defaultEnumTest,
     this.builderFactories,
     this.appliesBuilders,
@@ -66,28 +74,42 @@ class Builder extends Object with _$BuilderSerializerMixin {
 
 enum AutoApply { none, dependents, allPackages, rootPackage }
 
+enum BuildTo { cache, source }
+
+AutoApply _autoApplyFromJson(String input) =>
+    _fromJson(input, _autoApplyConvert, 'autoApply');
+
+String _autoApplyToJson(AutoApply value) =>
+    _toJson(value, _autoApplyConvert, 'autoApply');
+
+BuildTo _buildToFromJson(String input) =>
+    _fromJson(input, _buildToConvert, 'buildTo');
+
+String _buildToToJson(BuildTo value) =>
+    _toJson(value, _buildToConvert, 'buildTo');
+
 // TODO: remove all of this and annotate the fields on the enum – once we have
 // https://github.com/dart-lang/json_serializable/issues/38
-AutoApply _fromJson(String input) {
-  var value = _autoApplyConvert[input];
+T _fromJson<T>(String input, Map<String, T> convertMap, String fieldName) {
+  var value = convertMap[input];
   if (value == null) {
-    var allowed = _autoApplyConvert.keys.map((e) => '"$e"').join(', ');
+    var allowed = convertMap.keys.map((e) => '"$e"').join(', ');
     throw new ArgumentError.value(
-        input, 'autoApply', '"$input" is not in the supported set: $allowed.');
+        input, fieldName, '"$input" is not in the supported set: $allowed.');
   }
   return value;
 }
 
-String _toJson(AutoApply value) {
+String _toJson<T>(T value, Map<String, T> convertMap, String fieldName) {
   if (value == null) {
     return null;
   }
-  var string = _autoApplyConvert.entries
+  var string = convertMap.entries
       .singleWhere((e) => e.value == value, orElse: () => null)
       ?.key;
 
   if (string == null) {
-    throw new ArgumentError.value(value, 'autoApply', 'Unsupported value.');
+    throw new ArgumentError.value(value, fieldName, 'Unsupported value.');
   }
   return string;
 }
@@ -97,4 +119,9 @@ const _autoApplyConvert = const {
   'dependents': AutoApply.dependents,
   'all_packages': AutoApply.allPackages,
   'root_package': AutoApply.rootPackage
+};
+
+const _buildToConvert = const {
+  'cache': BuildTo.cache,
+  'source': BuildTo.source,
 };

--- a/json_serializable/test/yaml/build_config.dart
+++ b/json_serializable/test/yaml/build_config.dart
@@ -18,7 +18,7 @@ class Config extends Object with _$ConfigSerializerMixin {
   factory Config.fromJson(Map map) => _$ConfigFromJson(map);
 }
 
-@JsonSerializable(includeIfNull: false)
+@JsonSerializable(includeIfNull: false, allowUnrecognizedKeys: false)
 class Builder extends Object with _$BuilderSerializerMixin {
   @JsonKey(nullable: true)
   final String target;

--- a/json_serializable/test/yaml/build_config.dart
+++ b/json_serializable/test/yaml/build_config.dart
@@ -18,7 +18,7 @@ class Config extends Object with _$ConfigSerializerMixin {
   factory Config.fromJson(Map map) => _$ConfigFromJson(map);
 }
 
-@JsonSerializable(includeIfNull: false, allowUnrecognizedKeys: false)
+@JsonSerializable(includeIfNull: false, disallowUnregognizedKeys: true)
 class Builder extends Object with _$BuilderSerializerMixin {
   @JsonKey(nullable: true)
   final String target;

--- a/json_serializable/test/yaml/build_config.g.dart
+++ b/json_serializable/test/yaml/build_config.g.dart
@@ -12,7 +12,6 @@ part of 'build_config.dart';
 
 Config _$ConfigFromJson(Map json) {
   return $checkedNew('Config', json, () {
-    $checkAllowedKeys(json, const ['builders']);
     var val = new Config(
         builders: $checkedConvert(
             json,
@@ -30,23 +29,14 @@ abstract class _$ConfigSerializerMixin {
 
 Builder _$BuilderFromJson(Map json) {
   return $checkedNew('Builder', json, () {
-    $checkAllowedKeys(json, const [
-      'target',
-      'import',
-      'is_optional',
-      'auto_apply',
-      'defaultEnumTest',
-      'builder_factories',
-      'applies_builders',
-      'required_inputs',
-      'build_extensions'
-    ]);
     var val = new Builder(
         import: $checkedConvert(json, 'import', (v) => v as String),
         target: $checkedConvert(json, 'target', (v) => v as String),
         isOptional: $checkedConvert(json, 'is_optional', (v) => v as bool),
         autoApply: $checkedConvert(json, 'auto_apply',
-            (v) => v == null ? null : _fromJson(v as String)),
+            (v) => v == null ? null : _autoApplyFromJson(v as String)),
+        buildTo: $checkedConvert(json, 'build_to',
+            (v) => v == null ? null : _buildToFromJson(v as String)),
         defaultEnumTest: $checkedConvert(
             json,
             'defaultEnumTest',
@@ -67,6 +57,7 @@ Builder _$BuilderFromJson(Map json) {
   }, fieldKeyMap: const {
     'isOptional': 'is_optional',
     'autoApply': 'auto_apply',
+    'buildTo': 'build_to',
     'builderFactories': 'builder_factories',
     'appliesBuilders': 'applies_builders',
     'requiredInputs': 'required_inputs',
@@ -79,6 +70,7 @@ abstract class _$BuilderSerializerMixin {
   String get import;
   bool get isOptional;
   AutoApply get autoApply;
+  BuildTo get buildTo;
   AutoApply get defaultEnumTest;
   List<String> get builderFactories;
   List<String> get appliesBuilders;
@@ -96,7 +88,9 @@ abstract class _$BuilderSerializerMixin {
     writeNotNull('target', target);
     writeNotNull('import', import);
     writeNotNull('is_optional', isOptional);
-    writeNotNull('auto_apply', autoApply == null ? null : _toJson(autoApply));
+    writeNotNull(
+        'auto_apply', autoApply == null ? null : _autoApplyToJson(autoApply));
+    writeNotNull('build_to', buildTo == null ? null : _buildToToJson(buildTo));
     writeNotNull(
         'defaultEnumTest',
         defaultEnumTest == null

--- a/json_serializable/test/yaml/build_config.g.dart
+++ b/json_serializable/test/yaml/build_config.g.dart
@@ -29,6 +29,18 @@ abstract class _$ConfigSerializerMixin {
 
 Builder _$BuilderFromJson(Map json) {
   return $checkedNew('Builder', json, () {
+    $checkAllowedKeys(json, const [
+      'target',
+      'import',
+      'is_optional',
+      'auto_apply',
+      'build_to',
+      'defaultEnumTest',
+      'builder_factories',
+      'applies_builders',
+      'required_inputs',
+      'build_extensions'
+    ]);
     var val = new Builder(
         import: $checkedConvert(json, 'import', (v) => v as String),
         target: $checkedConvert(json, 'target', (v) => v as String),

--- a/json_serializable/test/yaml/build_config.g.dart
+++ b/json_serializable/test/yaml/build_config.g.dart
@@ -10,54 +10,69 @@ part of 'build_config.dart';
 // Generator: JsonSerializableGenerator
 // **************************************************************************
 
-Config _$ConfigFromJson(Map json) => $checkedNew(
-    'Config',
-    json,
-    () => new Config(
+Config _$ConfigFromJson(Map json) {
+  return $checkedNew('Config', json, () {
+    $checkAllowedKeys(json, const ['builders']);
+    var val = new Config(
         builders: $checkedConvert(
             json,
             'builders',
             (v) => (v as Map)?.map((k, e) => new MapEntry(k as String,
-                e == null ? null : new Builder.fromJson(e as Map))))));
+                e == null ? null : new Builder.fromJson(e as Map)))));
+    return val;
+  });
+}
 
 abstract class _$ConfigSerializerMixin {
   Map<String, Builder> get builders;
   Map<String, dynamic> toJson() => <String, dynamic>{'builders': builders};
 }
 
-Builder _$BuilderFromJson(Map json) => $checkedNew(
-        'Builder',
-        json,
-        () => new Builder(
-            import: $checkedConvert(json, 'import', (v) => v as String),
-            target: $checkedConvert(json, 'target', (v) => v as String),
-            isOptional: $checkedConvert(json, 'is_optional', (v) => v as bool),
-            autoApply: $checkedConvert(json, 'auto_apply',
-                (v) => v == null ? null : _fromJson(v as String)),
-            defaultEnumTest: $checkedConvert(
-                json,
-                'defaultEnumTest',
-                (v) => $enumDecodeNullable(
-                    'AutoApply', AutoApply.values, v as String)),
-            builderFactories: $checkedConvert(json, 'builder_factories',
-                (v) => (v as List).map((e) => e as String).toList()),
-            appliesBuilders: $checkedConvert(json, 'applies_builders',
-                (v) => (v as List)?.map((e) => e as String)?.toList()),
-            requiredInputs: $checkedConvert(json, 'required_inputs',
-                (v) => (v as List)?.map((e) => e as String)?.toList()),
-            buildExtentions: $checkedConvert(
-                json,
-                'build_extensions',
-                (v) => (v as Map)?.map((k, e) => new MapEntry(k as String,
-                    (e as List)?.map((e) => e as String)?.toList())))),
-        fieldKeyMap: const {
-          'isOptional': 'is_optional',
-          'autoApply': 'auto_apply',
-          'builderFactories': 'builder_factories',
-          'appliesBuilders': 'applies_builders',
-          'requiredInputs': 'required_inputs',
-          'buildExtentions': 'build_extensions'
-        });
+Builder _$BuilderFromJson(Map json) {
+  return $checkedNew('Builder', json, () {
+    $checkAllowedKeys(json, const [
+      'target',
+      'import',
+      'is_optional',
+      'auto_apply',
+      'defaultEnumTest',
+      'builder_factories',
+      'applies_builders',
+      'required_inputs',
+      'build_extensions'
+    ]);
+    var val = new Builder(
+        import: $checkedConvert(json, 'import', (v) => v as String),
+        target: $checkedConvert(json, 'target', (v) => v as String),
+        isOptional: $checkedConvert(json, 'is_optional', (v) => v as bool),
+        autoApply: $checkedConvert(json, 'auto_apply',
+            (v) => v == null ? null : _fromJson(v as String)),
+        defaultEnumTest: $checkedConvert(
+            json,
+            'defaultEnumTest',
+            (v) => $enumDecodeNullable(
+                'AutoApply', AutoApply.values, v as String)),
+        builderFactories: $checkedConvert(json, 'builder_factories',
+            (v) => (v as List).map((e) => e as String).toList()),
+        appliesBuilders: $checkedConvert(json, 'applies_builders',
+            (v) => (v as List)?.map((e) => e as String)?.toList()),
+        requiredInputs: $checkedConvert(json, 'required_inputs',
+            (v) => (v as List)?.map((e) => e as String)?.toList()),
+        buildExtentions: $checkedConvert(
+            json,
+            'build_extensions',
+            (v) => (v as Map)?.map((k, e) => new MapEntry(
+                k as String, (e as List)?.map((e) => e as String)?.toList()))));
+    return val;
+  }, fieldKeyMap: const {
+    'isOptional': 'is_optional',
+    'autoApply': 'auto_apply',
+    'builderFactories': 'builder_factories',
+    'appliesBuilders': 'applies_builders',
+    'requiredInputs': 'required_inputs',
+    'buildExtentions': 'build_extensions'
+  });
+}
 
 abstract class _$BuilderSerializerMixin {
   String get target;

--- a/json_serializable/test/yaml/config_test.yaml
+++ b/json_serializable/test/yaml/config_test.yaml
@@ -5,4 +5,4 @@ builders:
     builder_factories: ["myBuilder"]
     build_extensions: {".dart": [".tar.gz"]}
     auto_apply: root_package
-    apply_builders: ["|archive_extract_builder"]
+    applies_builders: ["|archive_extract_builder"]

--- a/json_serializable/test/yaml/yaml_test.dart
+++ b/json_serializable/test/yaml/yaml_test.dart
@@ -106,29 +106,52 @@ builders:
 line 3, column 5 of file.yaml: Could not create `Builder`. Unsupported value for `builder_factories`. Must have at least one value.
     builder_factories: []
     ^^^^^^^^^^^^^^^^^''',
+  r'''
+builders:
+  a:
+    foo: bar
+    baz: zap
+''': r'''
+Could not create `Builder`.
+Unrecognized keys [baz, foo], supported keys  are [target, import, is_optional, auto_apply, build_to, defaultEnumTest, builder_factories, applies_builders, required_inputs, build_extensions]
+
+line 4, column 5 of file.yaml: Invalid key "baz"
+    baz: zap
+    ^^^
+line 3, column 5 of file.yaml: Invalid key "foo"
+    foo: bar
+    ^^^''',
 };
 
 String _prettyPrintCheckedFromJsonException(CheckedFromJsonException err) {
   var yamlMap = err.map as YamlMap;
 
-  var yamlKey = yamlMap.nodes.keys.singleWhere(
-      (k) => (k as YamlScalar).value == err.key,
-      orElse: () => null) as YamlScalar;
-
-  var message = 'Could not create `${err.className}`.';
-  if (yamlKey == null) {
-    assert(err.key == null);
-    message = '${yamlMap.span.message(message)}\n${err.innerError}';
-  } else {
-    message = '$message Unsupported value for `${err.key}`.';
-    if (err.message != null) {
-      message = '$message ${err.message}';
-    }
-    message = yamlKey.span.message(message);
+  YamlScalar _getYamlKey(String key) {
+    return yamlMap.nodes.keys.singleWhere((k) => (k as YamlScalar).value == key,
+        orElse: () => null) as YamlScalar;
   }
 
+  var message = 'Could not create `${err.className}`.';
   if (err.innerError is UnrecognizedKeysException) {
-    message += '\n${(err.innerError as UnrecognizedKeysException).message}';
+    var innerError = err.innerError as UnrecognizedKeysException;
+    message += '\n${innerError.message}\n';
+    for (var key in innerError.unrecognizedKeys) {
+      var yamlKey = _getYamlKey(key);
+      assert(yamlKey != null);
+      message += '\n${yamlKey.span.message('Invalid key "$key"')}';
+    }
+  } else {
+    var yamlKey = _getYamlKey(err.key);
+    if (yamlKey == null) {
+      assert(err.key == null);
+      message = '${yamlMap.span.message(message)}\n${err.innerError}';
+    } else {
+      message = '$message Unsupported value for `${err.key}`.';
+      if (err.message != null) {
+        message = '$message ${err.message}';
+      }
+      message = yamlKey.span.message(message);
+    }
   }
 
   return message;

--- a/json_serializable/test/yaml/yaml_test.dart
+++ b/json_serializable/test/yaml/yaml_test.dart
@@ -118,13 +118,17 @@ String _prettyPrintCheckedFromJsonException(CheckedFromJsonException err) {
   var message = 'Could not create `${err.className}`.';
   if (yamlKey == null) {
     assert(err.key == null);
-    message = '${yamlMap.span.message(message)} ${err.innerError}';
+    message = '${yamlMap.span.message(message)}\n${err.innerError}';
   } else {
     message = '$message Unsupported value for `${err.key}`.';
     if (err.message != null) {
       message = '$message ${err.message}';
     }
     message = yamlKey.span.message(message);
+  }
+
+  if (err.innerError is UnrecognizedKeysException) {
+    message += '\n${(err.innerError as UnrecognizedKeysException).message}';
   }
 
   return message;

--- a/json_serializable/tool/build.dart
+++ b/json_serializable/tool/build.dart
@@ -68,7 +68,8 @@ final List<BuilderApplication> builders = [
         include: const [
           'test/kitchen_sink/kitchen_sink.dart',
           'test/kitchen_sink/kitchen_sink.non_nullable.dart',
-          'test/kitchen_sink/simple_object.dart'
+          'test/kitchen_sink/simple_object.dart',
+          'test/kitchen_sink/strict_keys_object.dart'
         ],
       )),
   applyToRoot(_jsonPartBuilder(checked: true, anyMap: true),

--- a/json_serializable/tool/builder.dart
+++ b/json_serializable/tool/builder.dart
@@ -50,6 +50,10 @@ class _NonNullableGenerator extends Generator {
             'Map<String, T> _defaultMap<T>() => <String, T>{};'),
         new _Replacement('SimpleObject _defaultSimpleObject() => null;',
             'SimpleObject _defaultSimpleObject() => new SimpleObject(42);'),
+        new _Replacement(
+            'StrictKeysObject _defaultStrictKeysObject() => null;',
+            'StrictKeysObject _defaultStrictKeysObject() => '
+            "new StrictKeysObject(10, 'cool');"),
         new _Replacement('DateTime dateTime;',
             'DateTime dateTime = new DateTime(1981, 6, 5);')
       ]);


### PR DESCRIPTION
Fixes https://github.com/dart-lang/json_serializable/issues/184

Added on `JsonSerializable` annotation, defaults to `false` (old behavior). If `true` then it throws an `UnrecognizedKeysException` which contains all the information about the allowed keys, unrecognized keys, etc.

As a part of this I also migrated everything to use blocks instead of fat arrows to simplify the codegen (this requires adding in an additional method call).

~~@kevmoo not sure how crazy you want me to go with testing here - there is a single test right now in the yaml_test.dart file which is more of an e2e_test as its checking for the actual error output.~~

Added a nested object in kitchen sink which uses this.