### PR TITLE
4 commits: mostly about supporting now JsonConverter logic

### DIFF
--- a/analysis_options.yaml
+++ b/analysis_options.yaml
@@ -52,7 +52,8 @@ linter:
     - prefer_adjacent_string_concatenation
     - prefer_collection_literals
     - prefer_conditional_assignment
-    - prefer_const_constructors
+    # Waiting on SDK >=2.1.0-dev.5.0 with linter fix
+    #- prefer_const_constructors
     - prefer_contains
     - prefer_equal_for_default_values
     - prefer_final_fields
@@ -73,7 +74,8 @@ linter:
     # Waiting on https://github.com/dart-lang/test/issues/915
     #- unnecessary_const
     - unnecessary_getters_setters
-    - unnecessary_lambdas
+    # We'll need a way to return a lambda from a TypeHelper to re-enable this
+    #- unnecessary_lambdas
     - unnecessary_new
     - unnecessary_null_aware_assignments
     - unnecessary_statements

--- a/json_annotation/CHANGELOG.md
+++ b/json_annotation/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 1.2.0
+
+* Added `JsonConverter` class to support custom conversion of types.
+
 ## 1.1.0
 
 * Added the `fieldRename` option to `JsonSerializable` and the associated

--- a/json_annotation/lib/json_annotation.dart
+++ b/json_annotation/lib/json_annotation.dart
@@ -12,6 +12,7 @@ library json_annotation;
 
 export 'src/allowed_keys_helpers.dart';
 export 'src/checked_helpers.dart';
+export 'src/json_converter.dart';
 export 'src/json_literal.dart';
 export 'src/json_serializable.dart';
 export 'src/wrapper_helpers.dart';

--- a/json_annotation/lib/src/json_converter.dart
+++ b/json_annotation/lib/src/json_converter.dart
@@ -1,0 +1,14 @@
+// Copyright (c) 2018, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+/// Implement this class to provide custom converters for a specific [Type].
+///
+/// [T] is the data type you'd like to convert to and from.
+///
+/// [S] is the type of the value stored in JSON. It must be a valid JSON type
+/// such as [String], [int], or [Map<String, dynamic>].
+abstract class JsonConverter<T, S> {
+  T fromJson(S json);
+  S toJson(T object);
+}

--- a/json_annotation/pubspec.yaml
+++ b/json_annotation/pubspec.yaml
@@ -1,5 +1,5 @@
 name: json_annotation
-version: 1.1.0
+version: 1.2.0-dev
 description: >-
   Classes and helper functions that support JSON code generation via the
   `json_serializable` package.

--- a/json_serializable/CHANGELOG.md
+++ b/json_serializable/CHANGELOG.md
@@ -1,9 +1,12 @@
-## 1.3.1
-
-* Export the following `TypeHelper` implementations in `package:json_serializable/type_helper.dart`:  
-  `ConvertHelper`, `MapHelper`, `EnumHelper`, `IterableHelper`, `ValueHelper`
-
 ## 1.3.0
+
+* Add support for types annotated with classes that extend `JsonConverter` from
+  `package:json_annotation`.
+
+* Export the following `TypeHelper` implementations in 
+  `package:json_serializable/type_helper.dart`:  
+  `ConvertHelper`, `EnumHelper`, `IterableHelper`, `JsonConverterHelper`, 
+  `MapHelper`, `ValueHelper`
 
 * Added support for `Set` type as a target.
 

--- a/json_serializable/lib/src/json_serializable_generator.dart
+++ b/json_serializable/lib/src/json_serializable_generator.dart
@@ -16,6 +16,7 @@ import 'type_helpers/convert_helper.dart';
 import 'type_helpers/date_time_helper.dart';
 import 'type_helpers/enum_helper.dart';
 import 'type_helpers/iterable_helper.dart';
+import 'type_helpers/json_converter_helper.dart';
 import 'type_helpers/json_helper.dart';
 import 'type_helpers/map_helper.dart';
 import 'type_helpers/uri_helper.dart';
@@ -31,16 +32,17 @@ class JsonSerializableGenerator
     IterableHelper(),
     MapHelper(),
     EnumHelper(),
-    ValueHelper()
+    ValueHelper(),
   ];
 
   static const _defaultHelpers = [JsonHelper(), DateTimeHelper(), UriHelper()];
 
   final List<TypeHelper> _typeHelpers;
 
-  Iterable<TypeHelper> get _allHelpers => const <TypeHelper>[ConvertHelper()]
-      .followedBy(_typeHelpers)
-      .followedBy(_coreHelpers);
+  Iterable<TypeHelper> get _allHelpers => const <TypeHelper>[
+        ConvertHelper(),
+        JsonConverterHelper()
+      ].followedBy(_typeHelpers).followedBy(_coreHelpers);
 
   /// If `true`, wrappers are used to minimize the number of
   /// [Map] and [List] instances created during serialization.

