### PR TITLE
TypeHelper serialize/deserialize return Object instead of String

### DIFF
--- a/analysis_options.yaml
+++ b/analysis_options.yaml
@@ -72,8 +72,7 @@ linter:
     - unnecessary_brace_in_string_interps
     - unnecessary_const
     - unnecessary_getters_setters
-    # We'll need a way to return a lambda from a TypeHelper to re-enable this
-    #- unnecessary_lambdas
+    - unnecessary_lambdas
     - unnecessary_new
     - unnecessary_null_aware_assignments
     - unnecessary_statements

--- a/json_serializable/CHANGELOG.md
+++ b/json_serializable/CHANGELOG.md
@@ -10,6 +10,12 @@
     `deserialize`. Many of the included `TypeHelper` implementations have been
     updated to indicate they expect more information from the source generator.
 
+  * `TypeHelper` `serialize` and `deserialize` have return type `Object` instead
+    of `String`. This allows coordination between instances to support more
+    advanced features – like using the new `LambdaResult` class to avoid
+    creating unnecessary lambdas. When creating `TypeHelper` implementations,
+    handle non-`String` results by calling `toString()` on unrecognized values.
+
 ## 1.3.0
 
 * Add support for types annotated with classes that extend `JsonConverter` from

--- a/json_serializable/lib/src/decode_helper.dart
+++ b/json_serializable/lib/src/decode_helper.dart
@@ -170,7 +170,7 @@ abstract class DecodeHelper implements HelperCore {
     String value;
     try {
       if (generator.checked) {
-        value = contextHelper.deserialize(targetType, 'v');
+        value = contextHelper.deserialize(targetType, 'v').toString();
         if (!checkedProperty) {
           value = '\$checkedConvert(json, $jsonKeyName, (v) => $value)';
         }
@@ -178,7 +178,9 @@ abstract class DecodeHelper implements HelperCore {
         assert(!checkedProperty,
             'should only be true if `_generator.checked` is true.');
 
-        value = contextHelper.deserialize(targetType, 'json[$jsonKeyName]');
+        value = contextHelper
+            .deserialize(targetType, 'json[$jsonKeyName]')
+            .toString();
       }
     } on UnsupportedTypeError catch (e) {
       throw createInvalidGenerationError('fromJson', field, e);

--- a/json_serializable/lib/src/encoder_helper.dart
+++ b/json_serializable/lib/src/encoder_helper.dart
@@ -224,7 +224,9 @@ class ${_wrapperClassName(true)} extends \$JsonMapWrapper {
 
   String _serializeField(FieldElement field, String accessExpression) {
     try {
-      return getHelperContext(field).serialize(field.type, accessExpression);
+      return getHelperContext(field)
+          .serialize(field.type, accessExpression)
+          .toString();
     } on UnsupportedTypeError catch (e) {
       throw createInvalidGenerationError('toJson', field, e);
     }

--- a/json_serializable/lib/src/type_helper.dart
+++ b/json_serializable/lib/src/type_helper.dart
@@ -19,11 +19,11 @@ abstract class TypeHelperContext {
 
   /// [expression] may be just the name of the field or it may an expression
   /// representing the serialization of a value.
-  String serialize(DartType fieldType, String expression);
+  Object serialize(DartType fieldType, String expression);
 
   /// [expression] may be just the name of the field or it may an expression
   /// representing the serialization of a value.
-  String deserialize(DartType fieldType, String expression);
+  Object deserialize(DartType fieldType, String expression);
 
   /// Adds [memberContent] to the set of generated, top-level members.
   void addMember(String memberContent);
@@ -55,7 +55,7 @@ abstract class TypeHelper<T extends TypeHelperContext> {
   /// String serialize(DartType targetType, String expression) =>
   ///   "$expression.id";
   /// ```.
-  String serialize(DartType targetType, String expression, T context);
+  Object serialize(DartType targetType, String expression, T context);
 
   /// Returns Dart code that deserializes an [expression] representing a JSON
   /// literal to into [targetType].
@@ -80,7 +80,21 @@ abstract class TypeHelper<T extends TypeHelperContext> {
   /// String deserialize(DartType targetType, String expression) =>
   ///   "new ${targetType.name}.fromInt($expression)";
   /// ```.
-  String deserialize(DartType targetType, String expression, T context);
+  Object deserialize(DartType targetType, String expression, T context);
+}
+
+class LambdaResult {
+  final String expression;
+  final String lambda;
+  LambdaResult(this.expression, this.lambda);
+
+  @override
+  String toString() => '$lambda($expression)';
+
+  static String process(Object subField, String closureArg) =>
+      (subField is LambdaResult && closureArg == subField.expression)
+          ? subField.lambda
+          : '($closureArg) => $subField';
 }
 
 class UnsupportedTypeError extends Error {

--- a/json_serializable/lib/src/type_helper_ctx.dart
+++ b/json_serializable/lib/src/type_helper_ctx.dart
@@ -55,19 +55,19 @@ class _TypeHelperCtx
   }
 
   @override
-  String serialize(DartType targetType, String expression) => _run(
+  Object serialize(DartType targetType, String expression) => _run(
       targetType,
       expression,
       (TypeHelper th) => th.serialize(targetType, expression, this));
 
   @override
-  String deserialize(DartType targetType, String expression) => _run(
+  Object deserialize(DartType targetType, String expression) => _run(
       targetType,
       expression,
       (TypeHelper th) => th.deserialize(targetType, expression, this));
 
-  String _run(DartType targetType, String expression,
-          String invoke(TypeHelper instance)) =>
+  Object _run(DartType targetType, String expression,
+          Object invoke(TypeHelper instance)) =>
       allHelpersImpl(_helperCore.generator).map(invoke).firstWhere(
           (r) => r != null,
           orElse: () => throw UnsupportedTypeError(

--- a/json_serializable/lib/src/type_helpers/iterable_helper.dart
+++ b/json_serializable/lib/src/type_helpers/iterable_helper.dart
@@ -33,18 +33,17 @@ class IterableHelper extends TypeHelper<TypeHelperContextWithConfig> {
     // will be identical to `substitute` – so no explicit mapping is needed.
     // If they are not equal, then we to write out the substitution.
     if (subField != closureArg) {
+      var lambda = LambdaResult.process(subField, closureArg);
       if (context.useWrappers && isList) {
         var method = '\$wrapList';
         if (context.nullable) {
           method = '${method}HandleNull';
         }
 
-        return '$method<$itemType>($expression, ($closureArg) => $subField)';
+        return '$method<$itemType>($expression, $lambda)';
       }
 
-      // TODO: the type could be imported from a library with a prefix!
-      expression =
-          '$expression$optionalQuestion.map(($closureArg) => $subField)';
+      expression = '$expression$optionalQuestion.map($lambda)';
 
       // expression now represents an Iterable (even if it started as a List
       // ...resetting `isList` to `false`.
@@ -79,8 +78,9 @@ class IterableHelper extends TypeHelper<TypeHelperContextWithConfig> {
 
     var optionalQuestion = context.nullable ? '?' : '';
 
-    var output =
-        '($expression as List)$optionalQuestion.map(($closureArg) => $itemSubVal)';
+    var lambda = LambdaResult.process(itemSubVal, closureArg);
+
+    var output = '($expression as List)$optionalQuestion.map($lambda)';
 
     if (_coreListChecker.isAssignableFromType(targetType)) {
       output += '$optionalQuestion.toList()';

--- a/json_serializable/lib/src/type_helpers/json_converter_helper.dart
+++ b/json_serializable/lib/src/type_helpers/json_converter_helper.dart
@@ -18,7 +18,7 @@ class JsonConverterHelper extends TypeHelper {
   const JsonConverterHelper();
 
   @override
-  String serialize(
+  LambdaResult serialize(
       DartType targetType, String expression, TypeHelperContext context) {
     var converter = _typeConverter(targetType, context);
 
@@ -26,11 +26,11 @@ class JsonConverterHelper extends TypeHelper {
       return null;
     }
 
-    return '${converter.accessString}.toJson($expression)';
+    return LambdaResult(expression, '${converter.accessString}.toJson');
   }
 
   @override
-  String deserialize(
+  LambdaResult deserialize(
       DartType targetType, String expression, TypeHelperContext context) {
     var converter = _typeConverter(targetType, context);
     if (converter == null) {
@@ -39,7 +39,8 @@ class JsonConverterHelper extends TypeHelper {
 
     var asContent = asStatement(converter.jsonType);
 
-    return '${converter.accessString}.fromJson($expression$asContent)';
+    return LambdaResult(
+        '$expression$asContent', '${converter.accessString}.fromJson');
   }
 }
 

--- a/json_serializable/lib/src/type_helpers/map_helper.dart
+++ b/json_serializable/lib/src/type_helpers/map_helper.dart
@@ -41,7 +41,8 @@ class MapHelper extends TypeHelper<TypeHelperContextWithConfig> {
         method = '${method}HandleNull';
       }
 
-      return '$method<$keyType, $valueType>($expression, ($closureArg) => $subFieldValue)';
+      var lambda = LambdaResult.process(subFieldValue, closureArg);
+      return '$method<$keyType, $valueType>($expression, $lambda)';
     }
 
     final optionalQuestion = context.nullable ? '?' : '';
@@ -99,7 +100,7 @@ class MapHelper extends TypeHelper<TypeHelperContextWithConfig> {
 
     String keyUsage;
     if (isEnumKey) {
-      keyUsage = context.deserialize(keyArg, _keyParam);
+      keyUsage = context.deserialize(keyArg, _keyParam).toString();
     } else if (context.anyMap && !_isObjectOrDynamic(keyArg)) {
       keyUsage = '$_keyParam as String';
     } else {

--- a/json_serializable/test/kitchen_sink/kitchen_sink.g.dart
+++ b/json_serializable/test/kitchen_sink/kitchen_sink.g.dart
@@ -167,14 +167,13 @@ abstract class _$JsonConverterTestClassSerializerMixin {
   DateTime get dateTime;
   Map<String, dynamic> toJson() => <String, dynamic>{
         'duration': durationConverter.toJson(duration),
-        'durationList':
-            durationList?.map((e) => durationConverter.toJson(e))?.toList(),
+        'durationList': durationList?.map(durationConverter.toJson)?.toList(),
         'bigInt': const BigIntStringConverter().toJson(bigInt),
         'bigIntMap': bigIntMap?.map(
             (k, e) => MapEntry(k, const BigIntStringConverter().toJson(e))),
         'numberSilly': TrivialNumberConverter.instance.toJson(numberSilly),
         'numberSillySet': numberSillySet
-            ?.map((e) => TrivialNumberConverter.instance.toJson(e))
+            ?.map(TrivialNumberConverter.instance.toJson)
             ?.toList(),
         'dateTime': const EpochDateTimeConverter().toJson(dateTime)
       };
@@ -198,8 +197,7 @@ abstract class _$JsonConverterGenericSerializerMixin<S, T, U> {
   Map<String, U> get itemMap;
   Map<String, dynamic> toJson() => <String, dynamic>{
         'item': GenericConverter<S>().toJson(item),
-        'itemList':
-            itemList?.map((e) => GenericConverter<T>().toJson(e))?.toList(),
+        'itemList': itemList?.map(GenericConverter<T>().toJson)?.toList(),
         'itemMap':
             itemMap?.map((k, e) => MapEntry(k, GenericConverter<U>().toJson(e)))
       };

--- a/json_serializable/test/kitchen_sink/kitchen_sink.non_nullable.checked.g.dart
+++ b/json_serializable/test/kitchen_sink/kitchen_sink.non_nullable.checked.g.dart
@@ -208,15 +208,13 @@ abstract class _$JsonConverterTestClassSerializerMixin {
   DateTime get dateTime;
   Map<String, dynamic> toJson() => <String, dynamic>{
         'duration': durationConverter.toJson(duration),
-        'durationList':
-            durationList.map((e) => durationConverter.toJson(e)).toList(),
+        'durationList': durationList.map(durationConverter.toJson).toList(),
         'bigInt': const BigIntStringConverter().toJson(bigInt),
         'bigIntMap': bigIntMap.map(
             (k, e) => MapEntry(k, const BigIntStringConverter().toJson(e))),
         'numberSilly': TrivialNumberConverter.instance.toJson(numberSilly),
-        'numberSillySet': numberSillySet
-            .map((e) => TrivialNumberConverter.instance.toJson(e))
-            .toList(),
+        'numberSillySet':
+            numberSillySet.map(TrivialNumberConverter.instance.toJson).toList(),
         'dateTime': const EpochDateTimeConverter().toJson(dateTime)
       };
 }
@@ -252,8 +250,7 @@ abstract class _$JsonConverterGenericSerializerMixin<S, T, U> {
   Map<String, U> get itemMap;
   Map<String, dynamic> toJson() => <String, dynamic>{
         'item': GenericConverter<S>().toJson(item),
-        'itemList':
-            itemList.map((e) => GenericConverter<T>().toJson(e)).toList(),
+        'itemList': itemList.map(GenericConverter<T>().toJson).toList(),
         'itemMap':
             itemMap.map((k, e) => MapEntry(k, GenericConverter<U>().toJson(e)))
       };

--- a/json_serializable/test/kitchen_sink/kitchen_sink.non_nullable.g.dart
+++ b/json_serializable/test/kitchen_sink/kitchen_sink.non_nullable.g.dart
@@ -152,15 +152,13 @@ abstract class _$JsonConverterTestClassSerializerMixin {
   DateTime get dateTime;
   Map<String, dynamic> toJson() => <String, dynamic>{
         'duration': durationConverter.toJson(duration),
-        'durationList':
-            durationList.map((e) => durationConverter.toJson(e)).toList(),
+        'durationList': durationList.map(durationConverter.toJson).toList(),
         'bigInt': const BigIntStringConverter().toJson(bigInt),
         'bigIntMap': bigIntMap.map(
             (k, e) => MapEntry(k, const BigIntStringConverter().toJson(e))),
         'numberSilly': TrivialNumberConverter.instance.toJson(numberSilly),
-        'numberSillySet': numberSillySet
-            .map((e) => TrivialNumberConverter.instance.toJson(e))
-            .toList(),
+        'numberSillySet':
+            numberSillySet.map(TrivialNumberConverter.instance.toJson).toList(),
         'dateTime': const EpochDateTimeConverter().toJson(dateTime)
       };
 }
@@ -183,8 +181,7 @@ abstract class _$JsonConverterGenericSerializerMixin<S, T, U> {
   Map<String, U> get itemMap;
   Map<String, dynamic> toJson() => <String, dynamic>{
         'item': GenericConverter<S>().toJson(item),
-        'itemList':
-            itemList.map((e) => GenericConverter<T>().toJson(e)).toList(),
+        'itemList': itemList.map(GenericConverter<T>().toJson).toList(),
         'itemMap':
             itemMap.map((k, e) => MapEntry(k, GenericConverter<U>().toJson(e)))
       };

--- a/json_serializable/test/kitchen_sink/kitchen_sink.non_nullable.wrapped.g.dart
+++ b/json_serializable/test/kitchen_sink/kitchen_sink.non_nullable.wrapped.g.dart
@@ -249,18 +249,17 @@ class _$JsonConverterTestClassJsonMapWrapper extends $JsonMapWrapper {
         case 'duration':
           return durationConverter.toJson(_v.duration);
         case 'durationList':
-          return $wrapList<Duration>(
-              _v.durationList, (e) => durationConverter.toJson(e));
+          return $wrapList<Duration>(_v.durationList, durationConverter.toJson);
         case 'bigInt':
           return const BigIntStringConverter().toJson(_v.bigInt);
         case 'bigIntMap':
           return $wrapMap<String, BigInt>(
-              _v.bigIntMap, (e) => const BigIntStringConverter().toJson(e));
+              _v.bigIntMap, const BigIntStringConverter().toJson);
         case 'numberSilly':
           return TrivialNumberConverter.instance.toJson(_v.numberSilly);
         case 'numberSillySet':
           return _v.numberSillySet
-              .map((e) => TrivialNumberConverter.instance.toJson(e))
+              .map(TrivialNumberConverter.instance.toJson)
               .toList();
         case 'dateTime':
           return const EpochDateTimeConverter().toJson(_v.dateTime);
@@ -304,11 +303,9 @@ class _$JsonConverterGenericJsonMapWrapper<S, T, U> extends $JsonMapWrapper {
         case 'item':
           return GenericConverter<S>().toJson(_v.item);
         case 'itemList':
-          return $wrapList<T>(
-              _v.itemList, (e) => GenericConverter<T>().toJson(e));
+          return $wrapList<T>(_v.itemList, GenericConverter<T>().toJson);
         case 'itemMap':
-          return $wrapMap<String, U>(
-              _v.itemMap, (e) => GenericConverter<U>().toJson(e));
+          return $wrapMap<String, U>(_v.itemMap, GenericConverter<U>().toJson);
       }
     }
     return null;

--- a/json_serializable/test/kitchen_sink/kitchen_sink.wrapped.g.dart
+++ b/json_serializable/test/kitchen_sink/kitchen_sink.wrapped.g.dart
@@ -264,17 +264,17 @@ class _$JsonConverterTestClassJsonMapWrapper extends $JsonMapWrapper {
           return durationConverter.toJson(_v.duration);
         case 'durationList':
           return $wrapListHandleNull<Duration>(
-              _v.durationList, (e) => durationConverter.toJson(e));
+              _v.durationList, durationConverter.toJson);
         case 'bigInt':
           return const BigIntStringConverter().toJson(_v.bigInt);
         case 'bigIntMap':
           return $wrapMapHandleNull<String, BigInt>(
-              _v.bigIntMap, (e) => const BigIntStringConverter().toJson(e));
+              _v.bigIntMap, const BigIntStringConverter().toJson);
         case 'numberSilly':
           return TrivialNumberConverter.instance.toJson(_v.numberSilly);
         case 'numberSillySet':
           return _v.numberSillySet
-              ?.map((e) => TrivialNumberConverter.instance.toJson(e))
+              ?.map(TrivialNumberConverter.instance.toJson)
               ?.toList();
         case 'dateTime':
           return const EpochDateTimeConverter().toJson(_v.dateTime);
@@ -319,10 +319,10 @@ class _$JsonConverterGenericJsonMapWrapper<S, T, U> extends $JsonMapWrapper {
           return GenericConverter<S>().toJson(_v.item);
         case 'itemList':
           return $wrapListHandleNull<T>(
-              _v.itemList, (e) => GenericConverter<T>().toJson(e));
+              _v.itemList, GenericConverter<T>().toJson);
         case 'itemMap':
           return $wrapMapHandleNull<String, U>(
-              _v.itemMap, (e) => GenericConverter<U>().toJson(e));
+              _v.itemMap, GenericConverter<U>().toJson);
       }
     }
     return null;


### PR DESCRIPTION
This allows coordination between instances to support more
advanced features.

Added LambdaResult class and return it in JsonConvertHelper to avoid
unnecessary lambdas