### PR TITLE
test: move `expectThrow` values to annotation on target elements

### DIFF
--- a/json_serializable/test/analysis_utils.dart
+++ b/json_serializable/test/analysis_utils.dart
@@ -6,9 +6,9 @@ import 'dart:async';
 
 import 'package:analyzer/dart/analysis/context_builder.dart';
 import 'package:analyzer/dart/analysis/context_locator.dart';
-import 'package:analyzer/dart/ast/ast.dart';
+import 'package:source_gen/source_gen.dart';
 
-Future<CompilationUnit> resolveCompilationUnit(String path) async {
+Future<LibraryReader> resolveCompilationUnit(String path) async {
   var contextLocator = new ContextLocator();
   var roots = contextLocator.locateRoots(includedPaths: [path]);
   if (roots.length != 1) {
@@ -18,5 +18,5 @@ Future<CompilationUnit> resolveCompilationUnit(String path) async {
   var analysisContext =
       new ContextBuilder().createContext(contextRoot: roots.single);
   var resolveResult = await analysisContext.currentSession.getResolvedAst(path);
-  return resolveResult.unit;
+  return new LibraryReader(resolveResult.unit.element.library);
 }

--- a/json_serializable/test/json_serializable_test.dart
+++ b/json_serializable/test/json_serializable_test.dart
@@ -75,8 +75,9 @@ void _registerTests(JsonSerializableGenerator generator) {
   }
 
   group('fails when generating for', () {
-    for (var thing in _library.annotatedWithExact(_shouldThrowChecker)) {
-      var element = thing.element;
+    for (var annotatedElement
+        in _library.annotatedWithExact(_shouldThrowChecker)) {
+      var element = annotatedElement.element;
       var constantValue = _shouldThrowChecker.firstAnnotationOfExact(element);
       var testDescription =
           constantValue.getField('testDescription').toStringValue();
@@ -85,7 +86,8 @@ void _registerTests(JsonSerializableGenerator generator) {
       var todoMatcher = constantValue.getField('todo').toStringValue();
 
       test('$testDescription (${element.name})', () {
-        expectThrows(thing.element.name, messageMatcher, todoMatcher);
+        expectThrows(
+            annotatedElement.element.name, messageMatcher, todoMatcher);
       });
     }
   });

--- a/json_serializable/test/json_serializable_test.dart
+++ b/json_serializable/test/json_serializable_test.dart
@@ -75,8 +75,39 @@ void _registerTests(JsonSerializableGenerator generator) {
   }
 
   group('fails when generating for', () {
-    for (var annotatedElement
-        in _library.annotatedWithExact(_shouldThrowChecker)) {
+    var annotatedElements = _library
+        .annotatedWithExact(_shouldThrowChecker)
+        .toList()
+          ..sort((a, b) => a.element.name.compareTo(b.element.name));
+
+    test('all expected members', () {
+      expect(annotatedElements.map((ae) => ae.element.name), [
+        'BadFromFuncReturnType',
+        'BadNoArgs',
+        'BadOneNamed',
+        'BadToFuncReturnType',
+        'BadTwoRequiredPositional',
+        'DefaultWithConstObject',
+        'DefaultWithFunction',
+        'DefaultWithNestedEnum',
+        'DefaultWithNonNullableClass',
+        'DefaultWithNonNullableField',
+        'DefaultWithSymbol',
+        'DefaultWithType',
+        'DupeKeys',
+        'IncludeIfNullDisallowNullClass',
+        'InvalidFromFunc2Args',
+        'InvalidFromFuncClassStatic',
+        'InvalidToFunc2Args',
+        'InvalidToFuncClassStatic',
+        'JsonValueWithBool',
+        'KeyDupesField',
+        'annotatedMethod',
+        'theAnswer',
+      ]);
+    });
+
+    for (var annotatedElement in annotatedElements) {
       var element = annotatedElement.element;
       var constantValue = _shouldThrowChecker.firstAnnotationOfExact(element);
       var testDescription =

--- a/json_serializable/test/json_serializable_test.dart
+++ b/json_serializable/test/json_serializable_test.dart
@@ -4,7 +4,6 @@
 
 @TestOn('vm')
 
-import 'package:analyzer/dart/ast/ast.dart';
 import 'package:dart_style/dart_style.dart' as dart_style;
 import 'package:json_serializable/json_serializable.dart';
 import 'package:json_serializable/src/constants.dart';
@@ -12,6 +11,7 @@ import 'package:source_gen/source_gen.dart';
 import 'package:test/test.dart';
 
 import 'analysis_utils.dart';
+import 'src/annotation.dart';
 import 'test_file_utils.dart';
 
 Matcher _throwsInvalidGenerationSourceError(messageMatcher, todoMatcher) =>
@@ -26,13 +26,13 @@ Matcher _throwsUnsupportedError(matcher) =>
 
 final _formatter = new dart_style.DartFormatter();
 
-CompilationUnit _compilationUnit;
+LibraryReader _library;
 
-void main() {
-  setUpAll(() async {
-    var path = testFilePath('test', 'src', 'json_serializable_test_input.dart');
-    _compilationUnit = await resolveCompilationUnit(path);
-  });
+const _shouldThrowChecker = const TypeChecker.fromRuntime(ShouldThrow);
+
+void main() async {
+  var path = testFilePath('test', 'src', 'json_serializable_test_input.dart');
+  _library = await resolveCompilationUnit(path);
 
   group('without wrappers',
       () => _registerTests(const JsonSerializableGenerator()));
@@ -41,8 +41,7 @@ void main() {
 }
 
 String _runForElementNamed(JsonSerializableGenerator generator, String name) {
-  var library = new LibraryReader(_compilationUnit.element.library);
-  var element = library.allElements.singleWhere((e) => e.name == name);
+  var element = _library.allElements.singleWhere((e) => e.name == name);
   var annotation = generator.typeChecker.firstAnnotationOf(element);
   var generated = generator
       .generateForAnnotatedElement(
@@ -62,10 +61,34 @@ void _registerTests(JsonSerializableGenerator generator) {
       _runForElementNamed(generator, name);
 
   void expectThrows(String elementName, messageMatcher, [todoMatcher]) {
+    if (messageMatcher == null) {
+      var element =
+          _library.allElements.singleWhere((e) => e.name == elementName);
+
+      var constantValue = _shouldThrowChecker.firstAnnotationOfExact(element);
+      messageMatcher = constantValue.getField('errorMessage').toStringValue();
+      todoMatcher ??= constantValue.getField('todo').toStringValue();
+    }
     todoMatcher ??= isEmpty;
     expect(() => runForElementNamed(elementName),
         _throwsInvalidGenerationSourceError(messageMatcher, todoMatcher));
   }
+
+  group('fails when generating for', () {
+    for (var thing in _library.annotatedWithExact(_shouldThrowChecker)) {
+      var element = thing.element;
+      var constantValue = _shouldThrowChecker.firstAnnotationOfExact(element);
+      var testDescription =
+          constantValue.getField('testDescription').toStringValue();
+      var messageMatcher =
+          constantValue.getField('errorMessage').toStringValue();
+      var todoMatcher = constantValue.getField('todo').toStringValue();
+
+      test('$testDescription (${element.name})', () {
+        expectThrows(thing.element.name, messageMatcher, todoMatcher);
+      });
+    }
+  });
 
   group('explicit toJson', () {
     test('nullable', () {
@@ -155,20 +178,6 @@ Map<String, dynamic> _$TrivialNestedNonNullableToJson(
 ''';
 
       expect(output, expected);
-    });
-  });
-
-  group('non-classes', () {
-    test('const field', () {
-      expectThrows('theAnswer', 'Generator cannot target `theAnswer`.',
-          'Remove the JsonSerializable annotation from `theAnswer`.');
-    });
-
-    test('method', () {
-      expectThrows(
-          'annotatedMethod',
-          'Generator cannot target `annotatedMethod`.',
-          'Remove the JsonSerializable annotation from `annotatedMethod`.');
     });
   });
 
@@ -402,18 +411,6 @@ Map<String, dynamic> _$OrderToJson(Order instance) => <String, dynamic>{
                 '_privateField. It is assigned to a private field.'));
       });
     }
-
-    test('fails if name duplicates existing field', () {
-      expectThrows(
-          'KeyDupesField',
-          'More than one field has the JSON key `str`.',
-          'Check the `JsonKey` annotations on fields.');
-    });
-
-    test('fails if two names collide', () {
-      expectThrows('DupeKeys', 'More than one field has the JSON key `a`.',
-          'Check the `JsonKey` annotations on fields.');
-    });
   });
 
   group('includeIfNull', () {
@@ -433,62 +430,6 @@ Map<String, dynamic> _$OrderToJson(Order instance) => <String, dynamic>{
   });
 
   group('functions', () {
-    group('fromJsonFunction', () {
-      test('with bad fromJson return type', () {
-        expectThrows(
-            'BadFromFuncReturnType',
-            'Error with `@JsonKey` on `field`. The `fromJson` function `_toInt` '
-            'return type `int` is not compatible with field type `String`.');
-      });
-      test('with 2 arg fromJson function', () {
-        expectThrows(
-            'InvalidFromFunc2Args',
-            'Error with `@JsonKey` on `field`. The `fromJson` function '
-            '`_twoArgFunction` must have one positional paramater.');
-      });
-      test('with class static function', () {
-        expectThrows(
-            'InvalidFromFuncClassStatic',
-            'Error with `@JsonKey` on `field`. '
-            'The function provided for `fromJson` must be top-level. '
-            'Static class methods (`_staticFunc`) are not supported.');
-      });
-      test('BadNoArgs', () {
-        expectThrows('BadNoArgs',
-            'Error with `@JsonKey` on `field`. The `fromJson` function `_noArgs` must have one positional paramater.');
-      });
-      test('BadTwoRequiredPositional', () {
-        expectThrows('BadTwoRequiredPositional',
-            'Error with `@JsonKey` on `field`. The `fromJson` function `_twoArgs` must have one positional paramater.');
-      });
-      test('BadOneNamed', () {
-        expectThrows('BadOneNamed',
-            'Error with `@JsonKey` on `field`. The `fromJson` function `_oneNamed` must have one positional paramater.');
-      });
-    });
-
-    group('toJsonFunction', () {
-      test('with bad fromJson return type', () {
-        expectThrows(
-            'BadToFuncReturnType',
-            'Error with `@JsonKey` on `field`. The `toJson` function `_toInt` '
-            'argument type `bool` is not compatible with field type `String`.');
-      });
-      test('with 2 arg fromJson function', () {
-        expectThrows(
-            'InvalidToFunc2Args',
-            'Error with `@JsonKey` on `field`. The `toJson` function '
-            '`_twoArgFunction` must have one positional paramater.');
-      });
-      test('with class static function', () {
-        expectThrows(
-            'InvalidToFuncClassStatic',
-            'Error with `@JsonKey` on `field`. '
-            'The function provided for `toJson` must be top-level. '
-            'Static class methods (`_staticFunc`) are not supported.');
-      });
-    });
-
     if (!generator.useWrappers) {
       test('object', () {
         var output = runForElementNamed('ObjectConvertMethods');
@@ -705,13 +646,6 @@ Map<String, dynamic> _$SubTypeToJson(SubType instance) {
 
   if (!generator.useWrappers) {
     group('enums annotated with JsonValue', () {
-      test('must be String, int, or null values', () {
-        expectThrows(
-            'JsonValueWithBool',
-            'The `JsonValue` annotation on `BadEnum.value` does not have a value '
-            'of type String, int, or null.');
-      });
-
       test('can be interesting', () {
         var output = runForElementNamed('JsonValueValid');
 
@@ -724,59 +658,6 @@ const _$GoodEnumEnumMap = const <GoodEnum, dynamic>{
   GoodEnum.nullValue: null
 };'''));
       });
-    });
-
-    group('default values fail with', () {
-      test('symbols', () {
-        expectThrows(
-            'DefaultWithSymbol',
-            'Error with `@JsonKey` on `field`. '
-            '`defaultValue` is `Symbol`, it must be a literal.');
-      });
-      test('functions', () {
-        expectThrows(
-            'DefaultWithFunction',
-            'Error with `@JsonKey` on `field`. '
-            '`defaultValue` is `Function`, it must be a literal.');
-      });
-      test('type', () {
-        expectThrows(
-            'DefaultWithType',
-            'Error with `@JsonKey` on `field`. '
-            '`defaultValue` is `Type`, it must be a literal.');
-      });
-      test('const object', () {
-        expectThrows(
-            'DefaultWithConstObject',
-            'Error with `@JsonKey` on `field`. '
-            '`defaultValue` is `Duration`, it must be a literal.');
-      });
-      test('enum value', () {
-        expectThrows(
-            'DefaultWithNestedEnum',
-            'Error with `@JsonKey` on `field`. '
-            '`defaultValue` is `List > Enum`, it must be a literal.');
-      });
-      test('non-nullable field', () {
-        expectThrows(
-            'DefaultWithNonNullableField',
-            'Error with `@JsonKey` on `field`. '
-            'Cannot use `defaultValue` on a field with `nullable` false.');
-      });
-      test('non-nullable class', () {
-        expectThrows(
-            'DefaultWithNonNullableClass',
-            'Error with `@JsonKey` on `field`. '
-            'Cannot use `defaultValue` on a field with `nullable` false.');
-      });
-    });
-
-    test('`disallowNullvalue` and `includeIfNull` both `true`', () {
-      expectThrows(
-          'IncludeIfNullDisallowNullClass',
-          'Error with `@JsonKey` on `field`. '
-          'Cannot set both `disallowNullvalue` and `includeIfNull` to `true`. '
-          'This leads to incompatible `toJson` and `fromJson` behavior.');
     });
   }
 }

--- a/json_serializable/test/src/annotation.dart
+++ b/json_serializable/test/src/annotation.dart
@@ -1,0 +1,10 @@
+// Copyright (c) 2018, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+class ShouldThrow {
+  final String testDescription;
+  final String errorMessage;
+  final String todo;
+  const ShouldThrow(this.testDescription, this.errorMessage, [this.todo]);
+}

--- a/json_serializable/test/src/default_value_input.dart
+++ b/json_serializable/test/src/default_value_input.dart
@@ -4,6 +4,10 @@
 
 part of 'json_serializable_test_input.dart';
 
+@ShouldThrow(
+    'default values fail with symbol',
+    'Error with `@JsonKey` on `field`. '
+    '`defaultValue` is `Symbol`, it must be a literal.')
 @JsonSerializable()
 class DefaultWithSymbol {
   @JsonKey(defaultValue: #symbol)
@@ -14,6 +18,10 @@ class DefaultWithSymbol {
 
 int _function() => 42;
 
+@ShouldThrow(
+    'default values fail with function',
+    'Error with `@JsonKey` on `field`. '
+    '`defaultValue` is `Function`, it must be a literal.')
 @JsonSerializable()
 class DefaultWithFunction {
   @JsonKey(defaultValue: _function)
@@ -22,6 +30,10 @@ class DefaultWithFunction {
   DefaultWithFunction();
 }
 
+@ShouldThrow(
+    'default values fail with Type',
+    'Error with `@JsonKey` on `field`. '
+    '`defaultValue` is `Type`, it must be a literal.')
 @JsonSerializable()
 class DefaultWithType {
   @JsonKey(defaultValue: Object)
@@ -30,6 +42,10 @@ class DefaultWithType {
   DefaultWithType();
 }
 
+@ShouldThrow(
+    'default values fail with const object',
+    'Error with `@JsonKey` on `field`. '
+    '`defaultValue` is `Duration`, it must be a literal.')
 @JsonSerializable()
 class DefaultWithConstObject {
   @JsonKey(defaultValue: const Duration())
@@ -40,6 +56,10 @@ class DefaultWithConstObject {
 
 enum Enum { value }
 
+@ShouldThrow(
+    'default values fail with nested enum',
+    'Error with `@JsonKey` on `field`. '
+    '`defaultValue` is `List > Enum`, it must be a literal.')
 @JsonSerializable()
 class DefaultWithNestedEnum {
   @JsonKey(defaultValue: [Enum.value])
@@ -48,6 +68,10 @@ class DefaultWithNestedEnum {
   DefaultWithNestedEnum();
 }
 
+@ShouldThrow(
+    'default values fail with non-nullable field',
+    'Error with `@JsonKey` on `field`. '
+    'Cannot use `defaultValue` on a field with `nullable` false.')
 @JsonSerializable()
 class DefaultWithNonNullableField {
   @JsonKey(defaultValue: 42, nullable: false)
@@ -56,6 +80,10 @@ class DefaultWithNonNullableField {
   DefaultWithNonNullableField();
 }
 
+@ShouldThrow(
+    'default values fail with non-nullable class',
+    'Error with `@JsonKey` on `field`. '
+    'Cannot use `defaultValue` on a field with `nullable` false.')
 @JsonSerializable(nullable: false)
 class DefaultWithNonNullableClass {
   @JsonKey(defaultValue: 42)

--- a/json_serializable/test/src/json_serializable_test_input.dart
+++ b/json_serializable/test/src/json_serializable_test_input.dart
@@ -5,13 +5,19 @@
 //ignore_for_file: avoid_unused_constructor_parameters, prefer_initializing_formals
 import 'package:json_annotation/json_annotation.dart';
 
+import 'annotation.dart';
+
 part 'default_value_input.dart';
 part 'generic_test_input.dart';
 part 'to_from_json_test_input.dart';
 
+@ShouldThrow('field', 'Generator cannot target `theAnswer`.',
+    'Remove the JsonSerializable annotation from `theAnswer`.')
 @JsonSerializable()
 const theAnswer = 42;
 
+@ShouldThrow('function', 'Generator cannot target `annotatedMethod`.',
+    'Remove the JsonSerializable annotation from `annotatedMethod`.')
 @JsonSerializable()
 void annotatedMethod() => null;
 
@@ -161,6 +167,10 @@ class NoCtorClass {
   factory NoCtorClass.fromJson(Map<String, dynamic> json) => null;
 }
 
+@ShouldThrow(
+    'fails if name duplicates existing field',
+    'More than one field has the JSON key `str`.',
+    'Check the `JsonKey` annotations on fields.')
 @JsonSerializable(createFactory: false)
 class KeyDupesField {
   @JsonKey(name: 'str')
@@ -169,6 +179,10 @@ class KeyDupesField {
   String str;
 }
 
+@ShouldThrow(
+    'fails if two names collide',
+    'More than one field has the JSON key `a`.',
+    'Check the `JsonKey` annotations on fields.')
 @JsonSerializable(createFactory: false)
 class DupeKeys {
   @JsonKey(name: 'a')
@@ -203,6 +217,11 @@ class PrivateFieldCtorClass {
   PrivateFieldCtorClass(this._privateField);
 }
 
+@ShouldThrow(
+    '`disallowNullvalue` and `includeIfNull` both `true`',
+    'Error with `@JsonKey` on `field`. '
+    'Cannot set both `disallowNullvalue` and `includeIfNull` to `true`. '
+    'This leads to incompatible `toJson` and `fromJson` behavior.')
 @JsonSerializable()
 class IncludeIfNullDisallowNullClass {
   @JsonKey(includeIfNull: true, disallowNullValue: true)
@@ -248,6 +267,10 @@ class TrivialNestedNonNullable {
   int otherField;
 }
 
+@ShouldThrow(
+    'enums annotated with JsonValue must be string, int or null',
+    'The `JsonValue` annotation on `BadEnum.value` does not have a value '
+    'of type String, int, or null.')
 @JsonSerializable()
 class JsonValueWithBool {
   BadEnum field;

--- a/json_serializable/test/src/to_from_json_test_input.dart
+++ b/json_serializable/test/src/to_from_json_test_input.dart
@@ -10,18 +10,31 @@ int _twoArgFunction(int a, int b) => 42;
 dynamic _toDynamic(dynamic input) => null;
 Object _toObject(Object input) => null;
 
+@ShouldThrow(
+    'fromJson with function with incompatible return type',
+    'Error with `@JsonKey` on `field`. The `fromJson` function `_toInt` '
+    'return type `int` is not compatible with field type `String`.')
 @JsonSerializable()
 class BadFromFuncReturnType {
   @JsonKey(fromJson: _toInt)
   String field;
 }
 
+@ShouldThrow(
+    'fromJson function with 2 arg fromJson function',
+    'Error with `@JsonKey` on `field`. The `fromJson` function '
+    '`_twoArgFunction` must have one positional paramater.')
 @JsonSerializable()
 class InvalidFromFunc2Args {
   @JsonKey(fromJson: _twoArgFunction)
   String field;
 }
 
+@ShouldThrow(
+    'with class static function',
+    'Error with `@JsonKey` on `field`. '
+    'The function provided for `fromJson` must be top-level. '
+    'Static class methods (`_staticFunc`) are not supported.')
 @JsonSerializable()
 class InvalidFromFuncClassStatic {
   static Duration _staticFunc(int param) => null;
@@ -30,18 +43,31 @@ class InvalidFromFuncClassStatic {
   String field;
 }
 
+@ShouldThrow(
+    'mismatched toJson return value',
+    'Error with `@JsonKey` on `field`. The `toJson` function `_toInt` '
+    'argument type `bool` is not compatible with field type `String`.')
 @JsonSerializable()
 class BadToFuncReturnType {
   @JsonKey(toJson: _toInt)
   String field;
 }
 
+@ShouldThrow(
+    'toJson function with 2 potitional required args',
+    'Error with `@JsonKey` on `field`. The `toJson` function '
+    '`_twoArgFunction` must have one positional paramater.')
 @JsonSerializable()
 class InvalidToFunc2Args {
   @JsonKey(toJson: _twoArgFunction)
   String field;
 }
 
+@ShouldThrow(
+    'toJson with class static function',
+    'Error with `@JsonKey` on `field`. '
+    'The function provided for `toJson` must be top-level. '
+    'Static class methods (`_staticFunc`) are not supported.')
 @JsonSerializable()
 class InvalidToFuncClassStatic {
   static Duration _staticFunc(int param) => null;
@@ -86,6 +112,10 @@ class FromDynamicCollection {
 
 String _noArgs() => null;
 
+@ShouldThrow(
+    'fromJson with zero-arg function',
+    'Error with `@JsonKey` on `field`. The `fromJson` function '
+    '`_noArgs` must have one positional paramater.')
 @JsonSerializable(createToJson: false)
 class BadNoArgs {
   @JsonKey(fromJson: _noArgs)
@@ -94,6 +124,10 @@ class BadNoArgs {
 
 String _twoArgs(a, b) => null;
 
+@ShouldThrow(
+    'fromJson with function with two positional args',
+    'Error with `@JsonKey` on `field`. The `fromJson` function '
+    '`_twoArgs` must have one positional paramater.')
 @JsonSerializable(createToJson: false)
 class BadTwoRequiredPositional {
   @JsonKey(fromJson: _twoArgs)
@@ -102,6 +136,10 @@ class BadTwoRequiredPositional {
 
 String _oneNamed({a}) => null;
 
+@ShouldThrow(
+    'fromJson with function with one named arg',
+    'Error with `@JsonKey` on `field`. The `fromJson` function '
+    '`_oneNamed` must have one positional paramater.')
 @JsonSerializable(createToJson: false)
 class BadOneNamed {
   @JsonKey(fromJson: _oneNamed)


### PR DESCRIPTION
For json_serializable_test - makes things much more DRY