### PR TITLE
Improve error handling with invalid build configuration

### DIFF
--- a/json_annotation/CHANGELOG.md
+++ b/json_annotation/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 * Added to `encodeEmptyCollection` to `JsonKey` and `JsonSerializable`.
 
+* `JsonSerializable.fromJson` now throws `CheckedFromJsonException` on errors.
+  This is potentially a breaking change. 
+
+* Added a more helpful `toString` to `CheckedFromJsonException`.
+
 ## 2.0.0
 
 * **Potentially Breaking** `JsonSerializable` no longer sets default values for

--- a/json_annotation/lib/src/checked_helpers.dart
+++ b/json_annotation/lib/src/checked_helpers.dart
@@ -105,4 +105,22 @@ class CheckedFromJsonException implements Exception {
     }
     return null;
   }
+
+  @override
+  String toString() {
+    final lines = <String>['CheckedFromJsonException'];
+
+    if (_className != null) {
+      lines.add('Could not create `$_className`.');
+    }
+    if (key != null) {
+      lines.add('There is a problem with "$key".');
+    }
+    if (message != null) {
+      lines.add(message);
+    } else if (innerError != null) {
+      lines.add(innerError.toString());
+    }
+    return lines.join('\n');
+  }
 }

--- a/json_annotation/lib/src/json_serializable.dart
+++ b/json_annotation/lib/src/json_serializable.dart
@@ -22,8 +22,9 @@ enum FieldRename {
 
 /// An annotation used to specify a class to generate code for.
 @JsonSerializable(
-  fieldRename: FieldRename.snake,
+  checked: true,
   disallowUnrecognizedKeys: true,
+  fieldRename: FieldRename.snake,
 )
 class JsonSerializable {
   /// If `true`, [Map] types are *not* assumed to be [Map<String, dynamic>]

--- a/json_annotation/lib/src/json_serializable.g.dart
+++ b/json_annotation/lib/src/json_serializable.g.dart
@@ -7,34 +7,54 @@ part of 'json_serializable.dart';
 // **************************************************************************
 
 JsonSerializable _$JsonSerializableFromJson(Map<String, dynamic> json) {
-  $checkKeys(json, allowedKeys: const [
-    'any_map',
-    'checked',
-    'create_factory',
-    'create_to_json',
-    'disallow_unrecognized_keys',
-    'encode_empty_collection',
-    'explicit_to_json',
-    'field_rename',
-    'generate_to_json_function',
-    'include_if_null',
-    'nullable',
-    'use_wrappers'
-  ]);
-  return JsonSerializable(
-      anyMap: json['any_map'] as bool,
-      checked: json['checked'] as bool,
-      createFactory: json['create_factory'] as bool,
-      createToJson: json['create_to_json'] as bool,
-      disallowUnrecognizedKeys: json['disallow_unrecognized_keys'] as bool,
-      encodeEmptyCollection: json['encode_empty_collection'] as bool,
-      explicitToJson: json['explicit_to_json'] as bool,
-      fieldRename:
-          _$enumDecodeNullable(_$FieldRenameEnumMap, json['field_rename']),
-      generateToJsonFunction: json['generate_to_json_function'] as bool,
-      includeIfNull: json['include_if_null'] as bool,
-      nullable: json['nullable'] as bool,
-      useWrappers: json['use_wrappers'] as bool);
+  return $checkedNew('JsonSerializable', json, () {
+    $checkKeys(json, allowedKeys: const [
+      'any_map',
+      'checked',
+      'create_factory',
+      'create_to_json',
+      'disallow_unrecognized_keys',
+      'encode_empty_collection',
+      'explicit_to_json',
+      'field_rename',
+      'generate_to_json_function',
+      'include_if_null',
+      'nullable',
+      'use_wrappers'
+    ]);
+    final val = JsonSerializable(
+        anyMap: $checkedConvert(json, 'any_map', (v) => v as bool),
+        checked: $checkedConvert(json, 'checked', (v) => v as bool),
+        createFactory:
+            $checkedConvert(json, 'create_factory', (v) => v as bool),
+        createToJson: $checkedConvert(json, 'create_to_json', (v) => v as bool),
+        disallowUnrecognizedKeys: $checkedConvert(
+            json, 'disallow_unrecognized_keys', (v) => v as bool),
+        encodeEmptyCollection:
+            $checkedConvert(json, 'encode_empty_collection', (v) => v as bool),
+        explicitToJson:
+            $checkedConvert(json, 'explicit_to_json', (v) => v as bool),
+        fieldRename: $checkedConvert(json, 'field_rename',
+            (v) => _$enumDecodeNullable(_$FieldRenameEnumMap, v)),
+        generateToJsonFunction: $checkedConvert(
+            json, 'generate_to_json_function', (v) => v as bool),
+        includeIfNull:
+            $checkedConvert(json, 'include_if_null', (v) => v as bool),
+        nullable: $checkedConvert(json, 'nullable', (v) => v as bool),
+        useWrappers: $checkedConvert(json, 'use_wrappers', (v) => v as bool));
+    return val;
+  }, fieldKeyMap: const {
+    'anyMap': 'any_map',
+    'createFactory': 'create_factory',
+    'createToJson': 'create_to_json',
+    'disallowUnrecognizedKeys': 'disallow_unrecognized_keys',
+    'encodeEmptyCollection': 'encode_empty_collection',
+    'explicitToJson': 'explicit_to_json',
+    'fieldRename': 'field_rename',
+    'generateToJsonFunction': 'generate_to_json_function',
+    'includeIfNull': 'include_if_null',
+    'useWrappers': 'use_wrappers'
+  });
 }
 
 Map<String, dynamic> _$JsonSerializableToJson(JsonSerializable instance) =>

--- a/json_serializable/CHANGELOG.md
+++ b/json_serializable/CHANGELOG.md
@@ -6,6 +6,8 @@
 
 * Added `BigIntTypeHelper` to `type_helper.dart` library.
 
+* Provide a more helpful error if the builder is improperly configured.
+
 ## 2.0.3
 
 * When invoking a `fromJson` constructor on a field type, generate a conversion

--- a/json_serializable/build.yaml
+++ b/json_serializable/build.yaml
@@ -3,7 +3,6 @@ targets:
   $default:
     builders:
       json_serializable:
-        enabled: true
         generate_for:
           include:
           - example/*

--- a/json_serializable/lib/builder.dart
+++ b/json_serializable/lib/builder.dart
@@ -22,6 +22,23 @@ import 'src/json_part_builder.dart';
 ///
 /// Not meant to be invoked by hand-authored code.
 Builder jsonSerializable(BuilderOptions options) {
-  final config = JsonSerializable.fromJson(options.config);
-  return jsonPartBuilder(config: config);
+  try {
+    final config = JsonSerializable.fromJson(options.config);
+    return jsonPartBuilder(config: config);
+  } on CheckedFromJsonException catch (e) {
+    final lines = <String>[
+      'Could not parse the options provided for `json_serializable`.'
+    ];
+
+    if (e.key != null) {
+      lines.add('There is a problem with "${e.key}".');
+    }
+    if (e.message != null) {
+      lines.add(e.message);
+    } else if (e.innerError != null) {
+      lines.add(e.innerError.toString());
+    }
+
+    throw StateError(lines.join('\n'));
+  }
 }


### PR DESCRIPTION
- `JsonSerializable.fromJson` now throws `CheckedFromJsonException` on
  errors.
- Added a more helpful `toString` to `CheckedFromJsonException`.