--- a/json_serializable/lib/src/type_helper_context.dart
+++ b/json_serializable/lib/src/type_helper_context.dart
@@ -25,6 +25,8 @@ class TypeHelperContext implements SerializeContext, DeserializeContext {
 
   bool get explicitToJson => _helperCore.generator.explicitToJson;
 
+  ClassElement get classElement => _helperCore.element;
+
   @override
   bool get nullable => _key.nullable;
 

--- a/json_serializable/lib/src/type_helpers/json_converter_helper.dart
+++ b/json_serializable/lib/src/type_helpers/json_converter_helper.dart
@@ -1,0 +1,159 @@
+// Copyright (c) 2018, the Dart project authors. Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+import 'package:analyzer/dart/constant/value.dart';
+import 'package:analyzer/dart/element/element.dart';
+import 'package:analyzer/dart/element/type.dart';
+
+import 'package:json_annotation/json_annotation.dart';
+import 'package:source_gen/source_gen.dart';
+
+import '../shared_checkers.dart';
+import '../type_helper.dart';
+import '../type_helper_context.dart';
+
+/// A [TypeHelper] that supports classes annotated with implementations of
+/// [JsonConverter].
+class JsonConverterHelper extends TypeHelper {
+  const JsonConverterHelper();
+
+  @override
+  String serialize(
+      DartType targetType, String expression, SerializeContext context) {
+    var converter = _typeConverter(targetType, context as TypeHelperContext);
+
+    if (converter == null) {
+      return null;
+    }
+
+    return '${converter.accessString}.toJson($expression)';
+  }
+
+  @override
+  String deserialize(
+      DartType targetType, String expression, DeserializeContext context) {
+    var converter = _typeConverter(targetType, context as TypeHelperContext);
+    if (converter == null) {
+      return null;
+    }
+
+    var asContent = asStatement(converter.jsonType);
+
+    return '${converter.accessString}.fromJson($expression$asContent)';
+  }
+}
+
+class _JsonConvertData {
+  final String accessString;
+  final DartType jsonType;
+
+  _JsonConvertData.className(String className, String accessor, this.jsonType)
+      : this.accessString = 'const $className${_withAccessor(accessor)}()';
+
+  _JsonConvertData.genericClass(
+      String className, String genericTypeArg, String accessor, this.jsonType)
+      : this.accessString =
+            '$className<$genericTypeArg>${_withAccessor(accessor)}()';
+
+  _JsonConvertData.propertyAccess(this.accessString, this.jsonType);
+
+  static String _withAccessor(String accessor) =>
+      accessor.isEmpty ? '' : '.$accessor';
+}
+
+_JsonConvertData _typeConverter(DartType targetType, TypeHelperContext ctx) {
+  var matchingAnnotations = ctx.classElement.metadata
+      .map((annotation) => _compatibleMatch(targetType, annotation))
+      .where((dt) => dt != null)
+      .toList();
+
+  if (matchingAnnotations.isEmpty) {
+    return null;
+  }
+
+  if (matchingAnnotations.length > 1) {
+    throw InvalidGenerationSourceError(
+        'Found more than one matching converter for `$targetType`.',
+        element: matchingAnnotations[1].elementAnnotation.element);
+  }
+
+  var match = matchingAnnotations.single;
+
+  var annotationElement = match.elementAnnotation.element;
+  if (annotationElement is PropertyAccessorElement) {
+    var enclosing = annotationElement.enclosingElement;
+
+    var accessString = annotationElement.name;
+
+    if (enclosing is ClassElement) {
+      accessString = '${enclosing.name}.$accessString';
+    }
+
+    return _JsonConvertData.propertyAccess(accessString, match.jsonType);
+  }
+
+  var reviver = ConstantReader(match.annotation).revive();
+
+  if (reviver.namedArguments.isNotEmpty ||
+      reviver.positionalArguments.isNotEmpty) {
+    throw InvalidGenerationSourceError(
+        'Generators with constructor arguments are not supported.',
+        element: match.elementAnnotation.element);
+  }
+
+  if (match.genericTypeArg != null) {
+    return _JsonConvertData.genericClass(match.annotation.type.name,
+        match.genericTypeArg, reviver.accessor, match.jsonType);
+  }
+
+  return _JsonConvertData.className(
+      match.annotation.type.name, reviver.accessor, match.jsonType);
+}
+
+class _ConverterMatch {
+  final DartObject annotation;
+  final DartType jsonType;
+  final ElementAnnotation elementAnnotation;
+  final String genericTypeArg;
+
+  _ConverterMatch(this.elementAnnotation, this.annotation, this.jsonType,
+      this.genericTypeArg);
+}
+
+_ConverterMatch _compatibleMatch(
+    DartType targetType, ElementAnnotation annotation) {
+  var constantValue = annotation.computeConstantValue();
+
+  var jsonConverterSuper = (constantValue.type.element as ClassElement)
+      .allSupertypes
+      .singleWhere(
+          (e) =>
+              e is InterfaceType && _jsonConverterChecker.isExactly(e.element),
+          orElse: () => null);
+
+  if (jsonConverterSuper == null) {
+    return null;
+  }
+
+  assert(jsonConverterSuper.typeParameters.length == 2);
+  assert(jsonConverterSuper.typeArguments.length == 2);
+
+  var fieldType = jsonConverterSuper.typeArguments[0];
+
+  if (fieldType.isEquivalentTo(targetType)) {
+    return _ConverterMatch(
+        annotation, constantValue, jsonConverterSuper.typeArguments[1], null);
+  }
+
+  if (fieldType is TypeParameterType && targetType is TypeParameterType) {
+    assert(annotation.element is! PropertyAccessorElement);
+
+    return _ConverterMatch(annotation, constantValue,
+        jsonConverterSuper.typeArguments[1], targetType.name);
+  }
+
+  return null;
+}
+
+const _jsonConverterChecker = TypeChecker.fromRuntime(JsonConverter);

--- a/json_serializable/lib/type_helper.dart
+++ b/json_serializable/lib/type_helper.dart
@@ -9,6 +9,7 @@ export 'src/type_helpers/convert_helper.dart';
 export 'src/type_helpers/date_time_helper.dart';
 export 'src/type_helpers/enum_helper.dart';
 export 'src/type_helpers/iterable_helper.dart';
+export 'src/type_helpers/json_converter_helper.dart';
 export 'src/type_helpers/json_helper.dart';
 export 'src/type_helpers/map_helper.dart';
 export 'src/type_helpers/uri_helper.dart';

--- a/json_serializable/pubspec.yaml
+++ b/json_serializable/pubspec.yaml
@@ -13,7 +13,7 @@ dependencies:
 
   # Use a tight version constraint to ensure that a constraint on
   # `json_annotation`. Properly constrains all features it provides.
-  json_annotation: '>=1.1.0 <1.2.0'
+  json_annotation: '>=1.2.0 <1.3.0'
   meta: ^1.1.0
   path: ^1.3.2
   source_gen: ^0.9.0
@@ -27,3 +27,7 @@ dev_dependencies:
   logging: ^0.11.3+1
   test: ^1.0.0
   yaml: ^2.1.13
+
+dependency_overrides:
+  json_annotation:
+    path: ../json_annotation

--- a/json_serializable/test/json_serializable_test.dart
+++ b/json_serializable/test/json_serializable_test.dart
@@ -154,8 +154,8 @@ void main() async {
   for (var entry in _annotatedElements.entries) {
     group(entry.key, () {
       test('[all expected classes]', () {
-        expect(entry.value.map((ae) => ae.element.name),
-            _expectedAnnotatedTests[entry.key]);
+        expect(_expectedAnnotatedTests,
+            containsPair(entry.key, entry.value.map((ae) => ae.element.name)));
       });
 
       for (var annotatedElement in entry.value) {

--- a/json_serializable/test/json_serializable_test.dart
+++ b/json_serializable/test/json_serializable_test.dart
@@ -96,6 +96,11 @@ const _expectedAnnotatedTests = {
     'SubTypeWithAnnotatedFieldOverrideExtendsWithOverrides',
     'SubTypeWithAnnotatedFieldOverrideImplements'
   ],
+  'json_converter_test_input.dart': [
+    'JsonConverterNamedCtor',
+    'JsonConverterDuplicateAnnotations',
+    'JsonConverterCtorParams',
+  ],
   'setter_test_input.dart': [
     'JustSetter',
     'JustSetterNoToJson',

--- a/json_serializable/test/kitchen_sink/json_converters.dart
+++ b/json_serializable/test/kitchen_sink/json_converters.dart
@@ -1,0 +1,65 @@
+// Copyright (c) 2018, the Dart project authors. Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+import 'package:json_annotation/json_annotation.dart';
+
+class GenericConverter<T> implements JsonConverter<T, Map<String, dynamic>> {
+  const GenericConverter();
+
+  @override
+  T fromJson(Map<String, dynamic> json) => null;
+  @override
+  Map<String, dynamic> toJson(T object) => {};
+}
+
+class TrivialNumber {
+  final int value;
+  TrivialNumber(this.value);
+}
+
+class TrivialNumberConverter implements JsonConverter<TrivialNumber, int> {
+  static const instance = const TrivialNumberConverter();
+
+  const TrivialNumberConverter();
+
+  @override
+  TrivialNumber fromJson(int json) => json == null ? null : TrivialNumber(json);
+
+  @override
+  int toJson(TrivialNumber object) => object?.value;
+}
+
+class BigIntStringConverter implements JsonConverter<BigInt, String> {
+  const BigIntStringConverter();
+
+  @override
+  BigInt fromJson(String json) => json == null ? null : BigInt.parse(json);
+
+  @override
+  String toJson(BigInt object) => object?.toString();
+}
+
+const durationConverter = DurationMillisecondConverter();
+
+class DurationMillisecondConverter implements JsonConverter<Duration, int> {
+  const DurationMillisecondConverter();
+
+  @override
+  Duration fromJson(int json) =>
+      json == null ? null : Duration(milliseconds: json);
+
+  @override
+  int toJson(Duration object) => object?.inMilliseconds;
+}
+
+class EpochDateTimeConverter implements JsonConverter<DateTime, int> {
+  const EpochDateTimeConverter();
+
+  @override
+  DateTime fromJson(int json) =>
+      json == null ? null : DateTime.fromMillisecondsSinceEpoch(json);
+
+  @override
+  int toJson(DateTime object) => object?.millisecondsSinceEpoch;
+}

--- a/json_serializable/test/kitchen_sink/kitchen_sink.dart
+++ b/json_serializable/test/kitchen_sink/kitchen_sink.dart
@@ -5,6 +5,7 @@
 // ignore_for_file: annotate_overrides, hash_and_equals
 import 'package:json_annotation/json_annotation.dart';
 
+import 'json_converters.dart';
 import 'kitchen_sink_interface.dart' as k;
 import 'simple_object.dart';
 import 'strict_keys_object.dart';
@@ -133,4 +134,44 @@ class KitchenSink extends Object
   }
 
   bool operator ==(Object other) => k.sinkEquals(this, other);
+}
+
+@JsonSerializable()
+// referencing a top-level field should work
+@durationConverter
+// referencing via a const constructor should work
+@BigIntStringConverter()
+@TrivialNumberConverter.instance
+@EpochDateTimeConverter()
+class JsonConverterTestClass extends Object
+    with _$JsonConverterTestClassSerializerMixin {
+  JsonConverterTestClass();
+
+  factory JsonConverterTestClass.fromJson(Map<String, dynamic> json) =>
+      _$JsonConverterTestClassFromJson(json);
+
+  Duration duration;
+  List<Duration> durationList;
+
+  BigInt bigInt;
+  Map<String, BigInt> bigIntMap;
+
+  TrivialNumber numberSilly;
+  Set<TrivialNumber> numberSillySet;
+
+  DateTime dateTime;
+}
+
+@JsonSerializable()
+@GenericConverter()
+class JsonConverterGeneric<S, T, U> extends Object
+    with _$JsonConverterGenericSerializerMixin<S, T, U> {
+  S item;
+  List<T> itemList;
+  Map<String, U> itemMap;
+
+  JsonConverterGeneric();
+
+  factory JsonConverterGeneric.fromJson(Map<String, dynamic> json) =>
+      _$JsonConverterGenericFromJson(json);
 }

--- a/json_serializable/test/kitchen_sink/kitchen_sink.g.dart
+++ b/json_serializable/test/kitchen_sink/kitchen_sink.g.dart
@@ -138,3 +138,69 @@ abstract class _$KitchenSinkSerializerMixin {
     return val;
   }
 }
+
+JsonConverterTestClass _$JsonConverterTestClassFromJson(Map json) {
+  return JsonConverterTestClass()
+    ..duration = durationConverter.fromJson(json['duration'] as int)
+    ..durationList = (json['durationList'] as List)
+        ?.map((e) => durationConverter.fromJson(e as int))
+        ?.toList()
+    ..bigInt = const BigIntStringConverter().fromJson(json['bigInt'] as String)
+    ..bigIntMap = (json['bigIntMap'] as Map)?.map((k, e) => MapEntry(
+        k as String, const BigIntStringConverter().fromJson(e as String)))
+    ..numberSilly =
+        TrivialNumberConverter.instance.fromJson(json['numberSilly'] as int)
+    ..numberSillySet = (json['numberSillySet'] as List)
+        ?.map((e) => TrivialNumberConverter.instance.fromJson(e as int))
+        ?.toSet()
+    ..dateTime =
+        const EpochDateTimeConverter().fromJson(json['dateTime'] as int);
+}
+
+abstract class _$JsonConverterTestClassSerializerMixin {
+  Duration get duration;
+  List<Duration> get durationList;
+  BigInt get bigInt;
+  Map<String, BigInt> get bigIntMap;
+  TrivialNumber get numberSilly;
+  Set<TrivialNumber> get numberSillySet;
+  DateTime get dateTime;
+  Map<String, dynamic> toJson() => <String, dynamic>{
+        'duration': durationConverter.toJson(duration),
+        'durationList':
+            durationList?.map((e) => durationConverter.toJson(e))?.toList(),
+        'bigInt': const BigIntStringConverter().toJson(bigInt),
+        'bigIntMap': bigIntMap?.map(
+            (k, e) => MapEntry(k, const BigIntStringConverter().toJson(e))),
+        'numberSilly': TrivialNumberConverter.instance.toJson(numberSilly),
+        'numberSillySet': numberSillySet
+            ?.map((e) => TrivialNumberConverter.instance.toJson(e))
+            ?.toList(),
+        'dateTime': const EpochDateTimeConverter().toJson(dateTime)
+      };
+}
+
+JsonConverterGeneric<S, T, U> _$JsonConverterGenericFromJson<S, T, U>(
+    Map json) {
+  return JsonConverterGeneric<S, T, U>()
+    ..item =
+        GenericConverter<S>().fromJson(json['item'] as Map<String, dynamic>)
+    ..itemList = (json['itemList'] as List)
+        ?.map((e) => GenericConverter<T>().fromJson(e as Map<String, dynamic>))
+        ?.toList()
+    ..itemMap = (json['itemMap'] as Map)?.map((k, e) => MapEntry(k as String,
+        GenericConverter<U>().fromJson(e as Map<String, dynamic>)));
+}
+
+abstract class _$JsonConverterGenericSerializerMixin<S, T, U> {
+  S get item;
+  List<T> get itemList;
+  Map<String, U> get itemMap;
+  Map<String, dynamic> toJson() => <String, dynamic>{
+        'item': GenericConverter<S>().toJson(item),
+        'itemList':
+            itemList?.map((e) => GenericConverter<T>().toJson(e))?.toList(),
+        'itemMap':
+            itemMap?.map((k, e) => MapEntry(k, GenericConverter<U>().toJson(e)))
+      };
+}

--- a/json_serializable/test/kitchen_sink/kitchen_sink.non_nullable.checked.dart
+++ b/json_serializable/test/kitchen_sink/kitchen_sink.non_nullable.checked.dart
@@ -17,6 +17,7 @@
 // ignore_for_file: annotate_overrides, hash_and_equals
 import 'package:json_annotation/json_annotation.dart';
 
+import 'json_converters.dart';
 import 'kitchen_sink_interface.dart' as k;
 import 'simple_object.dart';
 import 'strict_keys_object.dart';
@@ -145,4 +146,44 @@ class KitchenSink extends Object
   }
 
   bool operator ==(Object other) => k.sinkEquals(this, other);
+}
+
+@JsonSerializable(nullable: false)
+// referencing a top-level field should work
+@durationConverter
+// referencing via a const constructor should work
+@BigIntStringConverter()
+@TrivialNumberConverter.instance
+@EpochDateTimeConverter()
+class JsonConverterTestClass extends Object
+    with _$JsonConverterTestClassSerializerMixin {
+  JsonConverterTestClass();
+
+  factory JsonConverterTestClass.fromJson(Map<String, dynamic> json) =>
+      _$JsonConverterTestClassFromJson(json);
+
+  Duration duration;
+  List<Duration> durationList;
+
+  BigInt bigInt;
+  Map<String, BigInt> bigIntMap;
+
+  TrivialNumber numberSilly;
+  Set<TrivialNumber> numberSillySet;
+
+  DateTime dateTime = DateTime(1981, 6, 5);
+}
+
+@JsonSerializable(nullable: false)
+@GenericConverter()
+class JsonConverterGeneric<S, T, U> extends Object
+    with _$JsonConverterGenericSerializerMixin<S, T, U> {
+  S item;
+  List<T> itemList;
+  Map<String, U> itemMap;
+
+  JsonConverterGeneric();
+
+  factory JsonConverterGeneric.fromJson(Map<String, dynamic> json) =>
+      _$JsonConverterGenericFromJson(json);
 }

--- a/json_serializable/test/kitchen_sink/kitchen_sink.non_nullable.checked.g.dart
+++ b/json_serializable/test/kitchen_sink/kitchen_sink.non_nullable.checked.g.dart
@@ -156,3 +156,105 @@ abstract class _$KitchenSinkSerializerMixin {
         'validatedPropertyNo42': validatedPropertyNo42
       };
 }
+
+JsonConverterTestClass _$JsonConverterTestClassFromJson(Map json) {
+  return $checkedNew('JsonConverterTestClass', json, () {
+    var val = JsonConverterTestClass();
+    $checkedConvert(json, 'duration',
+        (v) => val.duration = durationConverter.fromJson(v as int));
+    $checkedConvert(
+        json,
+        'durationList',
+        (v) => val.durationList = (v as List)
+            .map((e) => durationConverter.fromJson(e as int))
+            .toList());
+    $checkedConvert(
+        json,
+        'bigInt',
+        (v) =>
+            val.bigInt = const BigIntStringConverter().fromJson(v as String));
+    $checkedConvert(
+        json,
+        'bigIntMap',
+        (v) => val.bigIntMap = (v as Map).map((k, e) => MapEntry(
+            k as String, const BigIntStringConverter().fromJson(e as String))));
+    $checkedConvert(
+        json,
+        'numberSilly',
+        (v) => val.numberSilly =
+            TrivialNumberConverter.instance.fromJson(v as int));
+    $checkedConvert(
+        json,
+        'numberSillySet',
+        (v) => val.numberSillySet = (v as List)
+            .map((e) => TrivialNumberConverter.instance.fromJson(e as int))
+            .toSet());
+    $checkedConvert(
+        json,
+        'dateTime',
+        (v) =>
+            val.dateTime = const EpochDateTimeConverter().fromJson(v as int));
+    return val;
+  });
+}
+
+abstract class _$JsonConverterTestClassSerializerMixin {
+  Duration get duration;
+  List<Duration> get durationList;
+  BigInt get bigInt;
+  Map<String, BigInt> get bigIntMap;
+  TrivialNumber get numberSilly;
+  Set<TrivialNumber> get numberSillySet;
+  DateTime get dateTime;
+  Map<String, dynamic> toJson() => <String, dynamic>{
+        'duration': durationConverter.toJson(duration),
+        'durationList':
+            durationList.map((e) => durationConverter.toJson(e)).toList(),
+        'bigInt': const BigIntStringConverter().toJson(bigInt),
+        'bigIntMap': bigIntMap.map(
+            (k, e) => MapEntry(k, const BigIntStringConverter().toJson(e))),
+        'numberSilly': TrivialNumberConverter.instance.toJson(numberSilly),
+        'numberSillySet': numberSillySet
+            .map((e) => TrivialNumberConverter.instance.toJson(e))
+            .toList(),
+        'dateTime': const EpochDateTimeConverter().toJson(dateTime)
+      };
+}
+
+JsonConverterGeneric<S, T, U> _$JsonConverterGenericFromJson<S, T, U>(
+    Map json) {
+  return $checkedNew('JsonConverterGeneric', json, () {
+    var val = JsonConverterGeneric<S, T, U>();
+    $checkedConvert(
+        json,
+        'item',
+        (v) => val.item =
+            GenericConverter<S>().fromJson(v as Map<String, dynamic>));
+    $checkedConvert(
+        json,
+        'itemList',
+        (v) => val.itemList = (v as List)
+            .map((e) =>
+                GenericConverter<T>().fromJson(e as Map<String, dynamic>))
+            .toList());
+    $checkedConvert(
+        json,
+        'itemMap',
+        (v) => val.itemMap = (v as Map).map((k, e) => MapEntry(k as String,
+            GenericConverter<U>().fromJson(e as Map<String, dynamic>))));
+    return val;
+  });
+}
+
+abstract class _$JsonConverterGenericSerializerMixin<S, T, U> {
+  S get item;
+  List<T> get itemList;
+  Map<String, U> get itemMap;
+  Map<String, dynamic> toJson() => <String, dynamic>{
+        'item': GenericConverter<S>().toJson(item),
+        'itemList':
+            itemList.map((e) => GenericConverter<T>().toJson(e)).toList(),
+        'itemMap':
+            itemMap.map((k, e) => MapEntry(k, GenericConverter<U>().toJson(e)))
+      };
+}

--- a/json_serializable/test/kitchen_sink/kitchen_sink.non_nullable.dart
+++ b/json_serializable/test/kitchen_sink/kitchen_sink.non_nullable.dart
@@ -11,6 +11,7 @@
 // ignore_for_file: annotate_overrides, hash_and_equals
 import 'package:json_annotation/json_annotation.dart';
 
+import 'json_converters.dart';
 import 'kitchen_sink_interface.dart' as k;
 import 'simple_object.dart';
 import 'strict_keys_object.dart';
@@ -139,4 +140,44 @@ class KitchenSink extends Object
   }
 
   bool operator ==(Object other) => k.sinkEquals(this, other);
