### PR TITLE
DO NOT SUMBIT: Question: is this a better way to get at enum values via pkg:analyzer?

### DIFF
--- a/json_serializable/lib/src/json_key_with_conversion.dart
+++ b/json_serializable/lib/src/json_key_with_conversion.dart
@@ -2,6 +2,7 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
+import 'package:analyzer/dart/ast/ast.dart';
 import 'package:analyzer/dart/element/element.dart';
 import 'package:analyzer/dart/element/type.dart';
 import 'package:analyzer/dart/constant/value.dart';
@@ -81,10 +82,12 @@ JsonKeyWithConversion _from(
   Object defaultValueLiteral;
   if (isEnum(defaultValueObject.type)) {
     var interfaceType = defaultValueObject.type as InterfaceType;
-    var allowedValues = interfaceType.accessors
-        .where((p) => p.returnType == interfaceType)
-        .map((p) => p.name)
-        .toList();
+    var unit = defaultValueObject.type.element.unit;
+    var declaration = unit.declarations.singleWhere((unit) =>
+            unit is EnumDeclaration && unit.element == interfaceType.element)
+        as EnumDeclaration;
+    var allowedValues = declaration.constants.map((p) => p.name).toList();
+
     var enumValueIndex = defaultValueObject.getField('index').toIntValue();
     defaultValueLiteral =
         '${interfaceType.name}.${allowedValues[enumValueIndex]}';


### PR DESCRIPTION
@scheglov @bwilkerson as you can likely tell be recent issues ( https://github.com/dart-lang/sdk/issues/33373 https://github.com/dart-lang/sdk/issues/33375 ) I'm looking at some code that details with enums.

Look at the diff here. Both before and after have their own code smell – is one preferred? Is there something I'm missing?

Thanks!