### PR TITLE
Add option for `explicitToJson`

### DIFF
--- a/json_serializable/CHANGELOG.md
+++ b/json_serializable/CHANGELOG.md
@@ -17,6 +17,8 @@
 * Added missing `checked` parameter to the
   `JsonSerializableGenerator.withDefaultHelpers` constructor.
 
+* Added `explicit_to_json` configuration option.
+
 ## 0.5.6
 
 * Added support for `JsonSerializable.disallowUnrecognizedKeys`.

--- a/json_serializable/README.md
+++ b/json_serializable/README.md
@@ -92,6 +92,7 @@ targets:
           use_wrappers: true
           any_map: true
           checked: true
+          explicit_to_json: true
 ```
 
 [example]: https://github.com/dart-lang/json_serializable/blob/master/example

--- a/json_serializable/lib/builder.dart
+++ b/json_serializable/lib/builder.dart
@@ -26,10 +26,12 @@ Builder jsonSerializable(BuilderOptions options) {
   var optionsMap = new Map<String, dynamic>.from(options.config);
 
   var builder = jsonPartBuilder(
-      header: optionsMap.remove('header') as String,
-      useWrappers: optionsMap.remove('use_wrappers') as bool,
-      checked: optionsMap.remove('checked') as bool,
-      anyMap: optionsMap.remove('any_map') as bool);
+    header: optionsMap.remove('header') as String,
+    useWrappers: optionsMap.remove('use_wrappers') as bool,
+    checked: optionsMap.remove('checked') as bool,
+    anyMap: optionsMap.remove('any_map') as bool,
+    explicitToJson: optionsMap.remove('explicit_to_json') as bool,
+  );
 
   if (optionsMap.isNotEmpty) {
     if (log == null) {

--- a/json_serializable/lib/src/json_part_builder.dart
+++ b/json_serializable/lib/src/json_part_builder.dart
@@ -20,15 +20,21 @@ import 'json_serializable_generator.dart';
 ///
 /// For details on [useWrappers], [anyMap], and [checked] see
 /// [JsonSerializableGenerator].
-Builder jsonPartBuilder(
-    {String header,
-    String formatOutput(String code),
-    bool useWrappers: false,
-    bool anyMap: false,
-    bool checked: false}) {
+Builder jsonPartBuilder({
+  String header,
+  String formatOutput(String code),
+  bool useWrappers: false,
+  bool anyMap: false,
+  bool checked: false,
+  bool explicitToJson: false,
+}) {
   return new PartBuilder([
     new JsonSerializableGenerator(
-        useWrappers: useWrappers, anyMap: anyMap, checked: checked),
+      useWrappers: useWrappers,
+      anyMap: anyMap,
+      checked: checked,
+      explicitToJson: explicitToJson,
+    ),
     const JsonLiteralGenerator()
   ], header: header, formatOutput: formatOutput);
 }

--- a/json_serializable/lib/src/json_serializable_generator.dart
+++ b/json_serializable/lib/src/json_serializable_generator.dart
@@ -68,6 +68,26 @@ class JsonSerializableGenerator
   /// [CheckedFromJsonException] is thrown.
   final bool checked;
 
+  /// If `true`, generated `toJson` methods will explicitly call `toJson` on
+  /// nested objects.
+  ///
+  /// When using JSON encoding support in `dart:convert`, `toJson` is
+  /// automatically called on objects, so the default behavior
+  /// (`explicitToJson: false`) is to omit the `toJson` call.
+  ///
+  /// Example of `explicitToJson: false` (default)
+  ///
+  /// ```dart
+  /// Map<String, dynamic> toJson() => {'child': child};
+  /// ```
+  ///
+  /// Example of `explicitToJson: true`
+  ///
+  /// ```dart
+  /// Map<String, dynamic> toJson() => {'child': child?.toJson()};
+  /// ```
+  final bool explicitToJson;
+
   /// Creates an instance of [JsonSerializableGenerator].
   ///
   /// If [typeHelpers] is not provided, three built-in helpers are used:
@@ -77,9 +97,11 @@ class JsonSerializableGenerator
     bool useWrappers: false,
     bool anyMap: false,
     bool checked: false,
+    bool explicitToJson: false,
   })  : this.useWrappers = useWrappers ?? false,
         this.anyMap = anyMap ?? false,
         this.checked = checked ?? false,
+        this.explicitToJson = explicitToJson ?? false,
         this._typeHelpers = typeHelpers ?? _defaultHelpers;
 
   /// Creates an instance of [JsonSerializableGenerator].

