### PR TITLE
release json_annotation 0.2.7

### DIFF
--- a/json_annotation/CHANGELOG.md
+++ b/json_annotation/CHANGELOG.md
@@ -4,6 +4,7 @@
   * Added a helper function to support this option. This function starts with a
     `$` and should only be referenced by generated code. It is not meant for
     direct use.
+  * Added `UnrecognizedKeysException` for reporting errors.
 
 ## 0.2.6
 

--- a/json_annotation/pubspec.yaml
+++ b/json_annotation/pubspec.yaml
@@ -1,5 +1,5 @@
 name: json_annotation
-version: 0.2.7-dev
+version: 0.2.7
 description: >-
   Classes and helper functions that support JSON code generation via the
   `json_serializable` package.


### PR DESCRIPTION
It would be nice to get this in before we release the latest build_config so we don't regress error reporting