### PR TITLE
Allow the latest build_config

### DIFF
--- a/json_serializable/CHANGELOG.md
+++ b/json_serializable/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## 2.2.2
 
 - Require at least Dart `2.2.0`.
+- Allow `build_config` `0.4.x`.
 
 ## 2.2.1
 

--- a/json_serializable/pubspec.yaml
+++ b/json_serializable/pubspec.yaml
@@ -1,5 +1,5 @@
 name: json_serializable
-version: 2.2.2-dev
+version: 2.2.2
 author: Dart Team <misc@dartlang.org>
 description: >-
   Automatically generate code for converting to and from JSON by annotating
@@ -11,7 +11,7 @@ environment:
 dependencies:
   analyzer: '>=0.33.3 <0.37.0'
   build: '>=0.12.6 <2.0.0'
-  build_config: '>=0.2.6 <0.4.0'
+  build_config: '>=0.2.6 <0.5.0'
 
   # Use a tight version constraint to ensure that a constraint on
   # `json_annotation` properly constrains all features it provides.


### PR DESCRIPTION
Breaking changes were only for uses of the Dart API, no breaking changes
to parsing `build.yaml`.