### PR TITLE
Add FieldRename.pascal

### DIFF
--- a/json_annotation/lib/src/json_serializable.dart
+++ b/json_annotation/lib/src/json_serializable.dart
@@ -17,7 +17,10 @@ enum FieldRename {
   kebab,
 
   /// Encodes a field named `snakeCase` with a JSON key `snake_case`.
-  snake
+  snake,
+
+  /// Encodes a field named `pascalCase` with a JSON key `PascalCase`.
+  pascal
 }
 
 /// An annotation used to specify a class to generate code for.

--- a/json_annotation/lib/src/json_serializable.g.dart
+++ b/json_annotation/lib/src/json_serializable.g.dart
@@ -96,5 +96,6 @@ T _$enumDecodeNullable<T>(Map<T, dynamic> enumValues, dynamic source) {
 const _$FieldRenameEnumMap = <FieldRename, dynamic>{
   FieldRename.none: 'none',
   FieldRename.kebab: 'kebab',
-  FieldRename.snake: 'snake'
+  FieldRename.snake: 'snake',
+  FieldRename.pascal: 'pascal'
 };

--- a/json_serializable/lib/src/json_key_utils.dart
+++ b/json_serializable/lib/src/json_key_utils.dart
@@ -190,6 +190,8 @@ String _encodedFieldName(JsonSerializable classAnnotation,
       return snakeCase(fieldElement.name);
     case FieldRename.kebab:
       return kebabCase(fieldElement.name);
+    case FieldRename.pascal:
+      return pascalCase(fieldElement.name);
   }
 
   return fieldElement.name;

--- a/json_serializable/lib/src/utils.dart
+++ b/json_serializable/lib/src/utils.dart
@@ -27,6 +27,14 @@ String kebabCase(String input) => _fixCase(input, '-');
 
 String snakeCase(String input) => _fixCase(input, '_');
 
+String pascalCase(String input) {
+  if (input.isEmpty) {
+    return '';
+  }
+  
+  return input[0].toUpperCase() + input.substring(1);
+}
+
 String _fixCase(String input, String separator) =>
     input.replaceAllMapped(_upperCase, (match) {
       var lower = match.group(0).toLowerCase();

--- a/json_serializable/lib/src/utils.dart
+++ b/json_serializable/lib/src/utils.dart
@@ -31,7 +31,7 @@ String pascalCase(String input) {
   if (input.isEmpty) {
     return '';
   }
-  
+
   return input[0].toUpperCase() + input.substring(1);
 }
 

--- a/json_serializable/pubspec.yaml
+++ b/json_serializable/pubspec.yaml
@@ -31,3 +31,7 @@ dev_dependencies:
   source_gen_test: ^0.1.0
   test: ^1.6.0
   yaml: ^2.1.13
+
+dependency_overrides:
+  json_annotation:
+    path: ../json_annotation

--- a/json_serializable/test/config_test.dart
+++ b/json_serializable/test/config_test.dart
@@ -111,7 +111,7 @@ void main() {
         config[entry.key] = entry.value;
 
         final lastLine = entry.key == 'field_rename'
-            ? '`42` is not one of the supported values: none, kebab, snake'
+            ? '`42` is not one of the supported values: none, kebab, snake, pascal'
             : "type 'int' is not a subtype of type 'bool' in type cast";
 
         final matcher = isA<StateError>().having(

--- a/json_serializable/test/json_serializable_test.dart
+++ b/json_serializable/test/json_serializable_test.dart
@@ -54,6 +54,7 @@ const _expectedAnnotatedTests = [
   'EncodeEmptyCollectionAsNullOnNonCollectionField',
   'FieldNamerKebab',
   'FieldNamerNone',
+  'FieldNamerPascal',
   'FieldNamerSnake',
   'FieldWithFromJsonCtorAndTypeParams',
   'FinalFields',

--- a/json_serializable/test/src/field_namer_input.dart
+++ b/json_serializable/test/src/field_namer_input.dart
@@ -38,6 +38,24 @@ class FieldNamerKebab {
 
 @ShouldGenerate(
   r'''
+Map<String, dynamic> _$FieldNamerPascalToJson(FieldNamerPascal instance) =>
+    <String, dynamic>{
+      'TheField': instance.theField,
+      'NAME_OVERRIDE': instance.nameOverride
+    };
+''',
+  configurations: ['default'],
+)
+@JsonSerializable(fieldRename: FieldRename.pascal, createFactory: false)
+class FieldNamerPascal {
+  String theField;
+
+  @JsonKey(name: 'NAME_OVERRIDE')
+  String nameOverride;
+}
+
+@ShouldGenerate(
+  r'''
 Map<String, dynamic> _$FieldNamerSnakeToJson(FieldNamerSnake instance) =>
     <String, dynamic>{
       'the_field': instance.theField,

--- a/json_serializable/test/utils_test.dart
+++ b/json_serializable/test/utils_test.dart
@@ -8,25 +8,45 @@ import 'package:test/test.dart';
 
 import 'package:json_serializable/src/utils.dart';
 
-const _items = {
+const _kebab_items = {
   'simple': 'simple',
   'twoWords': 'two-words',
   'FirstBig': 'first-big'
 };
 
+const _pascal_items = {
+  'simple': 'Simple',
+  'twoWords': 'TwoWords',
+  'FirstBig': 'FirstBig'
+};
+
+const _snake_items = {
+  'simple': 'simple',
+  'twoWords': 'two_words',
+  'FirstBig': 'first_big'
+};
+
 void main() {
   group('kebab', () {
-    for (final entry in _items.entries) {
+    for (final entry in _kebab_items.entries) {
       test('"${entry.key}"', () {
         expect(kebabCase(entry.key), entry.value);
       });
     }
   });
 
-  group('snake', () {
-    for (final entry in _items.entries) {
+  group('pascal', () {
+    for (final entry in _pascal_items.entries) {
       test('"${entry.key}"', () {
-        expect(snakeCase(entry.key), entry.value.replaceAll('-', '_'));
+        expect(pascalCase(entry.key), entry.value);
+      });
+    }
+  });
+
+  group('snake', () {
+    for (final entry in _snake_items.entries) {
+      test('"${entry.key}"', () {
+        expect(snakeCase(entry.key), entry.value);
       });
     }
   });

--- a/json_serializable/test/utils_test.dart
+++ b/json_serializable/test/utils_test.dart
@@ -8,19 +8,19 @@ import 'package:test/test.dart';
 
 import 'package:json_serializable/src/utils.dart';
 
-const _kebab_items = {
+const _kebabItems = {
   'simple': 'simple',
   'twoWords': 'two-words',
   'FirstBig': 'first-big'
 };
 
-const _pascal_items = {
+const _pascalItems = {
   'simple': 'Simple',
   'twoWords': 'TwoWords',
   'FirstBig': 'FirstBig'
 };
 
-const _snake_items = {
+const _snakeItems = {
   'simple': 'simple',
   'twoWords': 'two_words',
   'FirstBig': 'first_big'
@@ -28,7 +28,7 @@ const _snake_items = {
 
 void main() {
   group('kebab', () {
-    for (final entry in _kebab_items.entries) {
+    for (final entry in _kebabItems.entries) {
       test('"${entry.key}"', () {
         expect(kebabCase(entry.key), entry.value);
       });
@@ -36,7 +36,7 @@ void main() {
   });
 
   group('pascal', () {
-    for (final entry in _pascal_items.entries) {
+    for (final entry in _pascalItems.entries) {
       test('"${entry.key}"', () {
         expect(pascalCase(entry.key), entry.value);
       });
@@ -44,7 +44,7 @@ void main() {
   });
 
   group('snake', () {
-    for (final entry in _snake_items.entries) {
+    for (final entry in _snakeItems.entries) {
       test('"${entry.key}"', () {
         expect(snakeCase(entry.key), entry.value);
       });


### PR DESCRIPTION
Adds a `pascal` value to the `FieldRename` enum, for [PascalCase](http://wiki.c2.com/?PascalCase) JSON field name encoding.

Resolves #474.