### PR TITLE
Return defaultValue for unsupported enum instead throw exception

### DIFF
--- a/json_annotation/lib/src/json_key.dart
+++ b/json_annotation/lib/src/json_key.dart
@@ -26,6 +26,20 @@ class JsonKey {
   /// enclosing class.
   final bool nullable;
 
+  /// When `true`, `null` values are handled gracefully when
+  /// serializing the field to JSON and when deserializing `null` and
+  /// nonexistent values from a JSON map.
+  ///
+  /// Setting to `false` eliminates `null` verification in the generated code
+  /// for the annotated field, which reduces the code size. Errors may be thrown
+  /// at runtime if `null` values are encountered, but the original class should
+  /// also implement `null` runtime validation if it's critical.
+  ///
+  /// The default value, `null`, indicates that the behavior should be
+  /// acquired from the [JsonSerializable.unknowable] annotation on the
+  /// enclosing class.
+  final bool unknowable;
+
   /// `true` if the generator should include the this field in the serialized
   /// output, even if the value is `null`.
   ///
@@ -102,6 +116,7 @@ class JsonKey {
   const JsonKey({
     this.name,
     this.nullable,
+    this.unknowable,
     this.includeIfNull,
     this.ignore,
     this.fromJson,

--- a/json_serializable/lib/src/json_key_utils.dart
+++ b/json_serializable/lib/src/json_key_utils.dart
@@ -113,6 +113,7 @@ JsonKey _from(FieldElement element, JsonSerializable classAnnotation) {
     defaultValue: defaultValueLiteral,
     required: obj.getField('required').toBoolValue(),
     disallowNullValue: disallowNullValue,
+    unknowable: obj.getField('unknowable').toBoolValue(),
   );
 }
 
@@ -126,6 +127,7 @@ JsonKey _populateJsonKey(
   Object defaultValue,
   bool required,
   bool disallowNullValue,
+  bool unknowable,
 }) {
   final jsonKey = JsonKey(
       name: _encodedFieldName(classAnnotation, name, fieldElement),
@@ -135,7 +137,8 @@ JsonKey _populateJsonKey(
       ignore: ignore ?? false,
       defaultValue: defaultValue,
       required: required ?? false,
-      disallowNullValue: disallowNullValue ?? false);
+      disallowNullValue: disallowNullValue ?? false,
+      unknowable: unknowable ?? false);
 
   return jsonKey;
 }

--- a/json_serializable/lib/src/type_helper.dart
+++ b/json_serializable/lib/src/type_helper.dart
@@ -18,6 +18,9 @@ abstract class TypeHelperContext {
   /// Returns `true` if [fieldElement] could potentially contain a `null` value.
   bool get nullable;
 
+  /// Returns `true` if [fieldElement] could potentially contain a nonexistent value.
+  bool get unknowable;
+
   /// [expression] may be just the name of the field or it may an expression
   /// representing the serialization of a value.
   Object serialize(DartType fieldType, String expression);

--- a/json_serializable/lib/src/type_helper_ctx.dart
+++ b/json_serializable/lib/src/type_helper_ctx.dart
@@ -28,6 +28,9 @@ class _TypeHelperCtx
   bool get nullable => _key.nullable;
 
   @override
+  bool get unknowable => _key.unknowable;
+
+  @override
   ClassElement get classElement => _helperCore.element;
 
   @override

--- a/json_serializable/lib/src/type_helpers/enum_helper.dart
+++ b/json_serializable/lib/src/type_helpers/enum_helper.dart
@@ -42,9 +42,14 @@ class EnumHelper extends TypeHelper {
       context.addMember(_enumDecodeHelperNullable);
     }
 
+    if (context.unknowable) {
+      context.addMember(_enumDecodeHelperUnknowable);
+    }
+
     context.addMember(memberContent);
 
     final functionName =
+        context.unknowable ? r'_$enumDecodeUnknowable' :
         context.nullable ? r'_$enumDecodeNullable' : r'_$enumDecode';
     return '$functionName(${_constMapName(targetType)}, '
         '$expression)';
@@ -85,6 +90,17 @@ T _$enumDecode<T>(Map<T, dynamic> enumValues, dynamic source) {
 const _enumDecodeHelperNullable = r'''
 T _$enumDecodeNullable<T>(Map<T, dynamic> enumValues, dynamic source) {
   if (source == null) {
+    return null;
+  }
+  return _$enumDecode<T>(enumValues, source);
+}''';
+
+const _enumDecodeHelperUnknowable = r'''
+T _$enumDecodeUnknowable<T>(Map<T, dynamic> enumValues, dynamic source) {
+  if (source == null) {
+    return null;
+  }
+  if (enumValues.values.singleWhere((v)=> v == source) == null){
     return null;
   }
   return _$enumDecode<T>(enumValues, source);

--- a/json_serializable/test/integration/json_test_example.unknowable.dart
+++ b/json_serializable/test/integration/json_test_example.unknowable.dart
@@ -1,0 +1,160 @@
+// Copyright (c) 2018, the Dart project authors. Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+// **************************************************************************
+// _NonNullableGenerator
+// **************************************************************************
+
+// ignore_for_file: hash_and_equals
+import 'dart:collection';
+
+import 'package:json_annotation/json_annotation.dart';
+import 'json_test_common.dart';
+
+part 'json_test_example.unknowable.g.dart';
+
+@JsonSerializable(
+  nullable: false,
+)
+class Person {
+  final String firstName, middleName, lastName;
+  final DateTime dateOfBirth;
+  @JsonKey(name: '\$house')
+  final Category house;
+
+  Order order;
+
+  Map<String, Category> houseMap;
+  Map<Category, int> categoryCounts;
+
+  Person(this.firstName, this.lastName, this.house,
+      {this.middleName, this.dateOfBirth});
+
+  factory Person.fromJson(Map<String, dynamic> json) => _$PersonFromJson(json);
+
+  Map<String, dynamic> toJson() => _$PersonToJson(this);
+
+  @override
+  bool operator ==(Object other) =>
+      other is Person &&
+      firstName == other.firstName &&
+      middleName == other.middleName &&
+      lastName == other.lastName &&
+      dateOfBirth == other.dateOfBirth &&
+      house == other.house &&
+      deepEquals(houseMap, other.houseMap);
+}
+
+@JsonSerializable(
+  nullable: false,
+)
+class Order {
+  /// Used to test that `disallowNullValues: true` forces `includeIfNull: false`
+  @JsonKey(disallowNullValue: true)
+  int count;
+  bool isRushed;
+
+  Duration duration;
+
+  @JsonKey(nullable: true, unknowable: true, defaultValue: Category.notDiscoveredYet)
+  final Category category;
+  final UnmodifiableListView<Item> items;
+  Platform platform;
+  Map<String, Platform> altPlatforms;
+
+  Uri homepage;
+
+  @JsonKey(
+      name: 'status_code', defaultValue: StatusCode.success, nullable: true)
+  StatusCode statusCode;
+
+  @JsonKey(ignore: true)
+  String get platformValue => platform?.description;
+
+  set platformValue(String value) {
+    throw UnimplementedError('not impld');
+  }
+
+  // Ignored getter without value set in ctor
+  int get price => items.fold(0, (total, item) => item.price + total);
+
+  @JsonKey(ignore: true)
+  bool shouldBeCached;
+
+  Order(this.category, [Iterable<Item> items])
+      : items = UnmodifiableListView<Item>(
+            List<Item>.unmodifiable(items ?? const <Item>[]));
+
+  factory Order.fromJson(Map<String, dynamic> json) => _$OrderFromJson(json);
+
+  Map<String, dynamic> toJson() => _$OrderToJson(this);
+
+  @override
+  bool operator ==(Object other) =>
+      other is Order &&
+      count == other.count &&
+      isRushed == other.isRushed &&
+      deepEquals(items, other.items) &&
+      deepEquals(altPlatforms, other.altPlatforms);
+}
+
+@JsonSerializable(
+  nullable: false,
+)
+class Item extends ItemCore {
+  @JsonKey(includeIfNull: false, name: 'item-number')
+  int itemNumber;
+  List<DateTime> saleDates;
+  List<int> rates;
+
+  Item([int price]) : super(price);
+
+  factory Item.fromJson(Map<String, dynamic> json) => _$ItemFromJson(json);
+
+  Map<String, dynamic> toJson() => _$ItemToJson(this);
+
+  @override
+  bool operator ==(Object other) =>
+      other is Item &&
+      price == other.price &&
+      itemNumber == other.itemNumber &&
+      deepEquals(saleDates, other.saleDates);
+}
+
+@JsonSerializable(
+  nullable: false,
+)
+class Numbers {
+  List<int> ints;
+  List<num> nums;
+  List<double> doubles;
+
+  @JsonKey(nullable: false)
+  List<double> nnDoubles;
+
+  @JsonKey(fromJson: durationFromInt, toJson: durationToInt)
+  Duration duration;
+
+  @JsonKey(fromJson: dateTimeFromEpochUs, toJson: dateTimeToEpochUs)
+  DateTime date;
+
+  Numbers();
+
+  factory Numbers.fromJson(Map<String, dynamic> json) =>
+      _$NumbersFromJson(json);
+
+  Map<String, dynamic> toJson() => _$NumbersToJson(this);
+
+  @override
+  bool operator ==(Object other) =>
+      other is Numbers &&
+      deepEquals(ints, other.ints) &&
+      deepEquals(nums, other.nums) &&
+      deepEquals(doubles, other.doubles) &&
+      deepEquals(nnDoubles, other.nnDoubles) &&
+      deepEquals(duration, other.duration) &&
+      deepEquals(date, other.date);
+}

--- a/json_serializable/test/integration/json_test_example.unknowable.g.dart
+++ b/json_serializable/test/integration/json_test_example.unknowable.g.dart
@@ -1,0 +1,145 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+part of 'json_test_example.unknowable.dart';
+
+// **************************************************************************
+// JsonSerializableGenerator
+// **************************************************************************
+
+Person _$PersonFromJson(Map<String, dynamic> json) {
+  return Person(json['firstName'] as String, json['lastName'] as String,
+      _$enumDecode(_$CategoryEnumMap, json[r'$house']),
+      middleName: json['middleName'] as String,
+      dateOfBirth: DateTime.parse(json['dateOfBirth'] as String))
+    ..order = Order.fromJson(json['order'] as Map<String, dynamic>)
+    ..houseMap = (json['houseMap'] as Map<String, dynamic>)
+        .map((k, e) => MapEntry(k, _$enumDecode(_$CategoryEnumMap, e)))
+    ..categoryCounts = (json['categoryCounts'] as Map<String, dynamic>)
+        .map((k, e) => MapEntry(_$enumDecode(_$CategoryEnumMap, k), e as int));
+}
+
+Map<String, dynamic> _$PersonToJson(Person instance) => <String, dynamic>{
+      'firstName': instance.firstName,
+      'middleName': instance.middleName,
+      'lastName': instance.lastName,
+      'dateOfBirth': instance.dateOfBirth.toIso8601String(),
+      r'$house': _$CategoryEnumMap[instance.house],
+      'order': instance.order,
+      'houseMap':
+          instance.houseMap.map((k, e) => MapEntry(k, _$CategoryEnumMap[e])),
+      'categoryCounts': instance.categoryCounts
+          .map((k, e) => MapEntry(_$CategoryEnumMap[k], e))
+    };
+
+T _$enumDecode<T>(Map<T, dynamic> enumValues, dynamic source) {
+  if (source == null) {
+    throw ArgumentError('A value must be provided. Supported values: '
+        '${enumValues.values.join(', ')}');
+  }
+  return enumValues.entries
+      .singleWhere((e) => e.value == source,
+          orElse: () => throw ArgumentError(
+              '`$source` is not one of the supported values: '
+              '${enumValues.values.join(', ')}'))
+      .key;
+}
+
+const _$CategoryEnumMap = <Category, dynamic>{
+  Category.top: 'top',
+  Category.bottom: 'bottom',
+  Category.strange: 'strange',
+  Category.charmed: 'charmed',
+  Category.up: 'up',
+  Category.down: 'down',
+  Category.notDiscoveredYet: 'not_discovered_yet'
+};
+
+Order _$OrderFromJson(Map<String, dynamic> json) {
+  $checkKeys(json, disallowNullValues: const ['count']);
+  return Order(
+      _$enumDecodeUnknowable(_$CategoryEnumMap, json['category']) ??
+          Category.notDiscoveredYet,
+      (json['items'] as List)
+          .map((e) => Item.fromJson(e as Map<String, dynamic>)))
+    ..count = json['count'] as int
+    ..isRushed = json['isRushed'] as bool
+    ..duration = Duration(microseconds: json['duration'] as int)
+    ..platform = Platform.fromJson(json['platform'] as String)
+    ..altPlatforms = (json['altPlatforms'] as Map<String, dynamic>)
+        .map((k, e) => MapEntry(k, Platform.fromJson(e as String)))
+    ..homepage = Uri.parse(json['homepage'] as String)
+    ..statusCode =
+        _$enumDecodeNullable(_$StatusCodeEnumMap, json['status_code']) ??
+            StatusCode.success;
+}
+
+Map<String, dynamic> _$OrderToJson(Order instance) => <String, dynamic>{
+      'count': instance.count,
+      'isRushed': instance.isRushed,
+      'duration': instance.duration.inMicroseconds,
+      'category': _$CategoryEnumMap[instance.category],
+      'items': instance.items,
+      'platform': instance.platform,
+      'altPlatforms': instance.altPlatforms,
+      'homepage': instance.homepage.toString(),
+      'status_code': _$StatusCodeEnumMap[instance.statusCode]
+    };
+
+T _$enumDecodeNullable<T>(Map<T, dynamic> enumValues, dynamic source) {
+  if (source == null) {
+    return null;
+  }
+  return _$enumDecode<T>(enumValues, source);
+}
+
+T _$enumDecodeUnknowable<T>(Map<T, dynamic> enumValues, dynamic source) {
+  if (source == null) {
+    return null;
+  }
+  if (enumValues.values.singleWhere((v) => v == source) == null) {
+    return null;
+  }
+  return _$enumDecode<T>(enumValues, source);
+}
+
+const _$StatusCodeEnumMap = <StatusCode, dynamic>{
+  StatusCode.success: 200,
+  StatusCode.notFound: 404
+};
+
+Item _$ItemFromJson(Map<String, dynamic> json) {
+  return Item(json['price'] as int)
+    ..itemNumber = json['item-number'] as int
+    ..saleDates = (json['saleDates'] as List)
+        .map((e) => DateTime.parse(e as String))
+        .toList()
+    ..rates = (json['rates'] as List).map((e) => e as int).toList();
+}
+
+Map<String, dynamic> _$ItemToJson(Item instance) => <String, dynamic>{
+      'price': instance.price,
+      'item-number': instance.itemNumber,
+      'saleDates': instance.saleDates.map((e) => e.toIso8601String()).toList(),
+      'rates': instance.rates
+    };
+
+Numbers _$NumbersFromJson(Map<String, dynamic> json) {
+  return Numbers()
+    ..ints = (json['ints'] as List).map((e) => e as int).toList()
+    ..nums = (json['nums'] as List).map((e) => e as num).toList()
+    ..doubles =
+        (json['doubles'] as List).map((e) => (e as num).toDouble()).toList()
+    ..nnDoubles =
+        (json['nnDoubles'] as List).map((e) => (e as num).toDouble()).toList()
+    ..duration = durationFromInt(json['duration'] as int)
+    ..date = dateTimeFromEpochUs(json['date'] as int);
+}
+
+Map<String, dynamic> _$NumbersToJson(Numbers instance) => <String, dynamic>{
+      'ints': instance.ints,
+      'nums': instance.nums,
+      'doubles': instance.doubles,
+      'nnDoubles': instance.nnDoubles,
+      'duration': durationToInt(instance.duration),
+      'date': dateTimeToEpochUs(instance.date)
+    };

--- a/json_serializable/test/json_serializable_test.dart
+++ b/json_serializable/test/json_serializable_test.dart
@@ -74,7 +74,8 @@ const _expectedAnnotatedTests = {
     'PrivateFieldCtorClass',
     'IncludeIfNullDisallowNullClass',
     'JsonValueWithBool',
-    'JsonValueValid'
+    'JsonValueValid',
+    'JsonValueWithUnknowableField'
   ],
   'checked_test_input.dart': [
     'WithANonCtorGetterChecked',

--- a/json_serializable/test/src/_json_serializable_test_input.dart
+++ b/json_serializable/test/src/_json_serializable_test_input.dart
@@ -377,3 +377,62 @@ enum GoodEnum {
   @JsonValue(null)
   nullValue
 }
+
+@ShouldGenerate(r'''
+JsonValueWithUnknowableField _$JsonValueWithUnknowableFieldFromJson(
+    Map<String, dynamic> json) {
+  return JsonValueWithUnknowableField()
+    ..field =
+        _$enumDecodeUnknowable(_$UnknowableEnumValueEnumMap, json['field']) ??
+            UnknowableEnumValue.unknown;
+}
+
+Map<String, dynamic> _$JsonValueWithUnknowableFieldToJson(
+        JsonValueWithUnknowableField instance) =>
+    <String, dynamic>{'field': _$UnknowableEnumValueEnumMap[instance.field]};
+
+T _$enumDecode<T>(Map<T, dynamic> enumValues, dynamic source) {
+  if (source == null) {
+    throw ArgumentError('A value must be provided. Supported values: '
+        '${enumValues.values.join(', ')}');
+  }
+  return enumValues.entries
+      .singleWhere((e) => e.value == source,
+          orElse: () => throw ArgumentError(
+              '`$source` is not one of the supported values: '
+              '${enumValues.values.join(', ')}'))
+      .key;
+}
+
+T _$enumDecodeNullable<T>(Map<T, dynamic> enumValues, dynamic source) {
+  if (source == null) {
+    return null;
+  }
+  return _$enumDecode<T>(enumValues, source);
+}
+
+T _$enumDecodeUnknowable<T>(Map<T, dynamic> enumValues, dynamic source) {
+  if (source == null) {
+    return null;
+  }
+  if (enumValues.values.singleWhere((v) => v == source) == null) {
+    return null;
+  }
+  return _$enumDecode<T>(enumValues, source);
+}
+
+const _$UnknowableEnumValueEnumMap = <UnknowableEnumValue, dynamic>{
+  UnknowableEnumValue.specificEnum: 'specificEnum',
+  UnknowableEnumValue.unknown: 'unknown'
+};
+''', contains: true)
+@JsonSerializable()
+class JsonValueWithUnknowableField {
+  @JsonKey(nullable: true, unknowable: true, defaultValue: UnknowableEnumValue.unknown)
+  UnknowableEnumValue field;
+}
+
+enum UnknowableEnumValue {
+  specificEnum,
+  unknown
+}


### PR DESCRIPTION
For enum type, I think we should use `nullable` option for both `null` and nonexistent value. 

In our case, we have object Coupon which contains CouponType as type of specific Coupon. At the very first time, our CouponType is only `loship_promotion`. We also support unknown CouponType from UI, which showing a message for updating the application. And now, we have `merchant_promotion`  as a new type. Of course, the number of CouponType's values can be increased in the future. So we need to define the parser for unknown type, and I think this is a common case in the real world.

I'm trying to use `nullable` and `defaultValue` options for enum, but my code throws the exception because of unsupported values.

[json_serializable/json_annotation/lib/src/json_key.dart](json_key.dart)

```
 /// When `true`, `null` values are handled gracefully when
  /// serializing the field to JSON and when deserializing `null` and
  /// nonexistent values from a JSON map.
  ///
  /// Setting to `false` eliminates `null` verification in the generated code
  /// for the annotated field, which reduces the code size. Errors may be thrown
  /// at runtime if `null` values are encountered, but the original class should
  /// also implement `null` runtime validation if it's critical.
  ///
  /// The default value, `null`, indicates that the behavior should be
  /// acquired from the [JsonSerializable.nullable] annotation on the
  /// enclosing class.
  final bool nullable;
```