+}
+
+@JsonSerializable(nullable: false)
+// referencing a top-level field should work
+@durationConverter
+// referencing via a const constructor should work
+@BigIntStringConverter()
+@TrivialNumberConverter.instance
+@EpochDateTimeConverter()
+class JsonConverterTestClass extends Object
+    with _$JsonConverterTestClassSerializerMixin {
+  JsonConverterTestClass();
+
+  factory JsonConverterTestClass.fromJson(Map<String, dynamic> json) =>
+      _$JsonConverterTestClassFromJson(json);
+
+  Duration duration;
+  List<Duration> durationList;
+
+  BigInt bigInt;
+  Map<String, BigInt> bigIntMap;
+
+  TrivialNumber numberSilly;
+  Set<TrivialNumber> numberSillySet;
+
+  DateTime dateTime = DateTime(1981, 6, 5);
+}
+
+@JsonSerializable(nullable: false)
+@GenericConverter()
+class JsonConverterGeneric<S, T, U> extends Object
+    with _$JsonConverterGenericSerializerMixin<S, T, U> {
+  S item;
+  List<T> itemList;
+  Map<String, U> itemMap;
+
+  JsonConverterGeneric();
+
+  factory JsonConverterGeneric.fromJson(Map<String, dynamic> json) =>
+      _$JsonConverterGenericFromJson(json);
 }

