### PR TITLE
feature: allow customizing enum value serialization via annotations

### DIFF
--- a/json_annotation/CHANGELOG.md
+++ b/json_annotation/CHANGELOG.md
@@ -1,3 +1,11 @@
+## 0.3.0
+
+* Added `JsonValue` class for annotating `enum` fields with a custom
+  serialization value.
+
+* Removed `$checkAllowedKeys`, `$enumDecode` and `$enumDecodeNullable` which are
+  no longer needed by the latest release of `package:json_serializable`.
+
 ## 0.2.9
 
 * When `FormatException` is caught in "checked mode", use the `message`

--- a/json_annotation/lib/src/allowed_keys_helpers.dart
+++ b/json_annotation/lib/src/allowed_keys_helpers.dart
@@ -2,17 +2,6 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
-/// **DEPRECATED** Helper function used in generated code when
-/// `JsonSerializable.disallowUnrecognizedKeys` is `true`.
-///
-/// Should not be used directly.
-@Deprecated('Code generated with the latest `json_serializable` will use '
-    '`\$checkKeys` instead. This function will be removed in the next major '
-    'release.')
-void $checkAllowedKeys(Map map, Iterable<String> allowedKeys) {
-  $checkKeys(map, allowedKeys: allowedKeys?.toList());
-}
-
 /// Helper function used in generated `fromJson` code when
 /// `JsonSerializable.disallowUnrecognizedKeys` is true for an annotated type or
 /// `JsonKey.required` is `true` for any annotated fields.

--- a/json_annotation/lib/src/json_serializable.dart
+++ b/json_annotation/lib/src/json_serializable.dart
@@ -200,5 +200,6 @@ class JsonValue {
   ///
   /// Can be a [String] or an [int].
   final dynamic value;
+
   const JsonValue(this.value);
 }

--- a/json_annotation/lib/src/json_serializable.dart
+++ b/json_annotation/lib/src/json_serializable.dart
@@ -194,44 +194,11 @@ class JsonKey {
   });
 }
 
-// Until enum supports parse: github.com/dart-lang/sdk/issues/33244
-/// *Helper function used in generated code with `enum` values – should not be
-/// used directly.*
-///
-/// Returns an enum instance corresponding to [enumValue] from the enum named
-/// [enumName] with [values].
-///
-/// If [enumValue] is null or no corresponding values exists, an `ArgumentError`
-/// is thrown.
-///
-/// Given an enum named `Example`, an invocation would look like
-///
-/// ```dart
-/// $enumDecode('Example', Example.values, 'desiredValue')
-/// ```
-T $enumDecode<T>(String enumName, List<T> values, String enumValue) =>
-    values.singleWhere((e) => e.toString() == '$enumName.$enumValue',
-        orElse: () => throw new ArgumentError(
-            '`$enumValue` is not one of the supported values: '
-            '${values.map(_nameForEnumValue).join(', ')}'));
-
-/// *Helper function used in generated code with `enum` values – should not be
-/// used directly.*
-///
-/// Returns an enum instance corresponding to [enumValue] from the enum named
-/// [enumName] with [values].
-///
-/// If [enumValue] is `null`, `null` is returned.
-///
-/// If no corresponding values exists, an `ArgumentError` is thrown.
-///
-/// Given an enum named `Example`, an invocation would look like
-///
-/// ```dart
-/// $enumDecodeNullable('Example', Example.values, 'desiredValue')
-/// ```
-T $enumDecodeNullable<T>(String enumName, List<T> values, String enumValue) =>
-    enumValue == null ? null : $enumDecode(enumName, values, enumValue);
-
-// Until enum has a name property: github.com/dart-lang/sdk/issues/21712
-String _nameForEnumValue(Object value) => value.toString().split('.')[1];
+/// An annotation used to specify how a enum value is serialized.
+class JsonValue {
+  /// The value to use when serializing and deserializing.
+  ///
+  /// Can be a [String] or an [int].
+  final dynamic value;
+  const JsonValue(this.value);
+}

--- a/json_annotation/pubspec.yaml
+++ b/json_annotation/pubspec.yaml
@@ -1,5 +1,5 @@
 name: json_annotation
-version: 0.2.9
+version: 0.3.0-dev
 description: >-
   Classes and helper functions that support JSON code generation via the
   `json_serializable` package.

--- a/json_serializable/CHANGELOG.md
+++ b/json_serializable/CHANGELOG.md
@@ -1,3 +1,25 @@
+## 0.6.0
+
+* Now supports changing the serialized values of enums using `JsonValue`.
+
+  ```dart
+  enum AutoApply {
+    none,
+    dependents,
+    @JsonValue('all_packages')
+    allPackages,
+    @JsonValue('root_package')
+    rootPackage
+  }
+  ```
+
+* `JsonSerializableGenerator.generateForAnnotatedElement` now returns
+  `Iterable<String>` instead of `String`.
+
+* `SerializeContext` and `DeserializeContext` now have an `addMember` function
+  which allows `TypeHelper` instances to add additional members when handling
+  a field. This is useful for generating shared helpers, for instance.
+
 ## 0.5.8
 
 * Small fixes to support Dart 2 runtime semantics.

