### PR TITLE
Add pub version badges to json_serial + annotation

### DIFF
--- a/json_annotation/README.md
+++ b/json_annotation/README.md
@@ -1,3 +1,5 @@
+[![Pub Package](https://img.shields.io/pub/v/json_annotation.svg)](https://pub.dartlang.org/packages/json_annotation)
+
 Defines the annotations used by [json_serializable] to create code for JSON
 serialization and deserialization.
 

--- a/json_serializable/README.md
+++ b/json_serializable/README.md
@@ -1,4 +1,4 @@
-[![Build Status](https://travis-ci.org/dart-lang/json_serializable.svg?branch=master)](https://travis-ci.org/dart-lang/json_serializable)
+[![Pub Package](https://img.shields.io/pub/v/json_serializable.svg)](https://pub.dartlang.org/packages/json_serializable)
 
 Provides [Dart Build System] builders for handling JSON.
 


### PR DESCRIPTION
Remove build badge from json_serializable

We have it on the repo root readme. Unclear this is useful on the pub site