--- a/json_serializable/test/kitchen_sink/kitchen_sink.non_nullable.g.dart
+++ b/json_serializable/test/kitchen_sink/kitchen_sink.non_nullable.g.dart
@@ -123,3 +123,69 @@ abstract class _$KitchenSinkSerializerMixin {
         'validatedPropertyNo42': validatedPropertyNo42
       };
 }
+
+JsonConverterTestClass _$JsonConverterTestClassFromJson(Map json) {
+  return JsonConverterTestClass()
+    ..duration = durationConverter.fromJson(json['duration'] as int)
+    ..durationList = (json['durationList'] as List)
+        .map((e) => durationConverter.fromJson(e as int))
+        .toList()
+    ..bigInt = const BigIntStringConverter().fromJson(json['bigInt'] as String)
+    ..bigIntMap = (json['bigIntMap'] as Map).map((k, e) => MapEntry(
+        k as String, const BigIntStringConverter().fromJson(e as String)))
+    ..numberSilly =
+        TrivialNumberConverter.instance.fromJson(json['numberSilly'] as int)
+    ..numberSillySet = (json['numberSillySet'] as List)
+        .map((e) => TrivialNumberConverter.instance.fromJson(e as int))
+        .toSet()
+    ..dateTime =
+        const EpochDateTimeConverter().fromJson(json['dateTime'] as int);
+}
+
+abstract class _$JsonConverterTestClassSerializerMixin {
+  Duration get duration;
+  List<Duration> get durationList;
+  BigInt get bigInt;
+  Map<String, BigInt> get bigIntMap;
+  TrivialNumber get numberSilly;
+  Set<TrivialNumber> get numberSillySet;
+  DateTime get dateTime;
+  Map<String, dynamic> toJson() => <String, dynamic>{
+        'duration': durationConverter.toJson(duration),
+        'durationList':
+            durationList.map((e) => durationConverter.toJson(e)).toList(),
+        'bigInt': const BigIntStringConverter().toJson(bigInt),
+        'bigIntMap': bigIntMap.map(
+            (k, e) => MapEntry(k, const BigIntStringConverter().toJson(e))),
+        'numberSilly': TrivialNumberConverter.instance.toJson(numberSilly),
+        'numberSillySet': numberSillySet
+            .map((e) => TrivialNumberConverter.instance.toJson(e))
+            .toList(),
+        'dateTime': const EpochDateTimeConverter().toJson(dateTime)
+      };
+}
+
+JsonConverterGeneric<S, T, U> _$JsonConverterGenericFromJson<S, T, U>(
+    Map json) {
+  return JsonConverterGeneric<S, T, U>()
+    ..item =
+        GenericConverter<S>().fromJson(json['item'] as Map<String, dynamic>)
+    ..itemList = (json['itemList'] as List)
+        .map((e) => GenericConverter<T>().fromJson(e as Map<String, dynamic>))
+        .toList()
+    ..itemMap = (json['itemMap'] as Map).map((k, e) => MapEntry(k as String,
+        GenericConverter<U>().fromJson(e as Map<String, dynamic>)));
+}
+
+abstract class _$JsonConverterGenericSerializerMixin<S, T, U> {
+  S get item;
+  List<T> get itemList;
+  Map<String, U> get itemMap;
+  Map<String, dynamic> toJson() => <String, dynamic>{
+        'item': GenericConverter<S>().toJson(item),
+        'itemList':
+            itemList.map((e) => GenericConverter<T>().toJson(e)).toList(),
+        'itemMap':
+            itemMap.map((k, e) => MapEntry(k, GenericConverter<U>().toJson(e)))
+      };
+}

