### PR TITLE
Added new generate_to_json_function build option

### DIFF
--- a/json_annotation/CHANGELOG.md
+++ b/json_annotation/CHANGELOG.md
@@ -16,6 +16,9 @@
   `DisallowedNullValueException` that is thrown when corresponding keys exist in
   a source JSON map, but their values are `null`.
 
+* Updated documentation of `JsonSerializable.createToJson` to include details
+  of the new `generate_to_json_function` configuration option.
+
 ## 0.2.7+1
 
 * Small improvement to `UnrecognizedKeysException.message` output and

--- a/json_annotation/lib/src/json_serializable.dart
+++ b/json_annotation/lib/src/json_serializable.dart
@@ -25,15 +25,29 @@ class JsonSerializable {
   /// ```
   final bool createFactory;
 
-  /// If `true` (the default), a private `_$ClassNameMixin` class is created
+  /// If `true` (the default), code for decoding JSON is generated fon this
+  /// class.
+  ///
+  /// By default, a private `_$ClassNameMixin` class is created
   /// in the generated part file which contains a `toJson` method.
   ///
   /// Mix in this class to the source class:
   ///
   /// ```dart
   /// @JsonSerializable()
-  /// class Example extends Object with _$ExampleMixin {
+  /// class Example extends Object with _$ExampleSerializerMixin {
   ///   // ...
+  /// }
+  /// ```
+  ///
+  /// If `json_serializable` is configured with
+  /// `generate_to_json_function: true`, then a top-level function is created
+  /// that you can reference from your class.
+  ///
+  /// ```dart
+  /// @JsonSerializable()
+  /// class Example {
+  ///   Map<String, dynamic> toJson() => _$ExampleToJson(this);
   /// }
   /// ```
   final bool createToJson;

--- a/json_serializable/CHANGELOG.md
+++ b/json_serializable/CHANGELOG.md
@@ -18,6 +18,10 @@
   `JsonSerializableGenerator.withDefaultHelpers` constructor.
 
 * Added `explicit_to_json` configuration option.
+  * See `JsonSerializableGenerator.explicitToJson` for details.
+
+* Added `generate_to_json_function` configuration option.
+  * See `JsonSerializableGenerator.generateToJsonFunction` for details.
 
 ## 0.5.6
 

--- a/json_serializable/README.md
+++ b/json_serializable/README.md
@@ -93,6 +93,7 @@ targets:
           any_map: true
           checked: true
           explicit_to_json: true
+          generate_to_json_function: true
 ```
 
 [example]: https://github.com/dart-lang/json_serializable/blob/master/example

--- a/json_serializable/lib/builder.dart
+++ b/json_serializable/lib/builder.dart
@@ -31,6 +31,8 @@ Builder jsonSerializable(BuilderOptions options) {
     checked: optionsMap.remove('checked') as bool,
     anyMap: optionsMap.remove('any_map') as bool,
     explicitToJson: optionsMap.remove('explicit_to_json') as bool,
+    generateToJsonFunction:
+        optionsMap.remove('generate_to_json_function') as bool,
   );
 
   if (optionsMap.isNotEmpty) {

--- a/json_serializable/lib/src/json_part_builder.dart
+++ b/json_serializable/lib/src/json_part_builder.dart
@@ -27,6 +27,7 @@ Builder jsonPartBuilder({
   bool anyMap: false,
   bool checked: false,
   bool explicitToJson: false,
+  bool generateToJsonFunction: false,
 }) {
   return new PartBuilder([
     new JsonSerializableGenerator(
@@ -34,6 +35,7 @@ Builder jsonPartBuilder({
       anyMap: anyMap,
       checked: checked,
       explicitToJson: explicitToJson,
+      generateToJsonFunction: generateToJsonFunction,
     ),
     const JsonLiteralGenerator()
   ], header: header, formatOutput: formatOutput);

--- a/json_serializable/lib/src/json_serializable_generator.dart
+++ b/json_serializable/lib/src/json_serializable_generator.dart
@@ -88,6 +88,33 @@ class JsonSerializableGenerator
   /// ```
   final bool explicitToJson;
 
+  /// Controls how `toJson` functionality is generated for all types processed
+  /// by this generator.
+  ///
+  /// If `false` (the default), a private `_$ClassNameSerializerMixin` class is
+  /// created in the generated part file which contains a `toJson` method.
+  ///
+  /// Mix in this class to the source class:
+  ///
+  /// ```dart
+  /// @JsonSerializable()
+  /// class Example extends Object with _$ExampleSerializerMixin {
+  ///   // ...
+  /// }
+  /// ```
+  ///
+  /// If `true`, then a top-level function is created that you can reference
+  /// from your class.
+  ///
+  /// ```dart
+  /// @JsonSerializable()
+  /// class Example {
+  ///   // ...
+  ///   Map<String, dynamic> toJson() => _$ExampleToJson(this);
+  /// }
+  /// ```
+  final bool generateToJsonFunction;
+
   /// Creates an instance of [JsonSerializableGenerator].
   ///
   /// If [typeHelpers] is not provided, three built-in helpers are used:
@@ -98,10 +125,12 @@ class JsonSerializableGenerator
     bool anyMap: false,
     bool checked: false,
     bool explicitToJson: false,
+    bool generateToJsonFunction: false,
   })  : this.useWrappers = useWrappers ?? false,
         this.anyMap = anyMap ?? false,
         this.checked = checked ?? false,
         this.explicitToJson = explicitToJson ?? false,
