### PR TITLE
Export all TypeHelper implementations in type_helper.dart

### DIFF
--- a/json_serializable/CHANGELOG.md
+++ b/json_serializable/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 1.3.1
+
+* Export the following `TypeHelper` implementations in `package:json_serializable/type_helper.dart`:  
+  `ConvertHelper`, `MapHelper`, `EnumHelper`, `IterableHelper`, `ValueHelper`
+
 ## 1.3.0
 
 * Added support for `Set` type as a target.

--- a/json_serializable/lib/type_helper.dart
+++ b/json_serializable/lib/type_helper.dart
@@ -5,6 +5,11 @@
 export 'src/shared_checkers.dart' show simpleJsonTypeChecker, typeArgumentsOf;
 export 'src/type_helper.dart'
     show SerializeContext, DeserializeContext, TypeHelper, UnsupportedTypeError;
+export 'src/type_helpers/convert_helper.dart';
 export 'src/type_helpers/date_time_helper.dart';
+export 'src/type_helpers/enum_helper.dart';
+export 'src/type_helpers/iterable_helper.dart';
 export 'src/type_helpers/json_helper.dart';
+export 'src/type_helpers/map_helper.dart';
 export 'src/type_helpers/uri_helper.dart';
+export 'src/type_helpers/value_helper.dart';


### PR DESCRIPTION
Export all helpers in type_helper.dart so they can be reused in other packages (like dartson).
See https://github.com/eredo/dartson/issues/48#issuecomment-419239742 for original discussion. 