### PR TITLE
Eliminate new methods named with "get"

### DIFF
--- a/yaml_decode/lib/yaml_decode.dart
+++ b/yaml_decode/lib/yaml_decode.dart
@@ -24,7 +24,7 @@ ParsedYamlException toParsedYamlException(
 
     final node = yamlMap.nodes.keys.singleWhere(
         (k) => (k as YamlScalar).value == key,
-        orElse: () => yamlMap) as YamlScalar;
+        orElse: () => yamlMap) as YamlNode;
     return ParsedYamlException(
       exception.message,
       node,

--- a/yaml_decode/lib/yaml_decode.dart
+++ b/yaml_decode/lib/yaml_decode.dart
@@ -15,10 +15,6 @@ ParsedYamlException toParsedYamlException(
 }) {
   final yamlMap = exceptionMap ?? exception.map as YamlMap;
 
-  YamlNode _getYamlKey(String key) =>
-      yamlMap.nodes.keys.singleWhere((k) => (k as YamlScalar).value == key,
-          orElse: () => null) as YamlScalar;
-
   final innerError = exception.innerError;
 
   if (exception.badKey) {
@@ -26,7 +22,9 @@ ParsedYamlException toParsedYamlException(
         ? innerError.unrecognizedKeys.first
         : exception.key;
 
-    final node = _getYamlKey(key) ?? yamlMap;
+    final node = yamlMap.nodes.keys.singleWhere(
+        (k) => (k as YamlScalar).value == key,
+        orElse: () => yamlMap) as YamlScalar;
     return ParsedYamlException(
       exception.message,
       node,

--- a/yaml_test/test/yaml_test.dart
+++ b/yaml_test/test/yaml_test.dart
@@ -14,7 +14,7 @@ import 'package:yaml_decode/yaml_decode.dart';
 
 import 'src/build_config.dart';
 
-List<String> _getTests() => Directory(p.join('test', 'src'))
+List<String> get _tests => Directory(p.join('test', 'src'))
     .listSync()
     .where((fse) => fse is File && p.extension(fse.path) == '.yaml')
     .map((fse) => fse.path)
@@ -22,7 +22,7 @@ List<String> _getTests() => Directory(p.join('test', 'src'))
 
 void main() {
   group('valid configurations', () {
-    for (final filePath in _getTests()) {
+    for (final filePath in _tests) {
       test(p.basenameWithoutExtension(filePath), () {
         final content = File(filePath).readAsStringSync();
         final yamlContent = loadYaml(content, sourceUrl: filePath) as YamlMap;


### PR DESCRIPTION
https://dart.dev/guides/language/effective-dart/design#avoid-starting-a-method-name-with-get

- Change `_getTests()` to `get _tests`.
- Inline `_getYamlKey` since we can also inline the `orElse` case rather
  than using `null` and then `??`.