--- a/json_serializable/lib/src/helper_core.dart
+++ b/json_serializable/lib/src/helper_core.dart
@@ -20,6 +20,8 @@ abstract class HelperCore {
 
   HelperCore(this.generator, this.element, this.annotation);
 
+  void addMember(String memberContent);
+
   String get targetClassReference =>
       '${element.name}${genericClassArgumentsImpl(false)}';
 
@@ -41,7 +43,7 @@ abstract class HelperCore {
       new JsonKeyWithConversion(field, annotation);
 
   TypeHelperContext getHelperContext(FieldElement field) =>
-      new TypeHelperContext(generator, field.metadata, jsonKeyFor(field));
+      new TypeHelperContext(this, field.metadata, jsonKeyFor(field));
 }
 
 InvalidGenerationSourceError createInvalidGenerationError(

--- a/json_serializable/lib/src/json_key_with_conversion.dart
+++ b/json_serializable/lib/src/json_key_with_conversion.dart
@@ -79,15 +79,13 @@ JsonKeyWithConversion _from(
   var defaultValueObject = obj.getField('defaultValue');
 
   Object defaultValueLiteral;
-  if (isEnum(defaultValueObject.type)) {
-    var interfaceType = defaultValueObject.type as InterfaceType;
-    var allowedValues = interfaceType.element.fields
-        .where((p) => !p.isSynthetic)
-        .map((p) => p.name)
-        .toList();
+
+  var enumFields = iterateEnumFields(defaultValueObject.type);
+  if (enumFields != null) {
+    var allowedValues = enumFields.map((p) => p.name).toList();
     var enumValueIndex = defaultValueObject.getField('index').toIntValue();
     defaultValueLiteral =
-        '${interfaceType.name}.${allowedValues[enumValueIndex]}';
+        '${defaultValueObject.type.name}.${allowedValues[enumValueIndex]}';
   } else {
     defaultValueLiteral = _getLiteral(defaultValueObject, []);
     if (defaultValueLiteral != null) {

--- a/json_serializable/lib/src/json_literal_generator.dart
+++ b/json_serializable/lib/src/json_literal_generator.dart
@@ -52,7 +52,7 @@ String jsonLiteralAsDart(dynamic value, bool asConst) {
 
   if (value is List) {
     var listItems = value.map((v) => jsonLiteralAsDart(v, asConst)).join(', ');
-    return '${asConst ? 'const' : ''}[$listItems]';
+    return '${asConst ? 'const ' : ''}[$listItems]';
   }
 
   if (value is Map) return jsonMapAsDart(value, asConst);

--- a/json_serializable/lib/src/json_serializable_generator.dart
+++ b/json_serializable/lib/src/json_serializable_generator.dart
@@ -158,7 +158,7 @@ class JsonSerializableGenerator
               new List.unmodifiable(typeHelpers.followedBy(_defaultHelpers)));
 
   @override
-  String generateForAnnotatedElement(
+  Iterable<String> generateForAnnotatedElement(
       Element element, ConstantReader annotation, BuildStep buildStep) {
     if (element is! ClassElement) {
       var name = element.name;
@@ -170,7 +170,7 @@ class JsonSerializableGenerator
     var classElement = element as ClassElement;
     var classAnnotation = valueForAnnotation(annotation);
     var helper = new _GeneratorHelper(this, classElement, classAnnotation);
-    return helper._generate().join('\n\n');
+    return helper._generate();
   }
 }
 
@@ -179,7 +179,15 @@ class _GeneratorHelper extends HelperCore with EncodeHelper, DecodeHelper {
       JsonSerializable annotation)
       : super(generator, element, annotation);
 
+  final _addedMembers = new Set<String>();
+
+  @override
+  void addMember(String memberContent) {
+    _addedMembers.add(memberContent);
+  }
+
   Iterable<String> _generate() sync* {
+    assert(_addedMembers.isEmpty);
     var sortedFields = _createSortedFieldSet(element);
 
     // Used to keep track of why a field is ignored. Useful for providing
@@ -223,6 +231,8 @@ class _GeneratorHelper extends HelperCore with EncodeHelper, DecodeHelper {
     if (annotation.createToJson) {
       yield* createToJson(accessibleFieldSet);
     }
+
+    yield* _addedMembers;
   }
 }
 

--- a/json_serializable/lib/src/type_helper.dart
+++ b/json_serializable/lib/src/type_helper.dart
@@ -6,6 +6,7 @@ import 'package:analyzer/dart/element/element.dart';
 import 'package:analyzer/dart/element/type.dart';
 
 abstract class SerializeContext {
+  /// `true` if [serialize] should handle the case of `expression` being null.
   bool get nullable;
   bool get useWrappers;
 
@@ -13,12 +14,19 @@ abstract class SerializeContext {
   /// representing the serialization of a value.
   String serialize(DartType fieldType, String expression);
   List<ElementAnnotation> get metadata;
+
+  /// Adds [memberContent] to the set of generated, top-level members.
+  void addMember(String memberContent);
 }
 
 abstract class DeserializeContext {
+  /// `true` if [deserialize] should handle the case of `expression` being null.
   bool get nullable;
   String deserialize(DartType fieldType, String expression);
   List<ElementAnnotation> get metadata;
+
+  /// Adds [memberContent] to the set of generated, top-level members.
+  void addMember(String memberContent);
 }
 
 abstract class TypeHelper {

--- a/json_serializable/lib/src/type_helper_context.dart
+++ b/json_serializable/lib/src/type_helper_context.dart
@@ -5,23 +5,25 @@
 import 'package:analyzer/dart/element/element.dart';
 import 'package:analyzer/dart/element/type.dart';
 
+import 'helper_core.dart';
 import 'json_key_with_conversion.dart';
 import 'json_serializable_generator.dart';
 import 'type_helper.dart';
 
 class TypeHelperContext implements SerializeContext, DeserializeContext {
+  final HelperCore _helperCore;
+
   @override
   final List<ElementAnnotation> metadata;
 
-  final JsonSerializableGenerator _generator;
   final JsonKeyWithConversion _key;
 
   @override
-  bool get useWrappers => _generator.useWrappers;
+  bool get useWrappers => _helperCore.generator.useWrappers;
 
-  bool get anyMap => _generator.anyMap;
+  bool get anyMap => _helperCore.generator.anyMap;
 
-  bool get explicitToJson => _generator.explicitToJson;
+  bool get explicitToJson => _helperCore.generator.explicitToJson;
 
   @override
   bool get nullable => _key.nullable;
@@ -29,7 +31,12 @@ class TypeHelperContext implements SerializeContext, DeserializeContext {
   ConvertData get fromJsonData => _key.fromJsonData;
   ConvertData get toJsonData => _key.toJsonData;
 
-  TypeHelperContext(this._generator, this.metadata, this._key);
+  TypeHelperContext(this._helperCore, this.metadata, this._key);
+
+  @override
+  void addMember(String memberContent) {
+    _helperCore.addMember(memberContent);
+  }
 
   @override
   String serialize(DartType targetType, String expression) => _run(
@@ -45,7 +52,8 @@ class TypeHelperContext implements SerializeContext, DeserializeContext {
 
   String _run(DartType targetType, String expression,
           String invoke(TypeHelper instance)) =>
-      allHelpersImpl(_generator).map(invoke).firstWhere((r) => r != null,
+      allHelpersImpl(_helperCore.generator).map(invoke).firstWhere(
+          (r) => r != null,
           orElse: () => throw new UnsupportedTypeError(
               targetType, expression, _notSupportedWithTypeHelpersMsg));
 }

--- a/json_serializable/lib/src/utils.dart
+++ b/json_serializable/lib/src/utils.dart
@@ -27,6 +27,62 @@ JsonSerializable valueForAnnotation(ConstantReader annotation) =>
 bool isEnum(DartType targetType) =>
     targetType is InterfaceType && targetType.element.isEnum;
 
+final _enumMapExpando = new Expando<Map<FieldElement, dynamic>>();
+
+/// If [targetType] is an enum, returns a [Map] of the [FieldElement] instances
+/// associated with the enum values mapped to the [String] values that represent
+/// the serialized output.
+///
+/// By default, the [String] value is just the name of the enum value.
+/// If the enum value is annotated with [JsonKey], then the `name` property is
+/// used if it's set and not `null`.
+///
+/// If [targetType] is not an enum, `null` is returned.
+Map<FieldElement, dynamic> enumFieldsMap(DartType targetType) {
+  if (targetType is InterfaceType && targetType.element.isEnum) {
+    var value = _enumMapExpando[targetType];
+    if (value == null) {
+      _enumMapExpando[targetType] = value =
+          new Map<FieldElement, dynamic>.fromEntries(
+              targetType.element.fields.where((p) => !p.isSynthetic).map((fe) {
+        var annotation =
+            const TypeChecker.fromRuntime(JsonValue).firstAnnotationOfExact(fe);
+
+        dynamic fieldValue;
+        if (annotation == null) {
+          fieldValue = fe.name;
+        } else {
+          var reader = new ConstantReader(annotation);
+
+          var valueReader = reader.read('value');
+
+          if (valueReader.isString || valueReader.isNull || valueReader.isInt) {
+            fieldValue = valueReader.literalValue;
+          } else {
+            throw new InvalidGenerationSourceError(
+                'The `JsonValue` annotation on `$targetType.${fe.name}` does '
+                'not have a value of type String, int, or null.',
+                element: fe);
+          }
+        }
+
+        var entry = new MapEntry(fe, fieldValue);
+
+        return entry;
+      }));
+    }
+    return value;
+  }
+  return null;
+}
+
+/// If [targetType] is an enum, returns the [FieldElement] instances associated
+/// with its values.
+///
+/// Otherwise, `null`.
+Iterable<FieldElement> iterateEnumFields(DartType targetType) =>
+    enumFieldsMap(targetType)?.keys;
+
 /// Returns a quoted String literal for [value] that can be used in generated
 /// Dart code.
 String escapeDartString(String value) {

--- a/json_serializable/pubspec.yaml
+++ b/json_serializable/pubspec.yaml
@@ -1,22 +1,22 @@
 name: json_serializable
-version: 0.5.9-dev
+version: 0.6.0-dev
 author: Dart Team <misc@dartlang.org>
 description: Generates utilities to aid in serializing to/from JSON.
 homepage: https://github.com/dart-lang/json_serializable
 environment:
-  sdk: '>=2.0.0-dev.54 <2.0.0'
+  sdk: '>=2.0.0-dev.65 <2.0.0'
 
 dependencies:
-  analyzer: ^0.32.0
+  analyzer: ^0.32.2
   build: ^0.12.6
   build_config: '>=0.2.6 <0.4.0'
 
   # Use a tight version constraint to ensure that a constraint on
   # `json_annotation`. Properly constrains all features it provides.
-  json_annotation: '>=0.2.9 <0.2.10'
+  json_annotation: '>=0.3.0 <0.3.1'
   meta: ^1.1.0
   path: ^1.3.2
-  source_gen: ^0.8.2
+  source_gen: ^0.8.3
 
 dev_dependencies:
   build_runner: ^0.9.0
@@ -27,3 +27,7 @@ dev_dependencies:
   logging: ^0.11.3+1
   test: ^1.0.0
   yaml: ^2.1.13
+
+dependency_overrides:
+  json_annotation:
+    path: ../json_annotation

--- a/json_serializable/test/default_value/default_value.checked.g.dart
+++ b/json_serializable/test/default_value/default_value.checked.g.dart
@@ -47,8 +47,7 @@ DefaultValue _$DefaultValueFromJson(Map json) {
         json,
         'fieldEnum',
         (v) => val.fieldEnum =
-            $enumDecodeNullable('Greek', Greek.values, v as String) ??
-                Greek.beta);
+            _$enumDecodeNullable(_$GreekEnumMap, v) ?? Greek.beta);
     return val;
   });
 }
@@ -72,6 +71,33 @@ Map<String, dynamic> _$DefaultValueToJson(DefaultValue instance) {
   val['fieldListSimple'] = instance.fieldListSimple;
   val['fieldMapSimple'] = instance.fieldMapSimple;
   val['fieldMapListString'] = instance.fieldMapListString;
-  val['fieldEnum'] = instance.fieldEnum?.toString()?.split('.')?.last;
+  val['fieldEnum'] = _$GreekEnumMap[instance.fieldEnum];
   return val;
 }
+
+T _$enumDecode<T>(Map<T, dynamic> enumValues, dynamic source) {
+  if (source == null) {
+    throw new ArgumentError('A value must be provided. Supported values: '
+        '${enumValues.values.join(', ')}');
+  }
+  return enumValues.entries
+      .singleWhere((e) => e.value == source,
+          orElse: () => throw new ArgumentError(
+              '`$source` is not one of the supported values: '
+              '${enumValues.values.join(', ')}'))
+      .key;
+}
+
+T _$enumDecodeNullable<T>(Map<T, dynamic> enumValues, dynamic source) {
+  if (source == null) {
+    return null;
+  }
+  return _$enumDecode<T>(enumValues, source);
+}
+
+const _$GreekEnumMap = const <Greek, dynamic>{
+  Greek.alpha: 'alpha',
+  Greek.beta: 'beta',
+  Greek.gamma: 'gamma',
+  Greek.delta: 'delta'
+};

--- a/json_serializable/test/default_value/default_value.g.dart
+++ b/json_serializable/test/default_value/default_value.g.dart
@@ -30,9 +30,8 @@ DefaultValue _$DefaultValueFromJson(Map<String, dynamic> json) {
         {
           'root': ['child']
         }
-    ..fieldEnum = $enumDecodeNullable(
-            'Greek', Greek.values, json['fieldEnum'] as String) ??
-        Greek.beta;
+    ..fieldEnum =
+        _$enumDecodeNullable(_$GreekEnumMap, json['fieldEnum']) ?? Greek.beta;
 }
 
 Map<String, dynamic> _$DefaultValueToJson(DefaultValue instance) {
@@ -54,6 +53,33 @@ Map<String, dynamic> _$DefaultValueToJson(DefaultValue instance) {
   val['fieldListSimple'] = instance.fieldListSimple;
   val['fieldMapSimple'] = instance.fieldMapSimple;
   val['fieldMapListString'] = instance.fieldMapListString;
-  val['fieldEnum'] = instance.fieldEnum?.toString()?.split('.')?.last;
+  val['fieldEnum'] = _$GreekEnumMap[instance.fieldEnum];
   return val;
 }
+
+T _$enumDecode<T>(Map<T, dynamic> enumValues, dynamic source) {
+  if (source == null) {
+    throw new ArgumentError('A value must be provided. Supported values: '
+        '${enumValues.values.join(', ')}');
+  }
+  return enumValues.entries
+      .singleWhere((e) => e.value == source,
+          orElse: () => throw new ArgumentError(
+              '`$source` is not one of the supported values: '
+              '${enumValues.values.join(', ')}'))
+      .key;
+}
+
+T _$enumDecodeNullable<T>(Map<T, dynamic> enumValues, dynamic source) {
+  if (source == null) {
+    return null;
+  }
+  return _$enumDecode<T>(enumValues, source);
+}
+
+const _$GreekEnumMap = const <Greek, dynamic>{
+  Greek.alpha: 'alpha',
+  Greek.beta: 'beta',
+  Greek.gamma: 'gamma',
+  Greek.delta: 'delta'
+};

--- a/json_serializable/test/integration/integration_test.dart
+++ b/json_serializable/test/integration/integration_test.dart
@@ -5,7 +5,7 @@
 import 'package:test/test.dart';
 
 import '../test_utils.dart';
-import 'json_test_common.dart' show Category, Platform;
+import 'json_test_common.dart' show Category, Platform, StatusCode;
 import 'json_test_example.dart';
 
 Matcher _throwsArgumentError(matcher) =>
@@ -57,11 +57,13 @@ void main() {
     }
 
     test('null', () {
-      roundTripOrder(new Order(Category.charmed));
+      roundTripOrder(
+          new Order(Category.charmed)..statusCode = StatusCode.success);
     });
 
     test('empty', () {
       roundTripOrder(new Order(Category.strange, const [])
+        ..statusCode = StatusCode.success
         ..count = 0
         ..isRushed = false);
     });
@@ -72,33 +74,36 @@ void main() {
           ..itemNumber = 42
           ..saleDates = [new DateTime.now()]
       ])
+        ..statusCode = StatusCode.success
         ..count = 42
         ..isRushed = true);
     });
 
     test('almost empty json', () {
-      var order = new Order.fromJson({'category': 'top'});
+      var order = new Order.fromJson({'category': 'not_discovered_yet'});
       expect(order.items, isEmpty);
-      expect(order.category, Category.top);
+      expect(order.category, Category.notDiscoveredYet);
+      expect(order.statusCode, StatusCode.success);
       roundTripOrder(order);
     });
 
     test('required, but missing enum value fails', () {
       expect(
           () => new Order.fromJson({}),
-          _throwsArgumentError('`null` is not one of the supported values: '
-              'top, bottom, strange, charmed, up, down'));
+          _throwsArgumentError('A value must be provided. Supported values: '
+              'top, bottom, strange, charmed, up, down, not_discovered_yet'));
     });
 
     test('mismatched enum value fails', () {
       expect(
           () => new Order.fromJson({'category': 'weird'}),
           _throwsArgumentError('`weird` is not one of the supported values: '
-              'top, bottom, strange, charmed, up, down'));
+              'top, bottom, strange, charmed, up, down, not_discovered_yet'));
     });
 
     test('platform', () {
       var order = new Order(Category.charmed)
+        ..statusCode = StatusCode.success
         ..platform = Platform.undefined
         ..altPlatforms = {
           'u': Platform.undefined,
@@ -112,6 +117,7 @@ void main() {
     test('homepage', () {
       var order = new Order(Category.charmed)
         ..platform = Platform.undefined
+        ..statusCode = StatusCode.success
         ..altPlatforms = {
           'u': Platform.undefined,
           'f': Platform.foo,
@@ -119,6 +125,13 @@ void main() {
         }
         ..homepage = Uri.parse('https://dartlang.org');
 
+      roundTripOrder(order);
+    });
+
+    test('statusCode', () {
+      var order = new Order.fromJson(
+          {'category': 'not_discovered_yet', 'status_code': 404});
+      expect(order.statusCode, StatusCode.notFound);
       roundTripOrder(order);
     });
   });

--- a/json_serializable/test/integration/json_test_common.dart
+++ b/json_serializable/test/integration/json_test_common.dart
@@ -3,8 +3,25 @@
 // BSD-style license that can be found in the LICENSE file.
 
 import 'package:collection/collection.dart';
+import 'package:json_annotation/json_annotation.dart';
 
-enum Category { top, bottom, strange, charmed, up, down }
+enum Category {
+  top,
+  bottom,
+  strange,
+  charmed,
+  up,
+  down,
+  @JsonValue('not_discovered_yet')
+  notDiscoveredYet
+}
+
+enum StatusCode {
+  @JsonValue(200)
+  success,
+  @JsonValue(404)
+  notFound
+}
 
 Duration durationFromInt(int ms) => new Duration(milliseconds: ms);
 int durationToInt(Duration duration) => duration.inMilliseconds;

--- a/json_serializable/test/integration/json_test_example.dart
+++ b/json_serializable/test/integration/json_test_example.dart
@@ -51,6 +51,10 @@ class Order extends Object with _$OrderSerializerMixin {
 
   Uri homepage;
 
+  @JsonKey(
+      name: 'status_code', defaultValue: StatusCode.success, nullable: true)
+  StatusCode statusCode;
+
   @JsonKey(ignore: true)
   String get platformValue => platform?.description;
 

--- a/json_serializable/test/integration/json_test_example.g.dart
+++ b/json_serializable/test/integration/json_test_example.g.dart
@@ -11,11 +11,8 @@ part of 'json_test_example.dart';
 // **************************************************************************
 
 Person _$PersonFromJson(Map<String, dynamic> json) {
-  return new Person(
-      json['firstName'] as String,
-      json['lastName'] as String,
-      $enumDecodeNullable(
-          'Category', Category.values, json[r'$house'] as String),
+  return new Person(json['firstName'] as String, json['lastName'] as String,
+      _$enumDecodeNullable(_$CategoryEnumMap, json[r'$house']),
       middleName: json['middleName'] as String,
       dateOfBirth: json['dateOfBirth'] == null
           ? null
@@ -23,9 +20,8 @@ Person _$PersonFromJson(Map<String, dynamic> json) {
     ..order = json['order'] == null
         ? null
         : new Order.fromJson(json['order'] as Map<String, dynamic>)
-    ..houseMap = (json['houseMap'] as Map<String, dynamic>)?.map((k, e) =>
-        new MapEntry(
-            k, $enumDecodeNullable('Category', Category.values, e as String)));
+    ..houseMap = (json['houseMap'] as Map<String, dynamic>)?.map(
+        (k, e) => new MapEntry(k, _$enumDecodeNullable(_$CategoryEnumMap, e)));
 }
 
 abstract class _$PersonSerializerMixin {
@@ -41,17 +37,47 @@ abstract class _$PersonSerializerMixin {
         'middleName': middleName,
         'lastName': lastName,
         'dateOfBirth': dateOfBirth?.toIso8601String(),
-        r'$house': house?.toString()?.split('.')?.last,
+        r'$house': _$CategoryEnumMap[house],
         'order': order,
-        'houseMap': houseMap
-            ?.map((k, e) => new MapEntry(k, e?.toString()?.split('.')?.last))
+        'houseMap':
+            houseMap?.map((k, e) => new MapEntry(k, _$CategoryEnumMap[e]))
       };
 }
+
+T _$enumDecode<T>(Map<T, dynamic> enumValues, dynamic source) {
+  if (source == null) {
+    throw new ArgumentError('A value must be provided. Supported values: '
+        '${enumValues.values.join(', ')}');
+  }
+  return enumValues.entries
+      .singleWhere((e) => e.value == source,
+          orElse: () => throw new ArgumentError(
+              '`$source` is not one of the supported values: '
+              '${enumValues.values.join(', ')}'))
+      .key;
+}
+
+T _$enumDecodeNullable<T>(Map<T, dynamic> enumValues, dynamic source) {
+  if (source == null) {
+    return null;
+  }
+  return _$enumDecode<T>(enumValues, source);
+}
+
+const _$CategoryEnumMap = const <Category, dynamic>{
+  Category.top: 'top',
+  Category.bottom: 'bottom',
+  Category.strange: 'strange',
+  Category.charmed: 'charmed',
+  Category.up: 'up',
+  Category.down: 'down',
+  Category.notDiscoveredYet: 'not_discovered_yet'
+};
 
 Order _$OrderFromJson(Map<String, dynamic> json) {
   $checkKeys(json, disallowNullValues: const ['count']);
   return new Order(
-      $enumDecode('Category', Category.values, json['category'] as String),
+      _$enumDecode(_$CategoryEnumMap, json['category']),
       (json['items'] as List)?.map((e) =>
           e == null ? null : new Item.fromJson(e as Map<String, dynamic>)))
     ..count = json['count'] as int
@@ -63,7 +89,10 @@ Order _$OrderFromJson(Map<String, dynamic> json) {
             e) =>
         new MapEntry(k, e == null ? null : new Platform.fromJson(e as String)))
     ..homepage =
-        json['homepage'] == null ? null : Uri.parse(json['homepage'] as String);
+        json['homepage'] == null ? null : Uri.parse(json['homepage'] as String)
+    ..statusCode =
+        _$enumDecodeNullable(_$StatusCodeEnumMap, json['status_code']) ??
+            StatusCode.success;
 }
 
 abstract class _$OrderSerializerMixin {
@@ -74,6 +103,7 @@ abstract class _$OrderSerializerMixin {
   Platform get platform;
   Map<String, Platform> get altPlatforms;
   Uri get homepage;
+  StatusCode get statusCode;
   Map<String, dynamic> toJson() {
     var val = <String, dynamic>{};
 
@@ -85,14 +115,20 @@ abstract class _$OrderSerializerMixin {
 
     writeNotNull('count', count);
     val['isRushed'] = isRushed;
-    val['category'] = category.toString().split('.').last;
+    val['category'] = _$CategoryEnumMap[category];
     val['items'] = items;
     val['platform'] = platform;
     val['altPlatforms'] = altPlatforms;
     val['homepage'] = homepage?.toString();
+    val['status_code'] = _$StatusCodeEnumMap[statusCode];
     return val;
   }
 }
+
+const _$StatusCodeEnumMap = const <StatusCode, dynamic>{
+  StatusCode.success: 200,
+  StatusCode.notFound: 404
+};
 
 Item _$ItemFromJson(Map<String, dynamic> json) {
   return new Item(json['price'] as int)

--- a/json_serializable/test/integration/json_test_example.non_nullable.dart
+++ b/json_serializable/test/integration/json_test_example.non_nullable.dart
@@ -57,6 +57,10 @@ class Order extends Object with _$OrderSerializerMixin {
 
   Uri homepage;
 
+  @JsonKey(
+      name: 'status_code', defaultValue: StatusCode.success, nullable: true)
+  StatusCode statusCode;
+
   @JsonKey(ignore: true)
   String get platformValue => platform?.description;
 

--- a/json_serializable/test/integration/json_test_example.non_nullable.g.dart
+++ b/json_serializable/test/integration/json_test_example.non_nullable.g.dart
@@ -12,12 +12,12 @@ part of 'json_test_example.non_nullable.dart';
 
 Person _$PersonFromJson(Map<String, dynamic> json) {
   return new Person(json['firstName'] as String, json['lastName'] as String,
-      $enumDecode('Category', Category.values, json[r'$house'] as String),
+      _$enumDecode(_$CategoryEnumMap, json[r'$house']),
       middleName: json['middleName'] as String,
       dateOfBirth: DateTime.parse(json['dateOfBirth'] as String))
     ..order = new Order.fromJson(json['order'] as Map<String, dynamic>)
-    ..houseMap = (json['houseMap'] as Map<String, dynamic>).map((k, e) =>
-        new MapEntry(k, $enumDecode('Category', Category.values, e as String)));
+    ..houseMap = (json['houseMap'] as Map<String, dynamic>)
+        .map((k, e) => new MapEntry(k, _$enumDecode(_$CategoryEnumMap, e)));
 }
 
 abstract class _$PersonSerializerMixin {
@@ -33,17 +33,40 @@ abstract class _$PersonSerializerMixin {
         'middleName': middleName,
         'lastName': lastName,
         'dateOfBirth': dateOfBirth.toIso8601String(),
-        r'$house': house.toString().split('.').last,
+        r'$house': _$CategoryEnumMap[house],
         'order': order,
-        'houseMap': houseMap
-            .map((k, e) => new MapEntry(k, e.toString().split('.').last))
+        'houseMap':
+            houseMap.map((k, e) => new MapEntry(k, _$CategoryEnumMap[e]))
       };
 }
+
+T _$enumDecode<T>(Map<T, dynamic> enumValues, dynamic source) {
+  if (source == null) {
+    throw new ArgumentError('A value must be provided. Supported values: '
+        '${enumValues.values.join(', ')}');
+  }
+  return enumValues.entries
+      .singleWhere((e) => e.value == source,
+          orElse: () => throw new ArgumentError(
+              '`$source` is not one of the supported values: '
+              '${enumValues.values.join(', ')}'))
+      .key;
+}
+
+const _$CategoryEnumMap = const <Category, dynamic>{
+  Category.top: 'top',
+  Category.bottom: 'bottom',
+  Category.strange: 'strange',
+  Category.charmed: 'charmed',
+  Category.up: 'up',
+  Category.down: 'down',
+  Category.notDiscoveredYet: 'not_discovered_yet'
+};
 
 Order _$OrderFromJson(Map<String, dynamic> json) {
   $checkKeys(json, disallowNullValues: const ['count']);
   return new Order(
-      $enumDecode('Category', Category.values, json['category'] as String),
+      _$enumDecode(_$CategoryEnumMap, json['category']),
       (json['items'] as List)
           .map((e) => new Item.fromJson(e as Map<String, dynamic>)))
     ..count = json['count'] as int
@@ -51,7 +74,10 @@ Order _$OrderFromJson(Map<String, dynamic> json) {
     ..platform = new Platform.fromJson(json['platform'] as String)
     ..altPlatforms = (json['altPlatforms'] as Map<String, dynamic>)
         .map((k, e) => new MapEntry(k, new Platform.fromJson(e as String)))
-    ..homepage = Uri.parse(json['homepage'] as String);
+    ..homepage = Uri.parse(json['homepage'] as String)
+    ..statusCode =
+        _$enumDecodeNullable(_$StatusCodeEnumMap, json['status_code']) ??
+            StatusCode.success;
 }
 
 abstract class _$OrderSerializerMixin {
@@ -62,16 +88,30 @@ abstract class _$OrderSerializerMixin {
   Platform get platform;
   Map<String, Platform> get altPlatforms;
   Uri get homepage;
+  StatusCode get statusCode;
   Map<String, dynamic> toJson() => <String, dynamic>{
         'count': count,
         'isRushed': isRushed,
-        'category': category.toString().split('.').last,
+        'category': _$CategoryEnumMap[category],
         'items': items,
         'platform': platform,
         'altPlatforms': altPlatforms,
-        'homepage': homepage.toString()
+        'homepage': homepage.toString(),
+        'status_code': _$StatusCodeEnumMap[statusCode]
       };
 }
+
+T _$enumDecodeNullable<T>(Map<T, dynamic> enumValues, dynamic source) {
+  if (source == null) {
+    return null;
+  }
+  return _$enumDecode<T>(enumValues, source);
+}
+
+const _$StatusCodeEnumMap = const <StatusCode, dynamic>{
+  StatusCode.success: 200,
+  StatusCode.notFound: 404
+};
 
 Item _$ItemFromJson(Map<String, dynamic> json) {
   return new Item(json['price'] as int)

--- a/json_serializable/test/integration/json_test_example.non_nullable.wrapped.dart
+++ b/json_serializable/test/integration/json_test_example.non_nullable.wrapped.dart
@@ -63,6 +63,10 @@ class Order extends Object with _$OrderSerializerMixin {
 
   Uri homepage;
 
+  @JsonKey(
+      name: 'status_code', defaultValue: StatusCode.success, nullable: true)
+  StatusCode statusCode;
+
   @JsonKey(ignore: true)
   String get platformValue => platform?.description;
 

--- a/json_serializable/test/integration/json_test_example.non_nullable.wrapped.g.dart
+++ b/json_serializable/test/integration/json_test_example.non_nullable.wrapped.g.dart
@@ -12,12 +12,12 @@ part of 'json_test_example.non_nullable.wrapped.dart';
 
 Person _$PersonFromJson(Map<String, dynamic> json) {
   return new Person(json['firstName'] as String, json['lastName'] as String,
-      $enumDecode('Category', Category.values, json[r'$house'] as String),
+      _$enumDecode(_$CategoryEnumMap, json[r'$house']),
       middleName: json['middleName'] as String,
       dateOfBirth: DateTime.parse(json['dateOfBirth'] as String))
     ..order = new Order.fromJson(json['order'] as Map<String, dynamic>)
-    ..houseMap = (json['houseMap'] as Map<String, dynamic>).map((k, e) =>
-        new MapEntry(k, $enumDecode('Category', Category.values, e as String)));
+    ..houseMap = (json['houseMap'] as Map<String, dynamic>)
+        .map((k, e) => new MapEntry(k, _$enumDecode(_$CategoryEnumMap, e)));
 }
 
 abstract class _$PersonSerializerMixin {
@@ -59,22 +59,45 @@ class _$PersonJsonMapWrapper extends $JsonMapWrapper {
         case 'dateOfBirth':
           return _v.dateOfBirth.toIso8601String();
         case r'$house':
-          return _v.house.toString().split('.').last;
+          return _$CategoryEnumMap[_v.house];
         case 'order':
           return _v.order;
         case 'houseMap':
           return $wrapMap<String, Category>(
-              _v.houseMap, (e) => e.toString().split('.').last);
+              _v.houseMap, (e) => _$CategoryEnumMap[e]);
       }
     }
     return null;
   }
 }
 
+T _$enumDecode<T>(Map<T, dynamic> enumValues, dynamic source) {
+  if (source == null) {
+    throw new ArgumentError('A value must be provided. Supported values: '
+        '${enumValues.values.join(', ')}');
+  }
+  return enumValues.entries
+      .singleWhere((e) => e.value == source,
+          orElse: () => throw new ArgumentError(
+              '`$source` is not one of the supported values: '
+              '${enumValues.values.join(', ')}'))
+      .key;
+}
+
+const _$CategoryEnumMap = const <Category, dynamic>{
+  Category.top: 'top',
+  Category.bottom: 'bottom',
+  Category.strange: 'strange',
+  Category.charmed: 'charmed',
+  Category.up: 'up',
+  Category.down: 'down',
+  Category.notDiscoveredYet: 'not_discovered_yet'
+};
+
 Order _$OrderFromJson(Map<String, dynamic> json) {
   $checkKeys(json, disallowNullValues: const ['count']);
   return new Order(
-      $enumDecode('Category', Category.values, json['category'] as String),
+      _$enumDecode(_$CategoryEnumMap, json['category']),
       (json['items'] as List)
           .map((e) => new Item.fromJson(e as Map<String, dynamic>)))
     ..count = json['count'] as int
@@ -82,7 +105,10 @@ Order _$OrderFromJson(Map<String, dynamic> json) {
     ..platform = new Platform.fromJson(json['platform'] as String)
     ..altPlatforms = (json['altPlatforms'] as Map<String, dynamic>)
         .map((k, e) => new MapEntry(k, new Platform.fromJson(e as String)))
-    ..homepage = Uri.parse(json['homepage'] as String);
+    ..homepage = Uri.parse(json['homepage'] as String)
+    ..statusCode =
+        _$enumDecodeNullable(_$StatusCodeEnumMap, json['status_code']) ??
+            StatusCode.success;
 }
 
 abstract class _$OrderSerializerMixin {
@@ -93,6 +119,7 @@ abstract class _$OrderSerializerMixin {
   Platform get platform;
   Map<String, Platform> get altPlatforms;
   Uri get homepage;
+  StatusCode get statusCode;
   Map<String, dynamic> toJson() => new _$OrderJsonMapWrapper(this);
 }
 
@@ -108,7 +135,8 @@ class _$OrderJsonMapWrapper extends $JsonMapWrapper {
         'items',
         'platform',
         'altPlatforms',
-        'homepage'
+        'homepage',
+        'status_code'
       ];
 
   @override
@@ -120,7 +148,7 @@ class _$OrderJsonMapWrapper extends $JsonMapWrapper {
         case 'isRushed':
           return _v.isRushed;
         case 'category':
-          return _v.category.toString().split('.').last;
+          return _$CategoryEnumMap[_v.category];
         case 'items':
           return _v.items;
         case 'platform':
@@ -129,11 +157,25 @@ class _$OrderJsonMapWrapper extends $JsonMapWrapper {
           return _v.altPlatforms;
         case 'homepage':
           return _v.homepage.toString();
+        case 'status_code':
+          return _$StatusCodeEnumMap[_v.statusCode];
       }
     }
     return null;
   }
 }
+
+T _$enumDecodeNullable<T>(Map<T, dynamic> enumValues, dynamic source) {
+  if (source == null) {
+    return null;
+  }
+  return _$enumDecode<T>(enumValues, source);
+}
+
+const _$StatusCodeEnumMap = const <StatusCode, dynamic>{
+  StatusCode.success: 200,
+  StatusCode.notFound: 404
+};
 
 Item _$ItemFromJson(Map<String, dynamic> json) {
   return new Item(json['price'] as int)

--- a/json_serializable/test/integration/json_test_example.wrapped.dart
+++ b/json_serializable/test/integration/json_test_example.wrapped.dart
@@ -57,6 +57,10 @@ class Order extends Object with _$OrderSerializerMixin {
 
   Uri homepage;
 
+  @JsonKey(
+      name: 'status_code', defaultValue: StatusCode.success, nullable: true)
+  StatusCode statusCode;
+
   @JsonKey(ignore: true)
   String get platformValue => platform?.description;
 

--- a/json_serializable/test/integration/json_test_example.wrapped.g.dart
+++ b/json_serializable/test/integration/json_test_example.wrapped.g.dart
@@ -11,11 +11,8 @@ part of 'json_test_example.wrapped.dart';
 // **************************************************************************
 
 Person _$PersonFromJson(Map<String, dynamic> json) {
-  return new Person(
-      json['firstName'] as String,
-      json['lastName'] as String,
-      $enumDecodeNullable(
-          'Category', Category.values, json[r'$house'] as String),
+  return new Person(json['firstName'] as String, json['lastName'] as String,
+      _$enumDecodeNullable(_$CategoryEnumMap, json[r'$house']),
       middleName: json['middleName'] as String,
       dateOfBirth: json['dateOfBirth'] == null
           ? null
@@ -23,9 +20,8 @@ Person _$PersonFromJson(Map<String, dynamic> json) {
     ..order = json['order'] == null
         ? null
         : new Order.fromJson(json['order'] as Map<String, dynamic>)
-    ..houseMap = (json['houseMap'] as Map<String, dynamic>)?.map((k, e) =>
-        new MapEntry(
-            k, $enumDecodeNullable('Category', Category.values, e as String)));
+    ..houseMap = (json['houseMap'] as Map<String, dynamic>)?.map(
+        (k, e) => new MapEntry(k, _$enumDecodeNullable(_$CategoryEnumMap, e)));
 }
 
 abstract class _$PersonSerializerMixin {
@@ -67,22 +63,52 @@ class _$PersonJsonMapWrapper extends $JsonMapWrapper {
         case 'dateOfBirth':
           return _v.dateOfBirth?.toIso8601String();
         case r'$house':
-          return _v.house?.toString()?.split('.')?.last;
+          return _$CategoryEnumMap[_v.house];
         case 'order':
           return _v.order;
         case 'houseMap':
           return $wrapMapHandleNull<String, Category>(
-              _v.houseMap, (e) => e?.toString()?.split('.')?.last);
+              _v.houseMap, (e) => _$CategoryEnumMap[e]);
       }
     }
     return null;
   }
 }
 
+T _$enumDecode<T>(Map<T, dynamic> enumValues, dynamic source) {
+  if (source == null) {
+    throw new ArgumentError('A value must be provided. Supported values: '
+        '${enumValues.values.join(', ')}');
+  }
+  return enumValues.entries
+      .singleWhere((e) => e.value == source,
+          orElse: () => throw new ArgumentError(
+              '`$source` is not one of the supported values: '
+              '${enumValues.values.join(', ')}'))
+      .key;
+}
+
+T _$enumDecodeNullable<T>(Map<T, dynamic> enumValues, dynamic source) {
+  if (source == null) {
+    return null;
+  }
+  return _$enumDecode<T>(enumValues, source);
+}
+
+const _$CategoryEnumMap = const <Category, dynamic>{
+  Category.top: 'top',
+  Category.bottom: 'bottom',
+  Category.strange: 'strange',
+  Category.charmed: 'charmed',
+  Category.up: 'up',
+  Category.down: 'down',
+  Category.notDiscoveredYet: 'not_discovered_yet'
+};
+
 Order _$OrderFromJson(Map<String, dynamic> json) {
   $checkKeys(json, disallowNullValues: const ['count']);
   return new Order(
-      $enumDecode('Category', Category.values, json['category'] as String),
+      _$enumDecode(_$CategoryEnumMap, json['category']),
       (json['items'] as List)?.map((e) =>
           e == null ? null : new Item.fromJson(e as Map<String, dynamic>)))
     ..count = json['count'] as int
@@ -94,7 +120,10 @@ Order _$OrderFromJson(Map<String, dynamic> json) {
             e) =>
         new MapEntry(k, e == null ? null : new Platform.fromJson(e as String)))
     ..homepage =
-        json['homepage'] == null ? null : Uri.parse(json['homepage'] as String);
+        json['homepage'] == null ? null : Uri.parse(json['homepage'] as String)
+    ..statusCode =
+        _$enumDecodeNullable(_$StatusCodeEnumMap, json['status_code']) ??
+            StatusCode.success;
 }
 
 abstract class _$OrderSerializerMixin {
@@ -105,6 +134,7 @@ abstract class _$OrderSerializerMixin {
   Platform get platform;
   Map<String, Platform> get altPlatforms;
   Uri get homepage;
+  StatusCode get statusCode;
   Map<String, dynamic> toJson() => new _$OrderJsonMapWrapper(this);
 }
 
@@ -123,6 +153,7 @@ class _$OrderJsonMapWrapper extends $JsonMapWrapper {
     yield 'platform';
     yield 'altPlatforms';
     yield 'homepage';
+    yield 'status_code';
   }
 
   @override
@@ -134,7 +165,7 @@ class _$OrderJsonMapWrapper extends $JsonMapWrapper {
         case 'isRushed':
           return _v.isRushed;
         case 'category':
-          return _v.category.toString().split('.').last;
+          return _$CategoryEnumMap[_v.category];
         case 'items':
           return _v.items;
         case 'platform':
@@ -143,11 +174,18 @@ class _$OrderJsonMapWrapper extends $JsonMapWrapper {
           return _v.altPlatforms;
         case 'homepage':
           return _v.homepage?.toString();
+        case 'status_code':
+          return _$StatusCodeEnumMap[_v.statusCode];
       }
     }
     return null;
   }
 }
+
+const _$StatusCodeEnumMap = const <StatusCode, dynamic>{
+  StatusCode.success: 200,
+  StatusCode.notFound: 404
+};
 
 Item _$ItemFromJson(Map<String, dynamic> json) {
   return new Item(json['price'] as int)

--- a/json_serializable/test/src/json_serializable_test_input.dart
+++ b/json_serializable/test/src/json_serializable_test_input.dart
@@ -247,3 +247,30 @@ class TrivialNestedNonNullable {
   TrivialNestedNonNullable child;
   int otherField;
 }
+
+@JsonSerializable()
+class JsonValueWithBool {
+  BadEnum field;
+}
+
+enum BadEnum {
+  @JsonValue(true)
+  value
+}
+
+@JsonSerializable()
+class JsonValueValid {
+  GoodEnum field;
+}
+
+enum GoodEnum {
+  noAnnotation,
+  @JsonValue('string annotation')
+  stringAnnotation,
+  @JsonValue("string annotation with \$ funky 'values'")
+  stringAnnotationWeird,
+  @JsonValue(42)
+  intValue,
+  @JsonValue(null)
+  nullValue
+}

--- a/json_serializable/test/yaml/build_config.dart
+++ b/json_serializable/test/yaml/build_config.dart
@@ -32,11 +32,7 @@ class Builder extends Object with _$BuilderSerializerMixin {
   @JsonKey(disallowNullValue: true)
   final Uri configLocation;
 
-  @JsonKey(
-      name: 'auto_apply',
-      disallowNullValue: true,
-      toJson: _autoApplyToJson,
-      fromJson: _autoApplyFromJson)
+  @JsonKey(name: 'auto_apply', disallowNullValue: true)
   final AutoApply autoApply;
 
   @JsonKey(name: 'build_to')
@@ -77,45 +73,13 @@ class Builder extends Object with _$BuilderSerializerMixin {
   factory Builder.fromJson(Map map) => _$BuilderFromJson(map);
 }
 
-enum AutoApply { none, dependents, allPackages, rootPackage }
+enum AutoApply {
+  none,
+  dependents,
+  @JsonValue('all_packages')
+  allPackages,
+  @JsonValue('root_package')
+  rootPackage
+}
 
 enum BuildTo { cache, source }
-
-AutoApply _autoApplyFromJson(String input) =>
-    _fromJson(input, _autoApplyConvert, 'autoApply');
-
-String _autoApplyToJson(AutoApply value) =>
-    _toJson(value, _autoApplyConvert, 'autoApply');
-
-// TODO: remove all of this and annotate the fields on the enum – once we have
-// https://github.com/dart-lang/json_serializable/issues/38
-T _fromJson<T>(String input, Map<String, T> convertMap, String fieldName) {
-  var value = convertMap[input];
-  if (value == null) {
-    var allowed = convertMap.keys.map((e) => '"$e"').join(', ');
-    throw new ArgumentError.value(
-        input, fieldName, '"$input" is not in the supported set: $allowed.');
-  }
-  return value;
-}
-
-String _toJson<T>(T value, Map<String, T> convertMap, String fieldName) {
-  if (value == null) {
-    return null;
-  }
-  var string = convertMap.entries
-      .singleWhere((e) => e.value == value, orElse: () => null)
-      ?.key;
-
-  if (string == null) {
-    throw new ArgumentError.value(value, fieldName, 'Unsupported value.');
-  }
-  return string;
-}
-
-const _autoApplyConvert = const {
-  'none': AutoApply.none,
-  'dependents': AutoApply.dependents,
-  'all_packages': AutoApply.allPackages,
-  'root_package': AutoApply.rootPackage
-};

--- a/json_serializable/test/yaml/build_config.g.dart
+++ b/json_serializable/test/yaml/build_config.g.dart
@@ -51,14 +51,11 @@ Builder _$BuilderFromJson(Map json) {
         target: $checkedConvert(json, 'target', (v) => v as String),
         isOptional: $checkedConvert(json, 'is_optional', (v) => v as bool),
         autoApply: $checkedConvert(json, 'auto_apply',
-            (v) => v == null ? null : _autoApplyFromJson(v as String)),
-        buildTo: $checkedConvert(json, 'build_to',
-            (v) => $enumDecodeNullable('BuildTo', BuildTo.values, v as String)),
-        defaultEnumTest: $checkedConvert(
-            json,
-            'defaultEnumTest',
-            (v) => $enumDecodeNullable(
-                'AutoApply', AutoApply.values, v as String)),
+            (v) => _$enumDecodeNullable(_$AutoApplyEnumMap, v)),
+        buildTo: $checkedConvert(
+            json, 'build_to', (v) => _$enumDecodeNullable(_$BuildToEnumMap, v)),
+        defaultEnumTest: $checkedConvert(json, 'defaultEnumTest',
+            (v) => _$enumDecodeNullable(_$AutoApplyEnumMap, v)),
         builderFactories: $checkedConvert(json, 'builder_factories',
             (v) => (v as List).map((e) => e as String).toList()),
         appliesBuilders: $checkedConvert(json, 'applies_builders',
@@ -109,11 +106,9 @@ abstract class _$BuilderSerializerMixin {
     writeNotNull('import', import);
     writeNotNull('is_optional', isOptional);
     writeNotNull('configLocation', configLocation?.toString());
-    writeNotNull(
-        'auto_apply', autoApply == null ? null : _autoApplyToJson(autoApply));
-    writeNotNull('build_to', buildTo?.toString()?.split('.')?.last);
-    writeNotNull(
-        'defaultEnumTest', defaultEnumTest?.toString()?.split('.')?.last);
+    writeNotNull('auto_apply', _$AutoApplyEnumMap[autoApply]);
+    writeNotNull('build_to', _$BuildToEnumMap[buildTo]);
+    writeNotNull('defaultEnumTest', _$AutoApplyEnumMap[defaultEnumTest]);
     val['builder_factories'] = builderFactories;
     writeNotNull('applies_builders', appliesBuilders);
     writeNotNull('required_inputs', requiredInputs);
@@ -121,3 +116,35 @@ abstract class _$BuilderSerializerMixin {
     return val;
   }
 }
+
+T _$enumDecode<T>(Map<T, dynamic> enumValues, dynamic source) {
+  if (source == null) {
+    throw new ArgumentError('A value must be provided. Supported values: '
+        '${enumValues.values.join(', ')}');
+  }
+  return enumValues.entries
+      .singleWhere((e) => e.value == source,
+          orElse: () => throw new ArgumentError(
+              '`$source` is not one of the supported values: '
+              '${enumValues.values.join(', ')}'))
+      .key;
+}
+
+T _$enumDecodeNullable<T>(Map<T, dynamic> enumValues, dynamic source) {
+  if (source == null) {
+    return null;
+  }
+  return _$enumDecode<T>(enumValues, source);
+}
+
+const _$AutoApplyEnumMap = const <AutoApply, dynamic>{
+  AutoApply.none: 'none',
+  AutoApply.dependents: 'dependents',
+  AutoApply.allPackages: 'all_packages',
+  AutoApply.rootPackage: 'root_package'
+};
+
+const _$BuildToEnumMap = const <BuildTo, dynamic>{
+  BuildTo.cache: 'cache',
+  BuildTo.source: 'source'
+};

--- a/json_serializable/test/yaml/yaml_test.dart
+++ b/json_serializable/test/yaml/yaml_test.dart
@@ -78,7 +78,7 @@ builders:
   sample:
     defaultEnumTest: bob
 ''': r'''
-line 3, column 22 of file.yaml: Could not create `Builder`. Unsupported value for `defaultEnumTest`. `bob` is not one of the supported values: none, dependents, allPackages, rootPackage
+line 3, column 22 of file.yaml: Could not create `Builder`. Unsupported value for `defaultEnumTest`. `bob` is not one of the supported values: none, dependents, all_packages, root_package
     defaultEnumTest: bob
                      ^^^''',
   r'''
@@ -95,7 +95,7 @@ builders:
     target: "a target"
     auto_apply: unsupported
 ''': r'''
-line 4, column 17 of file.yaml: Could not create `Builder`. Unsupported value for `auto_apply`. "unsupported" is not in the supported set: "none", "dependents", "all_packages", "root_package".
+line 4, column 17 of file.yaml: Could not create `Builder`. Unsupported value for `auto_apply`. `unsupported` is not one of the supported values: none, dependents, all_packages, root_package
     auto_apply: unsupported
                 ^^^^^^^^^^^''',
   r'''


### PR DESCRIPTION
feature: allow customizing enum value serialization via annotations

* Require the latest Dart SDK
  Annotated enums fail without the CFE

* Require the latest pkg:analyzer
  Enum metadata parsing was just recently added

* Require the latest pkg:source_gen
  Uses multiple return values to allow generating shared helpers

* Removed several helpers in json_annotation
  They can now be generated as part of the source, which minimizes
  versioning issues with helpers.

* Small, but breaking changes to Generator API to return multiple
  values

* Added `addMember` API to Context classes to allow helpers to be
  generated.

* Updated integration test code to include an annotated enum

* Updated yaml test code to remove now superfluous convert logic and use
  annotated enums instead

Fixes https://github.com/dart-lang/json_serializable/issues/38