--- a/json_serializable/test/kitchen_sink/kitchen_sink.non_nullable.wrapped.dart
+++ b/json_serializable/test/kitchen_sink/kitchen_sink.non_nullable.wrapped.dart
@@ -17,6 +17,7 @@
 // ignore_for_file: annotate_overrides, hash_and_equals
 import 'package:json_annotation/json_annotation.dart';
 
+import 'json_converters.dart';
 import 'kitchen_sink_interface.dart' as k;
 import 'simple_object.dart';
 import 'strict_keys_object.dart';
@@ -145,4 +146,44 @@ class KitchenSink extends Object
   }
 
   bool operator ==(Object other) => k.sinkEquals(this, other);
+}
+
+@JsonSerializable(nullable: false)
+// referencing a top-level field should work
+@durationConverter
+// referencing via a const constructor should work
+@BigIntStringConverter()
+@TrivialNumberConverter.instance
+@EpochDateTimeConverter()
+class JsonConverterTestClass extends Object
+    with _$JsonConverterTestClassSerializerMixin {
+  JsonConverterTestClass();
+
+  factory JsonConverterTestClass.fromJson(Map<String, dynamic> json) =>
+      _$JsonConverterTestClassFromJson(json);
+
+  Duration duration;
+  List<Duration> durationList;
+
+  BigInt bigInt;
+  Map<String, BigInt> bigIntMap;
+
+  TrivialNumber numberSilly;
+  Set<TrivialNumber> numberSillySet;
+
+  DateTime dateTime = DateTime(1981, 6, 5);
+}
+
+@JsonSerializable(nullable: false)
+@GenericConverter()
+class JsonConverterGeneric<S, T, U> extends Object
+    with _$JsonConverterGenericSerializerMixin<S, T, U> {
+  S item;
+  List<T> itemList;
+  Map<String, U> itemMap;
+
+  JsonConverterGeneric();
+
+  factory JsonConverterGeneric.fromJson(Map<String, dynamic> json) =>
+      _$JsonConverterGenericFromJson(json);
 }