+        this.generateToJsonFunction = generateToJsonFunction ?? false,
         this._typeHelpers = typeHelpers ?? _defaultHelpers;
 
   /// Creates an instance of [JsonSerializableGenerator].
@@ -114,11 +143,13 @@ class JsonSerializableGenerator
     bool useWrappers: false,
     bool anyMap: false,
     bool checked: false,
+    bool generateToJsonFunction: false,
   }) =>
       new JsonSerializableGenerator(
           useWrappers: useWrappers,
           anyMap: anyMap,
           checked: checked,
+          generateToJsonFunction: generateToJsonFunction,
           typeHelpers:
               new List.unmodifiable(typeHelpers.followedBy(_defaultHelpers)));
 

--- a/json_serializable/test/config_test.dart
+++ b/json_serializable/test/config_test.dart
@@ -101,7 +101,8 @@ const _validConfig = const {
   'use_wrappers': true,
   'any_map': true,
   'checked': true,
-  'explicit_to_json': true
+  'explicit_to_json': true,
+  'generate_to_json_function': true,
 };
 
 const _invalidConfig = const {
@@ -109,5 +110,6 @@ const _invalidConfig = const {
   'use_wrappers': 42,
   'any_map': 42,
   'checked': 42,
-  'explicit_to_json': 42
+  'explicit_to_json': 42,
+  'generate_to_json_function': 42,
 };

--- a/json_serializable/test/default_value/default_value.checked.dart
+++ b/json_serializable/test/default_value/default_value.checked.dart
@@ -23,9 +23,7 @@ dvi.DefaultValue fromJson(Map<String, dynamic> json) =>
     _$DefaultValueFromJson(json);
 
 @JsonSerializable()
-class DefaultValue extends Object
-    with _$DefaultValueSerializerMixin
-    implements dvi.DefaultValue {
+class DefaultValue implements dvi.DefaultValue {
   @JsonKey(defaultValue: true)
   bool fieldBool;
 
@@ -62,4 +60,6 @@ class DefaultValue extends Object
 
   factory DefaultValue.fromJson(Map<String, dynamic> json) =>
       _$DefaultValueFromJson(json);
+
+  Map<String, dynamic> toJson() => _$DefaultValueToJson(this);
 }

--- a/json_serializable/test/default_value/default_value.checked.g.dart
+++ b/json_serializable/test/default_value/default_value.checked.g.dart
@@ -53,37 +53,25 @@ DefaultValue _$DefaultValueFromJson(Map json) {
   });
 }
 