--- a/json_serializable/lib/src/type_helper_context.dart
+++ b/json_serializable/lib/src/type_helper_context.dart
@@ -21,6 +21,8 @@ class TypeHelperContext implements SerializeContext, DeserializeContext {
 
   bool get anyMap => _generator.anyMap;
 
+  bool get explicitToJson => _generator.explicitToJson;
+
   @override
   bool get nullable => _key.nullable;
 

--- a/json_serializable/lib/src/type_helpers/json_helper.dart
+++ b/json_serializable/lib/src/type_helpers/json_helper.dart
@@ -21,11 +21,15 @@ class JsonHelper extends TypeHelper {
   /// By default, JSON encoding in from `dart:convert` calls `toJson()` on
   /// provided objects.
   @override
-  String serialize(DartType targetType, String expression, _) {
+  String serialize(
+      DartType targetType, String expression, SerializeContext context) {
     if (!_canSerialize(targetType)) {
       return null;
     }
 
+    if (context is TypeHelperContext && context.explicitToJson) {
+      return '$expression${context.nullable ? '?' : ''}.toJson()';
+    }
     return expression;
   }
 

--- a/json_serializable/test/config_test.dart
+++ b/json_serializable/test/config_test.dart
@@ -100,12 +100,14 @@ const _validConfig = const {
   'header': 'header',
   'use_wrappers': true,
   'any_map': true,
-  'checked': true
+  'checked': true,
+  'explicit_to_json': true
 };
 
 const _invalidConfig = const {
   'header': true,
   'use_wrappers': 42,
   'any_map': 42,
-  'checked': 42
+  'checked': 42,
+  'explicit_to_json': 42
 };

--- a/json_serializable/test/json_serializable_test.dart
+++ b/json_serializable/test/json_serializable_test.dart
@@ -66,6 +66,99 @@ void _registerTests(JsonSerializableGenerator generator) {
         _throwsInvalidGenerationSourceError(messageMatcher, todoMatcher));
   }
 
+  group('explicit toJson', () {
+    test('nullable', () async {
+      var output = await _runForElementNamed(
+          new JsonSerializableGenerator(
+              explicitToJson: true, useWrappers: generator.useWrappers),
+          'TrivialNestedNullable');
+
+      var expected = generator.useWrappers
+          ? r'''abstract class _$TrivialNestedNullableSerializerMixin {
+  TrivialNestedNullable get child;
+  int get otherField;
+  Map<String, dynamic> toJson() =>
+      new _$TrivialNestedNullableJsonMapWrapper(this);
+}
+
+class _$TrivialNestedNullableJsonMapWrapper extends $JsonMapWrapper {
+  final _$TrivialNestedNullableSerializerMixin _v;
+  _$TrivialNestedNullableJsonMapWrapper(this._v);
+
+  @override
+  Iterable<String> get keys => const ['child', 'otherField'];
+
+  @override
+  dynamic operator [](Object key) {
+    if (key is String) {
+      switch (key) {
+        case 'child':
+          return _v.child?.toJson();
+        case 'otherField':
+          return _v.otherField;
+      }
+    }
+    return null;
+  }
+}
+'''
+          : r'''abstract class _$TrivialNestedNullableSerializerMixin {
+  TrivialNestedNullable get child;
+  int get otherField;
+  Map<String, dynamic> toJson() =>
+      <String, dynamic>{'child': child?.toJson(), 'otherField': otherField};
+}
+''';
+
+      expect(output, expected);
+    });
+    test('non-nullable', () async {
+      var output = await _runForElementNamed(
+          new JsonSerializableGenerator(
+              explicitToJson: true, useWrappers: generator.useWrappers),
+          'TrivialNestedNonNullable');
+
+      var expected = generator.useWrappers
+          ? r'''abstract class _$TrivialNestedNonNullableSerializerMixin {
+  TrivialNestedNonNullable get child;
+  int get otherField;
+  Map<String, dynamic> toJson() =>
+      new _$TrivialNestedNonNullableJsonMapWrapper(this);
+}
+
+class _$TrivialNestedNonNullableJsonMapWrapper extends $JsonMapWrapper {
+  final _$TrivialNestedNonNullableSerializerMixin _v;
+  _$TrivialNestedNonNullableJsonMapWrapper(this._v);
+
+  @override
+  Iterable<String> get keys => const ['child', 'otherField'];
+
+  @override
+  dynamic operator [](Object key) {
+    if (key is String) {
+      switch (key) {
+        case 'child':
+          return _v.child.toJson();
+        case 'otherField':
+          return _v.otherField;
+      }
+    }
+    return null;
+  }
+}
+'''
+          : r'''abstract class _$TrivialNestedNonNullableSerializerMixin {
+  TrivialNestedNonNullable get child;
+  int get otherField;
+  Map<String, dynamic> toJson() =>
+      <String, dynamic>{'child': child.toJson(), 'otherField': otherField};
+}
+''';
+
+      expect(output, expected);
+    });
+  });
+
   group('non-classes', () {
     test('const field', () {
       expectThrows('theAnswer', 'Generator cannot target `theAnswer`.',

--- a/json_serializable/test/src/json_serializable_test_input.dart
+++ b/json_serializable/test/src/json_serializable_test_input.dart
@@ -220,3 +220,15 @@ class SuperType {
   int priceFraction(int other) =>
       superTypeViaCtor == null ? null : superTypeViaCtor ~/ other;
 }
+
+@JsonSerializable(createFactory: false)
+class TrivialNestedNullable {
+  TrivialNestedNullable child;
+  int otherField;
+}
+
+@JsonSerializable(createFactory: false, nullable: false)
+class TrivialNestedNonNullable {
+  TrivialNestedNonNullable child;
+  int otherField;
+}


### PR DESCRIPTION
Allows users to opt-in to including `.toJson()` calls on nested
objects in generated `toJson` methods.

This is useful if you want to round-trip the output of toJson without
putting it through jsonEncode and jsonDecode

Fixes #192