--- a/json_serializable/test/kitchen_sink/kitchen_sink.non_nullable.wrapped.g.dart
+++ b/json_serializable/test/kitchen_sink/kitchen_sink.non_nullable.wrapped.g.dart
@@ -197,3 +197,120 @@ class _$KitchenSinkJsonMapWrapper extends $JsonMapWrapper {
     return null;
   }
 }
+
+JsonConverterTestClass _$JsonConverterTestClassFromJson(Map json) {
+  return JsonConverterTestClass()
+    ..duration = durationConverter.fromJson(json['duration'] as int)
+    ..durationList = (json['durationList'] as List)
+        .map((e) => durationConverter.fromJson(e as int))
+        .toList()
+    ..bigInt = const BigIntStringConverter().fromJson(json['bigInt'] as String)
+    ..bigIntMap = (json['bigIntMap'] as Map).map((k, e) => MapEntry(
+        k as String, const BigIntStringConverter().fromJson(e as String)))
+    ..numberSilly =
+        TrivialNumberConverter.instance.fromJson(json['numberSilly'] as int)
+    ..numberSillySet = (json['numberSillySet'] as List)
+        .map((e) => TrivialNumberConverter.instance.fromJson(e as int))
+        .toSet()
+    ..dateTime =
+        const EpochDateTimeConverter().fromJson(json['dateTime'] as int);
+}
+
+abstract class _$JsonConverterTestClassSerializerMixin {
+  Duration get duration;
+  List<Duration> get durationList;
+  BigInt get bigInt;
+  Map<String, BigInt> get bigIntMap;
+  TrivialNumber get numberSilly;
+  Set<TrivialNumber> get numberSillySet;
+  DateTime get dateTime;
+  Map<String, dynamic> toJson() => _$JsonConverterTestClassJsonMapWrapper(this);
+}
+
+class _$JsonConverterTestClassJsonMapWrapper extends $JsonMapWrapper {
+  final _$JsonConverterTestClassSerializerMixin _v;
+  _$JsonConverterTestClassJsonMapWrapper(this._v);
+
+  @override
+  Iterable<String> get keys => const [
+        'duration',
+        'durationList',
+        'bigInt',
+        'bigIntMap',
+        'numberSilly',
+        'numberSillySet',
+        'dateTime'
+      ];
+
+  @override
+  dynamic operator [](Object key) {
+    if (key is String) {
+      switch (key) {
+        case 'duration':
+          return durationConverter.toJson(_v.duration);
+        case 'durationList':
+          return $wrapList<Duration>(
+              _v.durationList, (e) => durationConverter.toJson(e));
+        case 'bigInt':
+          return const BigIntStringConverter().toJson(_v.bigInt);
+        case 'bigIntMap':
+          return $wrapMap<String, BigInt>(
+              _v.bigIntMap, (e) => const BigIntStringConverter().toJson(e));
+        case 'numberSilly':
+          return TrivialNumberConverter.instance.toJson(_v.numberSilly);
+        case 'numberSillySet':
+          return _v.numberSillySet
+              .map((e) => TrivialNumberConverter.instance.toJson(e))
+              .toList();
+        case 'dateTime':
+          return const EpochDateTimeConverter().toJson(_v.dateTime);
+      }
+    }
+    return null;
+  }
+}
+
+JsonConverterGeneric<S, T, U> _$JsonConverterGenericFromJson<S, T, U>(
+    Map json) {
+  return JsonConverterGeneric<S, T, U>()
+    ..item =
+        GenericConverter<S>().fromJson(json['item'] as Map<String, dynamic>)
+    ..itemList = (json['itemList'] as List)
+        .map((e) => GenericConverter<T>().fromJson(e as Map<String, dynamic>))
+        .toList()
+    ..itemMap = (json['itemMap'] as Map).map((k, e) => MapEntry(k as String,
+        GenericConverter<U>().fromJson(e as Map<String, dynamic>)));
+}
+
+abstract class _$JsonConverterGenericSerializerMixin<S, T, U> {
+  S get item;
+  List<T> get itemList;
+  Map<String, U> get itemMap;
+  Map<String, dynamic> toJson() =>
+      _$JsonConverterGenericJsonMapWrapper<S, T, U>(this);
+}
+
+class _$JsonConverterGenericJsonMapWrapper<S, T, U> extends $JsonMapWrapper {
+  final _$JsonConverterGenericSerializerMixin<S, T, U> _v;
+  _$JsonConverterGenericJsonMapWrapper(this._v);
+
+  @override
+  Iterable<String> get keys => const ['item', 'itemList', 'itemMap'];
+
+  @override
+  dynamic operator [](Object key) {
+    if (key is String) {
+      switch (key) {
+        case 'item':
+          return GenericConverter<S>().toJson(_v.item);
+        case 'itemList':
+          return $wrapList<T>(
+              _v.itemList, (e) => GenericConverter<T>().toJson(e));
+        case 'itemMap':
+          return $wrapMap<String, U>(
+              _v.itemMap, (e) => GenericConverter<U>().toJson(e));
+      }
+    }
+    return null;
+  }
+}