-abstract class _$DefaultValueSerializerMixin {
-  bool get fieldBool;
-  String get fieldString;
-  int get fieldInt;
-  double get fieldDouble;
-  List<dynamic> get fieldListEmpty;
-  Map<dynamic, dynamic> get fieldMapEmpty;
-  List<int> get fieldListSimple;
-  Map<String, int> get fieldMapSimple;
-  Map<String, List<String>> get fieldMapListString;
-  Greek get fieldEnum;
-  Map<String, dynamic> toJson() {
-    var val = <String, dynamic>{
-      'fieldBool': fieldBool,
-    };
+Map<String, dynamic> _$DefaultValueToJson(DefaultValue instance) {
+  var val = <String, dynamic>{
+    'fieldBool': instance.fieldBool,
+  };
 
-    void writeNotNull(String key, dynamic value) {
-      if (value != null) {
-        val[key] = value;
-      }
+  void writeNotNull(String key, dynamic value) {
+    if (value != null) {
+      val[key] = value;
     }
-
-    writeNotNull('fieldString', fieldString);
-    val['fieldInt'] = fieldInt;
-    val['fieldDouble'] = fieldDouble;
-    val['fieldListEmpty'] = fieldListEmpty;
-    val['fieldMapEmpty'] = fieldMapEmpty;
-    val['fieldListSimple'] = fieldListSimple;
-    val['fieldMapSimple'] = fieldMapSimple;
-    val['fieldMapListString'] = fieldMapListString;
-    val['fieldEnum'] = fieldEnum?.toString()?.split('.')?.last;
-    return val;
   }
+
+  writeNotNull('fieldString', instance.fieldString);
+  val['fieldInt'] = instance.fieldInt;
+  val['fieldDouble'] = instance.fieldDouble;
+  val['fieldListEmpty'] = instance.fieldListEmpty;
+  val['fieldMapEmpty'] = instance.fieldMapEmpty;
+  val['fieldListSimple'] = instance.fieldListSimple;
+  val['fieldMapSimple'] = instance.fieldMapSimple;
+  val['fieldMapListString'] = instance.fieldMapListString;
+  val['fieldEnum'] = instance.fieldEnum?.toString()?.split('.')?.last;
+  return val;
 }

--- a/json_serializable/test/default_value/default_value.dart
+++ b/json_serializable/test/default_value/default_value.dart
@@ -17,9 +17,7 @@ dvi.DefaultValue fromJson(Map<String, dynamic> json) =>
     _$DefaultValueFromJson(json);
 
 @JsonSerializable()
-class DefaultValue extends Object
-    with _$DefaultValueSerializerMixin
-    implements dvi.DefaultValue {
+class DefaultValue implements dvi.DefaultValue {
   @JsonKey(defaultValue: true)
   bool fieldBool;
 
@@ -56,4 +54,6 @@ class DefaultValue extends Object
 
   factory DefaultValue.fromJson(Map<String, dynamic> json) =>
       _$DefaultValueFromJson(json);
+
+  Map<String, dynamic> toJson() => _$DefaultValueToJson(this);
 }

--- a/json_serializable/test/default_value/default_value.g.dart
+++ b/json_serializable/test/default_value/default_value.g.dart
@@ -35,37 +35,25 @@ DefaultValue _$DefaultValueFromJson(Map<String, dynamic> json) {
         Greek.beta;
 }
 
-abstract class _$DefaultValueSerializerMixin {
-  bool get fieldBool;
-  String get fieldString;
-  int get fieldInt;
-  double get fieldDouble;
-  List<dynamic> get fieldListEmpty;
-  Map<dynamic, dynamic> get fieldMapEmpty;
-  List<int> get fieldListSimple;
-  Map<String, int> get fieldMapSimple;
-  Map<String, List<String>> get fieldMapListString;
-  Greek get fieldEnum;
-  Map<String, dynamic> toJson() {
-    var val = <String, dynamic>{
-      'fieldBool': fieldBool,
-    };
+Map<String, dynamic> _$DefaultValueToJson(DefaultValue instance) {
+  var val = <String, dynamic>{
+    'fieldBool': instance.fieldBool,
+  };
 
-    void writeNotNull(String key, dynamic value) {
-      if (value != null) {
-        val[key] = value;
-      }
+  void writeNotNull(String key, dynamic value) {
+    if (value != null) {
+      val[key] = value;
     }
-
-    writeNotNull('fieldString', fieldString);
-    val['fieldInt'] = fieldInt;
-    val['fieldDouble'] = fieldDouble;
-    val['fieldListEmpty'] = fieldListEmpty;
-    val['fieldMapEmpty'] = fieldMapEmpty;
-    val['fieldListSimple'] = fieldListSimple;
-    val['fieldMapSimple'] = fieldMapSimple;
-    val['fieldMapListString'] = fieldMapListString;
-    val['fieldEnum'] = fieldEnum?.toString()?.split('.')?.last;
-    return val;
   }
+
+  writeNotNull('fieldString', instance.fieldString);
+  val['fieldInt'] = instance.fieldInt;
+  val['fieldDouble'] = instance.fieldDouble;
+  val['fieldListEmpty'] = instance.fieldListEmpty;
+  val['fieldMapEmpty'] = instance.fieldMapEmpty;
+  val['fieldListSimple'] = instance.fieldListSimple;
+  val['fieldMapSimple'] = instance.fieldMapSimple;
+  val['fieldMapListString'] = instance.fieldMapListString;
+  val['fieldEnum'] = instance.fieldEnum?.toString()?.split('.')?.last;
+  return val;
 }

--- a/json_serializable/test/default_value/default_value_interface.dart
+++ b/json_serializable/test/default_value/default_value_interface.dart
@@ -6,8 +6,6 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
-// ignore_for_file: annotate_overrides
-
 abstract class DefaultValue {
   bool fieldBool;
   String fieldString;

--- a/json_serializable/test/generic_files/generic_class.dart
+++ b/json_serializable/test/generic_files/generic_class.dart
@@ -2,15 +2,12 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
-// ignore_for_file: annotate_overrides
-
 import 'package:json_annotation/json_annotation.dart';
 
 part 'generic_class.g.dart';
 
 @JsonSerializable()
-class GenericClass<T extends num, S> extends Object
-    with _$GenericClassSerializerMixin<T, S> {
+class GenericClass<T extends num, S> {
   @JsonKey(fromJson: _dataFromJson, toJson: _dataToJson)
   Object fieldObject;
 
@@ -30,6 +27,8 @@ class GenericClass<T extends num, S> extends Object
 
   factory GenericClass.fromJson(Map<String, dynamic> json) =>
       _$GenericClassFromJson<T, S>(json);
+
+  Map<String, dynamic> toJson() => _$GenericClassToJson(this);
 }
 
 T _dataFromJson<T, S, U>(Map<String, dynamic> input, [S other1, U other2]) =>

--- a/json_serializable/test/generic_files/generic_class.g.dart
+++ b/json_serializable/test/generic_files/generic_class.g.dart
@@ -30,17 +30,17 @@ GenericClass<T, S> _$GenericClassFromJson<T extends num, S>(
         : _dataFromJson(json['fieldS'] as Map<String, dynamic>);
 }
 
-abstract class _$GenericClassSerializerMixin<T extends num, S> {
-  Object get fieldObject;
-  dynamic get fieldDynamic;
-  int get fieldInt;
-  T get fieldT;
-  S get fieldS;
-  Map<String, dynamic> toJson() => <String, dynamic>{
-        'fieldObject': fieldObject == null ? null : _dataToJson(fieldObject),
-        'fieldDynamic': fieldDynamic == null ? null : _dataToJson(fieldDynamic),
-        'fieldInt': fieldInt == null ? null : _dataToJson(fieldInt),
-        'fieldT': fieldT == null ? null : _dataToJson(fieldT),
-        'fieldS': fieldS == null ? null : _dataToJson(fieldS)
-      };
-}
+Map<String, dynamic> _$GenericClassToJson<T extends num, S>(
+        GenericClass<T, S> instance) =>
+    <String, dynamic>{
+      'fieldObject': instance.fieldObject == null
+          ? null
+          : _dataToJson(instance.fieldObject),
+      'fieldDynamic': instance.fieldDynamic == null
+          ? null
+          : _dataToJson(instance.fieldDynamic),
+      'fieldInt':
+          instance.fieldInt == null ? null : _dataToJson(instance.fieldInt),
+      'fieldT': instance.fieldT == null ? null : _dataToJson(instance.fieldT),
+      'fieldS': instance.fieldS == null ? null : _dataToJson(instance.fieldS)
+    };

--- a/json_serializable/test/generic_files/generic_class.wrapped.dart
+++ b/json_serializable/test/generic_files/generic_class.wrapped.dart
@@ -8,15 +8,12 @@
 // Generator: _WrappedGenerator
 // **************************************************************************
 
-// ignore_for_file: annotate_overrides
-
 import 'package:json_annotation/json_annotation.dart';
 
 part 'generic_class.wrapped.g.dart';
 
 @JsonSerializable()
-class GenericClass<T extends num, S> extends Object
-    with _$GenericClassSerializerMixin<T, S> {
+class GenericClass<T extends num, S> {
   @JsonKey(fromJson: _dataFromJson, toJson: _dataToJson)
   Object fieldObject;
 
@@ -36,6 +33,8 @@ class GenericClass<T extends num, S> extends Object
 
   factory GenericClass.fromJson(Map<String, dynamic> json) =>
       _$GenericClassFromJson<T, S>(json);
+
+  Map<String, dynamic> toJson() => _$GenericClassToJson(this);
 }
 
 T _dataFromJson<T, S, U>(Map<String, dynamic> input, [S other1, U other2]) =>

--- a/json_serializable/test/generic_files/generic_class.wrapped.g.dart
+++ b/json_serializable/test/generic_files/generic_class.wrapped.g.dart
@@ -30,17 +30,12 @@ GenericClass<T, S> _$GenericClassFromJson<T extends num, S>(
         : _dataFromJson(json['fieldS'] as Map<String, dynamic>);
 }
 
-abstract class _$GenericClassSerializerMixin<T extends num, S> {
-  Object get fieldObject;
-  dynamic get fieldDynamic;
-  int get fieldInt;
-  T get fieldT;
-  S get fieldS;
-  Map<String, dynamic> toJson() => new _$GenericClassJsonMapWrapper<T, S>(this);
-}
+Map<String, dynamic> _$GenericClassToJson<T extends num, S>(
+        GenericClass<T, S> instance) =>
+    new _$GenericClassJsonMapWrapper<T, S>(instance);
 
 class _$GenericClassJsonMapWrapper<T extends num, S> extends $JsonMapWrapper {
-  final _$GenericClassSerializerMixin<T, S> _v;
+  final GenericClass<T, S> _v;
   _$GenericClassJsonMapWrapper(this._v);
 
   @override

--- a/json_serializable/tool/build.dart
+++ b/json_serializable/tool/build.dart
@@ -13,11 +13,13 @@ import 'package:json_serializable/src/json_part_builder.dart' as jpb;
 
 import 'builder.dart';
 
-Builder _jsonPartBuilder(
-    {bool useWrappers: false,
-    bool anyMap: false,
-    bool checked: false,
-    bool format}) {
+Builder _jsonPartBuilder({
+  bool useWrappers,
+  bool anyMap,
+  bool checked,
+  bool format,
+  bool generateToJsonFunction,
+}) {
   format ??= true;
   String Function(String code) formatOutput;
 
@@ -30,7 +32,8 @@ Builder _jsonPartBuilder(
       formatOutput: formatOutput,
       useWrappers: useWrappers,
       anyMap: anyMap,
-      checked: checked);
+      checked: checked,
+      generateToJsonFunction: generateToJsonFunction);
 }
 
 final List<BuilderApplication> builders = [
@@ -56,11 +59,16 @@ final List<BuilderApplication> builders = [
       generateFor: const InputSet(
         include: const [
           'example/example.dart',
-          'test/default_value/default_value.dart',
-          'test/generic_files/generic_class.dart',
           'test/test_files/json_literal.dart',
           'test/test_files/json_test_example.dart',
           'test/test_files/json_test_example.non_nullable.dart'
+        ],
+      )),
+  applyToRoot(_jsonPartBuilder(generateToJsonFunction: true),
+      generateFor: const InputSet(
+        include: const [
+          'test/generic_files/generic_class.dart',
+          'test/default_value/default_value.dart',
         ],
       )),
   applyToRoot(_jsonPartBuilder(anyMap: true),
@@ -75,16 +83,28 @@ final List<BuilderApplication> builders = [
   applyToRoot(_jsonPartBuilder(checked: true, anyMap: true),
       generateFor: const InputSet(
         include: const [
-          'test/default_value/default_value.checked.dart',
           'test/kitchen_sink/kitchen_sink.non_nullable.checked.dart',
           'test/yaml/build_config.dart',
+        ],
+      )),
+  applyToRoot(
+      _jsonPartBuilder(
+          checked: true, anyMap: true, generateToJsonFunction: true),
+      generateFor: const InputSet(
+        include: const [
+          'test/default_value/default_value.checked.dart',
         ],
       )),
   applyToRoot(_jsonPartBuilder(useWrappers: true),
       generateFor: const InputSet(
         include: const [
-          'test/generic_files/generic_class*wrapped.dart',
           'test/test_files/json_test_example*wrapped.dart',
+        ],
+      )),
+  applyToRoot(_jsonPartBuilder(useWrappers: true, generateToJsonFunction: true),
+      generateFor: const InputSet(
+        include: const [
+          'test/generic_files/generic_class*wrapped.dart',
         ],
       )),
   applyToRoot(_jsonPartBuilder(useWrappers: true, anyMap: true),


### PR DESCRIPTION
Controls how `toJson` functionality is generated for all types processed
by this generator.

If `false` (the default), a private `_$ClassNameSerializerMixin` class is
created in the generated part file which contains a `toJson` method.

Mix in this class to the source class:

```dart
@JsonSerializable()
class Example extends Object with _$ExampleSerializerMixin {
  // ...
}
```

If `true`, then a top-level function is created that you can reference
from your class.

```dart
@JsonSerializable()
class Example {
  // ...
  Map<String, dynamic> toJson() => _$ExampleToJson(this);
}
```