### PR TITLE
Refactor implementation of to/fromJson methods on fields

### DIFF
--- a/json_serializable/CHANGELOG.md
+++ b/json_serializable/CHANGELOG.md
@@ -1,3 +1,13 @@
+## 2.0.0
+
+* `package:json_serializable/type_helper.dart`
+
+  * **BREAKING** `ConvertHelper` constructor now has two required arguments
+    which allow it to find `ConvertData` associated with custom field serialize
+    methods.
+  
+  * Added new class `ConvertData`.
+
 ## 1.3.0
 
 * Add support for types annotated with classes that extend `JsonConverter` from

--- a/json_serializable/lib/src/convert_pair.dart
+++ b/json_serializable/lib/src/convert_pair.dart
@@ -30,8 +30,7 @@ class ConvertPair {
   }
 }
 
-ConvertData _convertData(
-    DartObject obj, FieldElement element, bool isFrom) {
+ConvertData _convertData(DartObject obj, FieldElement element, bool isFrom) {
   var paramName = isFrom ? 'fromJson' : 'toJson';
   var objectValue = obj.getField(paramName);
 

--- a/json_serializable/lib/src/convert_pair.dart
+++ b/json_serializable/lib/src/convert_pair.dart
@@ -1,0 +1,90 @@
+// Copyright (c) 2018, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+import 'package:analyzer/dart/element/element.dart';
+import 'package:analyzer/dart/element/type.dart';
+import 'package:analyzer/dart/constant/value.dart';
+import 'package:json_annotation/json_annotation.dart';
+
+import 'type_helpers/convert_helper.dart';
+import 'utils.dart';
+
+class ConvertPair {
+  static final _expando = Expando<ConvertPair>();
+  static ConvertPair fromJsonKey(JsonKey key) => _expando[key];
+
+  final ConvertData fromJson, toJson;
+
+  ConvertPair._(this.fromJson, this.toJson);
+
+  factory ConvertPair(DartObject obj, FieldElement element) {
+    var toJson = _convertData(obj, element, false);
+    var fromJson = _convertData(obj, element, true);
+
+    return ConvertPair._(fromJson, toJson);
+  }
+
+  void populate(JsonKey key) {
+    _expando[key] = this;
+  }
+}
+
+ConvertData _convertData(
+    DartObject obj, FieldElement element, bool isFrom) {
+  var paramName = isFrom ? 'fromJson' : 'toJson';
+  var objectValue = obj.getField(paramName);
+
+  if (objectValue.isNull) {
+    return null;
+  }
+
+  var type = objectValue.type as FunctionType;
+
+  var executableElement = type.element as ExecutableElement;
+
+  if (executableElement.parameters.isEmpty ||
+      executableElement.parameters.first.isNamed ||
+      executableElement.parameters.where((pe) => !pe.isOptional).length > 1) {
+    throwUnsupported(
+        element,
+        'The `$paramName` function `${executableElement.name}` must have one '
+        'positional paramater.');
+  }
+
+  var argType = executableElement.parameters.first.type;
+  if (isFrom) {
+    var returnType = executableElement.returnType;
+
+    if (returnType is TypeParameterType) {
+      // We keep things simple in this case. We rely on inferred type arguments
+      // to the `fromJson` function.
+      // TODO: consider adding error checking here if there is confusion.
+    } else if (!returnType.isAssignableTo(element.type)) {
+      throwUnsupported(
+          element,
+          'The `$paramName` function `${executableElement.name}` return type '
+          '`$returnType` is not compatible with field type `${element.type}`.');
+    }
+  } else {
+    if (argType is TypeParameterType) {
+      // We keep things simple in this case. We rely on inferred type arguments
+      // to the `fromJson` function.
+      // TODO: consider adding error checking here if there is confusion.
+    } else if (!element.type.isAssignableTo(argType)) {
+      throwUnsupported(
+          element,
+          'The `$paramName` function `${executableElement.name}` argument type '
+          '`$argType` is not compatible with field type'
+          ' `${element.type}`.');
+    }
+  }
+
+  var name = executableElement.name;
+
+  if (executableElement is MethodElement) {
+    name = '${executableElement.enclosingElement.name}.$name';
+  }
+
+  return ConvertData(name, argType);
+}

--- a/json_serializable/lib/src/helper_core.dart
+++ b/json_serializable/lib/src/helper_core.dart
@@ -39,8 +39,7 @@ abstract class HelperCore {
   String genericClassArgumentsImpl(bool withConstraints) =>
       genericClassArguments(element, withConstraints);
 
-  JsonKeyWithConversion jsonKeyFor(FieldElement field) =>
-      JsonKeyWithConversion(field, annotation);
+  JsonKey jsonKeyFor(FieldElement field) => jsonKeyForField(field, annotation);
 
   TypeHelperContext getHelperContext(FieldElement field) =>
       TypeHelperContext(this, field.metadata, jsonKeyFor(field));

--- a/json_serializable/lib/src/json_serializable_generator.dart
+++ b/json_serializable/lib/src/json_serializable_generator.dart
@@ -12,6 +12,7 @@ import 'encoder_helper.dart';
 import 'field_helpers.dart';
 import 'helper_core.dart';
 import 'type_helper.dart';
+import 'type_helper_context.dart';
 import 'type_helpers/convert_helper.dart';
 import 'type_helpers/date_time_helper.dart';
 import 'type_helpers/enum_helper.dart';
@@ -40,7 +41,7 @@ class JsonSerializableGenerator
   final List<TypeHelper> _typeHelpers;
 
   Iterable<TypeHelper> get _allHelpers => const <TypeHelper>[
-        ConvertHelper(),
+        ConvertHelper(serializeData, deserializeData),
         JsonConverterHelper()
       ].followedBy(_typeHelpers).followedBy(_coreHelpers);
 

--- a/json_serializable/lib/src/type_helper_context.dart
+++ b/json_serializable/lib/src/type_helper_context.dart
@@ -4,11 +4,23 @@
 
 import 'package:analyzer/dart/element/element.dart';
 import 'package:analyzer/dart/element/type.dart';
+import 'package:json_annotation/json_annotation.dart';
 
+import 'convert_pair.dart';
 import 'helper_core.dart';
-import 'json_key_with_conversion.dart';
 import 'json_serializable_generator.dart';
 import 'type_helper.dart';
+
+import 'type_helpers/convert_helper.dart';
+
+ConvertData serializeData(SerializeContext ctx) =>
+    _pairFromContext(ctx as TypeHelperContext)?.toJson;
+
+ConvertData deserializeData(DeserializeContext ctx) =>
+    _pairFromContext(ctx as TypeHelperContext)?.fromJson;
+
+ConvertPair _pairFromContext(TypeHelperContext ctx) =>
+    ConvertPair.fromJsonKey(ctx._key);
 
 class TypeHelperContext implements SerializeContext, DeserializeContext {
   final HelperCore _helperCore;
@@ -16,7 +28,7 @@ class TypeHelperContext implements SerializeContext, DeserializeContext {
   @override
   final List<ElementAnnotation> metadata;
 
-  final JsonKeyWithConversion _key;
+  final JsonKey _key;
 
   @override
   bool get useWrappers => _helperCore.generator.useWrappers;
@@ -29,9 +41,6 @@ class TypeHelperContext implements SerializeContext, DeserializeContext {
 
   @override
   bool get nullable => _key.nullable;
-
-  ConvertData get fromJsonData => _key.fromJsonData;
-  ConvertData get toJsonData => _key.toJsonData;
 
   TypeHelperContext(this._helperCore, this.metadata, this._key);
 

--- a/json_serializable/lib/src/type_helpers/convert_helper.dart
+++ b/json_serializable/lib/src/type_helpers/convert_helper.dart
@@ -6,15 +6,24 @@ import 'package:analyzer/dart/element/type.dart';
 
 import '../shared_checkers.dart';
 import '../type_helper.dart';
-import '../type_helper_context.dart';
+
+class ConvertData {
+  final String name;
+  final DartType paramType;
+
+  ConvertData(this.name, this.paramType);
+}
 
 class ConvertHelper extends TypeHelper {
-  const ConvertHelper();
+  final ConvertData Function(SerializeContext) serializeConvertData;
+  final ConvertData Function(DeserializeContext) deserializeConvertData;
+
+  const ConvertHelper(this.serializeConvertData, this.deserializeConvertData);
 
   @override
   String serialize(
       DartType targetType, String expression, SerializeContext context) {
-    var toJsonData = (context as TypeHelperContext).toJsonData;
+    var toJsonData = serializeConvertData(context);
     if (toJsonData != null) {
       assert(toJsonData.paramType is TypeParameterType ||
           targetType.isAssignableTo(toJsonData.paramType));
@@ -27,7 +36,7 @@ class ConvertHelper extends TypeHelper {
   @override
   String deserialize(
       DartType targetType, String expression, DeserializeContext context) {
-    var fromJsonData = (context as TypeHelperContext).fromJsonData;
+    var fromJsonData = deserializeConvertData(context);
     if (fromJsonData != null) {
       var asContent = asStatement(fromJsonData.paramType);
       var result = '${fromJsonData.name}($expression$asContent)';

--- a/json_serializable/pubspec.yaml
+++ b/json_serializable/pubspec.yaml
@@ -1,5 +1,5 @@
 name: json_serializable
-version: 1.3.0
+version: 2.0.0-dev
 author: Dart Team <misc@dartlang.org>
 description: Generates utilities to aid in serializing to/from JSON.
 homepage: https://github.com/dart-lang/json_serializable


### PR DESCRIPTION
The ConvertHelper class exposed in 1.3.0 is effectively worthless
outside of json_serializable because it relies on internal state that
assumes the in-box generator.

This commit exposes the hooks necessary for another generator to
use ConvertHelper by providing callbacks for providing ConvertData
for a given context.

Eliminates the internal JsonKeyWithConversion class
Exposes a new ConvertData class

Refactors the to/fromJson logic out of `json_key_with_conversion.dart`
into its own file - which should make maintenance easier