--- a/json_serializable/test/kitchen_sink/kitchen_sink.wrapped.dart
+++ b/json_serializable/test/kitchen_sink/kitchen_sink.wrapped.dart
@@ -11,6 +11,7 @@
 // ignore_for_file: annotate_overrides, hash_and_equals
 import 'package:json_annotation/json_annotation.dart';
 
+import 'json_converters.dart';
 import 'kitchen_sink_interface.dart' as k;
 import 'simple_object.dart';
 import 'strict_keys_object.dart';
@@ -139,4 +140,44 @@ class KitchenSink extends Object
   }
 
   bool operator ==(Object other) => k.sinkEquals(this, other);
+}
+
+@JsonSerializable()
+// referencing a top-level field should work
+@durationConverter
+// referencing via a const constructor should work
+@BigIntStringConverter()
+@TrivialNumberConverter.instance
+@EpochDateTimeConverter()
+class JsonConverterTestClass extends Object
+    with _$JsonConverterTestClassSerializerMixin {
+  JsonConverterTestClass();
+
+  factory JsonConverterTestClass.fromJson(Map<String, dynamic> json) =>
+      _$JsonConverterTestClassFromJson(json);
+
+  Duration duration;
+  List<Duration> durationList;
+
+  BigInt bigInt;
+  Map<String, BigInt> bigIntMap;
+
+  TrivialNumber numberSilly;
+  Set<TrivialNumber> numberSillySet;
+
+  DateTime dateTime;
+}
+
+@JsonSerializable()
+@GenericConverter()
+class JsonConverterGeneric<S, T, U> extends Object
+    with _$JsonConverterGenericSerializerMixin<S, T, U> {
+  S item;
+  List<T> itemList;
+  Map<String, U> itemMap;
+
+  JsonConverterGeneric();
+
+  factory JsonConverterGeneric.fromJson(Map<String, dynamic> json) =>
+      _$JsonConverterGenericFromJson(json);
 }

--- a/json_serializable/test/kitchen_sink/kitchen_sink.wrapped.g.dart
+++ b/json_serializable/test/kitchen_sink/kitchen_sink.wrapped.g.dart
@@ -211,3 +211,120 @@ class _$KitchenSinkJsonMapWrapper extends $JsonMapWrapper {
     return null;
   }
 }
+
+JsonConverterTestClass _$JsonConverterTestClassFromJson(Map json) {
+  return JsonConverterTestClass()
+    ..duration = durationConverter.fromJson(json['duration'] as int)
+    ..durationList = (json['durationList'] as List)
+        ?.map((e) => durationConverter.fromJson(e as int))
+        ?.toList()
+    ..bigInt = const BigIntStringConverter().fromJson(json['bigInt'] as String)
+    ..bigIntMap = (json['bigIntMap'] as Map)?.map((k, e) => MapEntry(
+        k as String, const BigIntStringConverter().fromJson(e as String)))
+    ..numberSilly =
+        TrivialNumberConverter.instance.fromJson(json['numberSilly'] as int)
+    ..numberSillySet = (json['numberSillySet'] as List)
+        ?.map((e) => TrivialNumberConverter.instance.fromJson(e as int))
+        ?.toSet()
+    ..dateTime =
+        const EpochDateTimeConverter().fromJson(json['dateTime'] as int);
+}
+
+abstract class _$JsonConverterTestClassSerializerMixin {
+  Duration get duration;
+  List<Duration> get durationList;
+  BigInt get bigInt;
+  Map<String, BigInt> get bigIntMap;
+  TrivialNumber get numberSilly;
+  Set<TrivialNumber> get numberSillySet;
+  DateTime get dateTime;
+  Map<String, dynamic> toJson() => _$JsonConverterTestClassJsonMapWrapper(this);
+}
+
+class _$JsonConverterTestClassJsonMapWrapper extends $JsonMapWrapper {
+  final _$JsonConverterTestClassSerializerMixin _v;
+  _$JsonConverterTestClassJsonMapWrapper(this._v);
+
+  @override
+  Iterable<String> get keys => const [
+        'duration',
+        'durationList',
+        'bigInt',
+        'bigIntMap',
+        'numberSilly',
+        'numberSillySet',
+        'dateTime'
+      ];
+
+  @override
+  dynamic operator [](Object key) {
+    if (key is String) {
+      switch (key) {
+        case 'duration':
+          return durationConverter.toJson(_v.duration);
+        case 'durationList':
+          return $wrapListHandleNull<Duration>(
+              _v.durationList, (e) => durationConverter.toJson(e));
+        case 'bigInt':
+          return const BigIntStringConverter().toJson(_v.bigInt);
+        case 'bigIntMap':
+          return $wrapMapHandleNull<String, BigInt>(
+              _v.bigIntMap, (e) => const BigIntStringConverter().toJson(e));
+        case 'numberSilly':
+          return TrivialNumberConverter.instance.toJson(_v.numberSilly);
+        case 'numberSillySet':
+          return _v.numberSillySet
+              ?.map((e) => TrivialNumberConverter.instance.toJson(e))
+              ?.toList();
+        case 'dateTime':
+          return const EpochDateTimeConverter().toJson(_v.dateTime);
+      }
+    }
+    return null;
+  }
+}
+
+JsonConverterGeneric<S, T, U> _$JsonConverterGenericFromJson<S, T, U>(
+    Map json) {
+  return JsonConverterGeneric<S, T, U>()
+    ..item =
+        GenericConverter<S>().fromJson(json['item'] as Map<String, dynamic>)
+    ..itemList = (json['itemList'] as List)
+        ?.map((e) => GenericConverter<T>().fromJson(e as Map<String, dynamic>))
+        ?.toList()
+    ..itemMap = (json['itemMap'] as Map)?.map((k, e) => MapEntry(k as String,
+        GenericConverter<U>().fromJson(e as Map<String, dynamic>)));
+}
+
+abstract class _$JsonConverterGenericSerializerMixin<S, T, U> {
+  S get item;
+  List<T> get itemList;
+  Map<String, U> get itemMap;
+  Map<String, dynamic> toJson() =>
+      _$JsonConverterGenericJsonMapWrapper<S, T, U>(this);
+}
+
+class _$JsonConverterGenericJsonMapWrapper<S, T, U> extends $JsonMapWrapper {
+  final _$JsonConverterGenericSerializerMixin<S, T, U> _v;
+  _$JsonConverterGenericJsonMapWrapper(this._v);
+
+  @override
+  Iterable<String> get keys => const ['item', 'itemList', 'itemMap'];
+
+  @override
+  dynamic operator [](Object key) {
+    if (key is String) {
+      switch (key) {
+        case 'item':
+          return GenericConverter<S>().toJson(_v.item);
+        case 'itemList':
+          return $wrapListHandleNull<T>(
+              _v.itemList, (e) => GenericConverter<T>().toJson(e));
+        case 'itemMap':
+          return $wrapMapHandleNull<String, U>(
+              _v.itemMap, (e) => GenericConverter<U>().toJson(e));
+      }
+    }
+    return null;
+  }
+}

