### PR TITLE
Fix travis for Dart 2.0.0 stable

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -42,8 +42,13 @@ jobs:
       env: PKG="json_serializable"
       dart: stable
     - stage: unit_test
-      name: "SDK: stable - DIR: json_serializable - TASKS: pub run test"
-      script: ./tool/travis.sh test_1
+      name: "SDK: dev - DIR: json_serializable - TASKS: [pub run test --run-skipped, pub run build_runner test -- -p chrome]"
+      script: ./tool/travis.sh test_0 command
+      env: PKG="json_serializable"
+      dart: dev
+    - stage: unit_test
+      name: "SDK: stable - DIR: json_serializable - TASKS: [pub run test --run-skipped, pub run build_runner test -- -p chrome]"
+      script: ./tool/travis.sh test_0 command
       env: PKG="json_serializable"
       dart: stable
     - stage: unit_test
@@ -51,41 +56,6 @@ jobs:
       script: ./tool/travis.sh test_1
       env: PKG="json_serializable"
       dart: "2.0.0"
-    - stage: unit_test
-      name: "SDK: dev - DIR: json_serializable - TASKS: pub run test"
-      script: ./tool/travis.sh test_1
-      env: PKG="json_serializable"
-      dart: dev
-    - stage: unit_test
-      name: "SDK: stable - DIR: json_serializable - TASKS: pub run test --run-skipped test/ensure_build_test.dart"
-      script: ./tool/travis.sh test_2
-      env: PKG="json_serializable"
-      dart: stable
-    - stage: unit_test
-      name: "SDK: 2.0.0 - DIR: json_serializable - TASKS: pub run test --run-skipped test/ensure_build_test.dart"
-      script: ./tool/travis.sh test_2
-      env: PKG="json_serializable"
-      dart: "2.0.0"
-    - stage: unit_test
-      name: "SDK: dev - DIR: json_serializable - TASKS: pub run test --run-skipped test/ensure_build_test.dart"
-      script: ./tool/travis.sh test_2
-      env: PKG="json_serializable"
-      dart: dev
-    - stage: unit_test
-      name: "SDK: stable - DIR: json_serializable - TASKS: pub run build_runner test -- -p chrome"
-      script: ./tool/travis.sh command
-      env: PKG="json_serializable"
-      dart: stable
-    - stage: unit_test
-      name: "SDK: 2.0.0 - DIR: json_serializable - TASKS: pub run build_runner test -- -p chrome"
-      script: ./tool/travis.sh command
-      env: PKG="json_serializable"
-      dart: "2.0.0"
-    - stage: unit_test
-      name: "SDK: dev - DIR: json_serializable - TASKS: pub run build_runner test -- -p chrome"
-      script: ./tool/travis.sh command
-      env: PKG="json_serializable"
-      dart: dev
 
 stages:
   - analyzer_and_format

--- a/json_serializable/mono_pkg.yaml
+++ b/json_serializable/mono_pkg.yaml
@@ -6,21 +6,24 @@ dart:
 
 stages:
   - analyzer_and_format:
-    - group:
-      - dartfmt
-      - dartanalyzer: --fatal-infos --fatal-warnings .
-      dart: [dev]
+      - group:
+          - dartfmt
+          - dartanalyzer: --fatal-infos --fatal-warnings .
+        dart: [dev]
   - analyzer_and_format_stable:
-    - group:
-      - dartfmt
-      - dartanalyzer: --fatal-warnings .
-      dart: [stable]
+      - group:
+          - dartfmt
+          - dartanalyzer: --fatal-warnings .
+        dart: [stable]
   - unit_test:
-    # Run the tests -- include the default-skipped presubmit tests
-    - test
-    - test: --run-skipped test/ensure_build_test.dart
-    - command: pub run build_runner test -- -p chrome
+      - group:
+          - test: --run-skipped
+          - command: pub run build_runner test -- -p chrome
+        dart: [dev, stable]
+      - group:
+          - test
+        dart: [2.0.0]
 
 cache:
   directories:
-  - .dart_tool/build
+    - .dart_tool/build

--- a/tool/travis.sh
+++ b/tool/travis.sh
@@ -49,11 +49,6 @@ while (( "$#" )); do
     echo -e 'pub run test'
     pub run test || EXIT_CODE=$?
     ;;
-  test_2) echo
-    echo -e '\033[1mTASK: test_2\033[22m'
-    echo -e 'pub run test --run-skipped test/ensure_build_test.dart'
-    pub run test --run-skipped test/ensure_build_test.dart || EXIT_CODE=$?
-    ;;
   *) echo -e "\033[31mNot expecting TASK '${TASK}'. Error!\033[0m"
     EXIT_CODE=1
     ;;


### PR DESCRIPTION
Guessing configuration-specific imports
(now used by pkg:package_resolver)
are broken on DDC on Dart 2.0.0