### PR TITLE
Fix typo field name between the comments.

### DIFF
--- a/json_annotation/lib/src/json_serializable.dart
+++ b/json_annotation/lib/src/json_serializable.dart
@@ -70,7 +70,7 @@ class JsonSerializable {
   /// ```
   ///
   /// If `json_serializable` is configured with
-  /// `generate_to_json_function: true`, then a top-level function is created
+  /// `generateToJsonFunction: true`, then a top-level function is created
   /// that you can reference from your class.
   ///
   /// ```dart


### PR DESCRIPTION
generate_to_json_function => generateToJsonFunction