--- a/json_serializable/test/src/_json_serializable_test_input.dart
+++ b/json_serializable/test/src/_json_serializable_test_input.dart
@@ -12,6 +12,7 @@ part 'default_value_input.dart';
 part 'field_namer_input.dart';
 part 'generic_test_input.dart';
 part 'inheritance_test_input.dart';
+part 'json_converter_test_input.dart';
 part 'setter_test_input.dart';
 part 'to_from_json_test_input.dart';
 

--- a/json_serializable/test/src/json_converter_test_input.dart
+++ b/json_serializable/test/src/json_converter_test_input.dart
@@ -1,0 +1,99 @@
+// Copyright (c) 2018, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+part of '_json_serializable_test_input.dart';
+
+@ShouldGenerate(r'''
+JsonConverterNamedCtor<E> _$JsonConverterNamedCtorFromJson<E>(
+    Map<String, dynamic> json) {
+  return JsonConverterNamedCtor<E>()
+    ..value = const _DurationMillisecondConverter.named()
+        .fromJson(json['value'] as int)
+    ..genericValue =
+        _GenericConverter<E>.named().fromJson(json['genericValue'] as int)
+    ..keyAnnotationFirst = json['keyAnnotationFirst'] == null
+        ? null
+        : JsonConverterNamedCtor._fromJson(json['keyAnnotationFirst'] as int);
+}
+
+Map<String, dynamic> _$JsonConverterNamedCtorToJson<E>(
+        JsonConverterNamedCtor<E> instance) =>
+    <String, dynamic>{
+      'value':
+          const _DurationMillisecondConverter.named().toJson(instance.value),
+      'genericValue':
+          _GenericConverter<E>.named().toJson(instance.genericValue),
+      'keyAnnotationFirst': instance.keyAnnotationFirst == null
+          ? null
+          : JsonConverterNamedCtor._toJson(instance.keyAnnotationFirst)
+    };
+''')
+@JsonSerializable()
+@_DurationMillisecondConverter.named()
+@_GenericConverter.named()
+class JsonConverterNamedCtor<E> {
+  Duration value;
+  E genericValue;
+
+  // Field annotations have precedence over class annotations
+  @JsonKey(fromJson: _fromJson, toJson: _toJson)
+  Duration keyAnnotationFirst;
+
+  static Duration _fromJson(int value) => null;
+  static int _toJson(Duration object) => 42;
+}
+
+class _GenericConverter<T> implements JsonConverter<T, int> {
+  const _GenericConverter();
+  const _GenericConverter.named();
+
+  @override
+  T fromJson(int json) => null;
+
+  @override
+  int toJson(T object) => 0;
+}
+
+// More than one matching converter on a class
+@ShouldThrow('Found more than one matching converter for `Duration`.')
+@JsonSerializable()
+@_durationConverter
+@_DurationMillisecondConverter()
+class JsonConverterDuplicateAnnotations {
+  Duration value;
+}
+
+const _durationConverter = _DurationMillisecondConverter();
+
+class _DurationMillisecondConverter implements JsonConverter<Duration, int> {
+  const _DurationMillisecondConverter();
+
+  const _DurationMillisecondConverter.named();
+
+  @override
+  Duration fromJson(int json) =>
+      json == null ? null : Duration(milliseconds: json);
+
+  @override
+  int toJson(Duration object) => object?.inMilliseconds;
+}
+
+// converter has parameters
+@ShouldThrow('Generators with constructor arguments are not supported.')
+@JsonSerializable()
+@_ConverterWithCtorParams(42)
+class JsonConverterCtorParams {
+  Duration value;
+}
+
+class _ConverterWithCtorParams implements JsonConverter<Duration, int> {
+  final int param;
+  const _ConverterWithCtorParams(this.param);
+
+  @override
+  Duration fromJson(int json) => null;
+
+  @override
+  int toJson(Duration object) => 0;
+}


### PR DESCRIPTION
Related to https://github.com/dart-lang/json_serializable/issues/202

You can now annotate a class with an implementation of `JsonConverter` to support custom decode/encode.

This is a bit more readable than having separate to/from JSON annotations on a field. It also plugs in like a TypeHelper, so you can do things like `List<MyType>` or ever `List<T>` where T is a generic type for the class.