### PR TITLE
pass the source value to conversion functions, even if nullable is false

### DIFF
--- a/analysis_options.yaml
+++ b/analysis_options.yaml
@@ -42,7 +42,6 @@ linter:
     - library_prefixes
     - list_remove_unrelated_type
     - literal_only_boolean_expressions
-    - no_adjacent_strings_in_list
     - no_duplicate_case_values
     - non_constant_identifier_names
     - null_closures

--- a/json_serializable/CHANGELOG.md
+++ b/json_serializable/CHANGELOG.md
@@ -3,6 +3,12 @@
 - **BREAKING** Removed support for `JsonSerializable.useWrappers`.
 - **BREAKING** Removed support for `JsonSerializable.generateToJsonFunction`.
 - **BREAKING** Removed support for `encodeEmptyCollection`.
+- **BREAKING** If a field has a conversion function defined – either 
+  `JsonKey.toJson` or a custom `JsonConverter` annotation – don't intercept
+  `null` values, even if `nullable` is explicitly set to `false`. This allows
+  these functions to provide alternative values for `null` – such as an empty
+  collection – which replaces the functionality provided by
+  `encodeEmptyCollection`.
 
 ## 2.3.0
 

--- a/json_serializable/lib/src/json_key_utils.dart
+++ b/json_serializable/lib/src/json_key_utils.dart
@@ -5,6 +5,7 @@
 import 'package:analyzer/dart/constant/value.dart';
 import 'package:analyzer/dart/element/element.dart';
 import 'package:analyzer/dart/element/type.dart';
+import 'package:build/build.dart';
 import 'package:json_annotation/json_annotation.dart';
 import 'package:source_gen/source_gen.dart';
 
@@ -15,6 +16,21 @@ final _jsonKeyExpando = Expando<JsonKey>();
 
 JsonKey jsonKeyForField(FieldElement field, JsonSerializable classAnnotation) =>
     _jsonKeyExpando[field] ??= _from(field, classAnnotation);
+
+/// Will log "info" if [element] has an explicit value for [JsonKey.nullable]
+/// telling the programmer that it will be ignored.
+void logFieldWithConversionFunction(FieldElement element) {
+  final jsonKey = _jsonKeyExpando[element];
+  if (_explicitNullableExpando[jsonKey] ?? false) {
+    log.info(
+      'The `JsonKey.nullable` value on '
+      '`${element.enclosingElement.name}.${element.name}` will be ignored '
+      'because a custom conversion function is being used.',
+    );
+
+    _explicitNullableExpando[jsonKey] = null;
+  }
+}
 
 JsonKey _from(FieldElement element, JsonSerializable classAnnotation) {
   // If an annotation exists on `element` the source is a 'real' field.
@@ -127,7 +143,7 @@ JsonKey _populateJsonKey(
     }
   }
 
-  return JsonKey(
+  final jsonKey = JsonKey(
     defaultValue: defaultValue,
     disallowNullValue: disallowNullValue ?? false,
     ignore: ignore ?? false,
@@ -137,7 +153,13 @@ JsonKey _populateJsonKey(
     nullable: nullable ?? classAnnotation.nullable,
     required: required ?? false,
   );
+
+  _explicitNullableExpando[jsonKey] = nullable != null;
+
+  return jsonKey;
 }
+
+final _explicitNullableExpando = Expando<bool>('explicit nullable');
 
 String _encodedFieldName(JsonSerializable classAnnotation,
     String jsonKeyNameValue, FieldElement fieldElement) {

--- a/json_serializable/lib/src/type_helpers/convert_helper.dart
+++ b/json_serializable/lib/src/type_helpers/convert_helper.dart
@@ -4,6 +4,7 @@
 
 import 'package:analyzer/dart/element/type.dart';
 
+import '../json_key_utils.dart';
 import '../shared_checkers.dart';
 import '../type_helper.dart';
 
@@ -18,6 +19,7 @@ class ConvertData {
 
 abstract class TypeHelperContextWithConvert extends TypeHelperContext {
   ConvertData get serializeConvertData;
+
   ConvertData get deserializeConvertData;
 }
 
@@ -28,30 +30,28 @@ class ConvertHelper extends TypeHelper<TypeHelperContextWithConvert> {
   String serialize(DartType targetType, String expression,
       TypeHelperContextWithConvert context) {
     final toJsonData = context.serializeConvertData;
-    if (toJsonData != null) {
-      assert(toJsonData.paramType is TypeParameterType ||
-          targetType.isAssignableTo(toJsonData.paramType));
-      return toJsonSerializeImpl(toJsonData.name, expression, context.nullable);
+    if (toJsonData == null) {
+      return null;
     }
-    return null;
+
+    logFieldWithConversionFunction(context.fieldElement);
+
+    assert(toJsonData.paramType is TypeParameterType ||
+        targetType.isAssignableTo(toJsonData.paramType));
+    return '${toJsonData.name}($expression)';
   }
 
   @override
   String deserialize(DartType targetType, String expression,
       TypeHelperContextWithConvert context) {
     final fromJsonData = context.deserializeConvertData;
-    if (fromJsonData != null) {
-      final asContent = asStatement(fromJsonData.paramType);
-      final result = '${fromJsonData.name}($expression$asContent)';
-      return commonNullPrefix(context.nullable, expression, result).toString();
+    if (fromJsonData == null) {
+      return null;
     }
-    return null;
-  }
-}
 
-/// Exposed to support `EncodeHelper` – not exposed publicly.
-String toJsonSerializeImpl(
-    String toJsonDataName, String expression, bool nullable) {
-  final result = '$toJsonDataName($expression)';
-  return commonNullPrefix(nullable, expression, result).toString();
+    logFieldWithConversionFunction(context.fieldElement);
+
+    final asContent = asStatement(fromJsonData.paramType);
+    return '${fromJsonData.name}($expression$asContent)';
+  }
 }

--- a/json_serializable/lib/src/type_helpers/json_converter_helper.dart
+++ b/json_serializable/lib/src/type_helpers/json_converter_helper.dart
@@ -8,6 +8,7 @@ import 'package:analyzer/dart/element/type.dart';
 import 'package:json_annotation/json_annotation.dart';
 import 'package:source_gen/source_gen.dart';
 
+import '../json_key_utils.dart';
 import '../shared_checkers.dart';
 import '../type_helper.dart';
 
@@ -25,8 +26,9 @@ class JsonConverterHelper extends TypeHelper {
       return null;
     }
 
-    return commonNullPrefix(context.nullable, expression,
-        LambdaResult(expression, '${converter.accessString}.toJson'));
+    logFieldWithConversionFunction(context.fieldElement);
+
+    return LambdaResult(expression, '${converter.accessString}.toJson');
   }
 
   @override
@@ -39,11 +41,10 @@ class JsonConverterHelper extends TypeHelper {
 
     final asContent = asStatement(converter.jsonType);
 
-    return commonNullPrefix(
-        context.nullable,
-        expression,
-        LambdaResult(
-            '$expression$asContent', '${converter.accessString}.fromJson'));
+    logFieldWithConversionFunction(context.fieldElement);
+
+    return LambdaResult(
+        '$expression$asContent', '${converter.accessString}.fromJson');
   }
 }
 

--- a/json_serializable/lib/type_helper.dart
+++ b/json_serializable/lib/type_helper.dart
@@ -6,7 +6,7 @@ export 'src/shared_checkers.dart' show simpleJsonTypeChecker, typeArgumentsOf;
 export 'src/type_helper.dart'
     show TypeHelperContext, TypeHelper, UnsupportedTypeError;
 export 'src/type_helpers/big_int_helper.dart';
-export 'src/type_helpers/convert_helper.dart' hide toJsonSerializeImpl;
+export 'src/type_helpers/convert_helper.dart';
 export 'src/type_helpers/date_time_helper.dart';
 export 'src/type_helpers/enum_helper.dart';
 export 'src/type_helpers/iterable_helper.dart';

--- a/json_serializable/test/generic_files/generic_class.g.dart
+++ b/json_serializable/test/generic_files/generic_class.g.dart
@@ -9,43 +9,26 @@ part of 'generic_class.dart';
 GenericClass<T, S> _$GenericClassFromJson<T extends num, S>(
     Map<String, dynamic> json) {
   return GenericClass<T, S>()
-    ..fieldObject = json['fieldObject'] == null
-        ? null
-        : GenericClass._dataFromJson(
-            json['fieldObject'] as Map<String, dynamic>)
-    ..fieldDynamic = json['fieldDynamic'] == null
-        ? null
-        : GenericClass._dataFromJson(
-            json['fieldDynamic'] as Map<String, dynamic>)
-    ..fieldInt = json['fieldInt'] == null
-        ? null
-        : GenericClass._dataFromJson(json['fieldInt'] as Map<String, dynamic>)
-    ..fieldT = json['fieldT'] == null
-        ? null
-        : GenericClass._dataFromJson(json['fieldT'] as Map<String, dynamic>)
-    ..fieldS = json['fieldS'] == null
-        ? null
-        : GenericClass._dataFromJson(json['fieldS'] as Map<String, dynamic>);
+    ..fieldObject =
+        GenericClass._dataFromJson(json['fieldObject'] as Map<String, dynamic>)
+    ..fieldDynamic =
+        GenericClass._dataFromJson(json['fieldDynamic'] as Map<String, dynamic>)
+    ..fieldInt =
+        GenericClass._dataFromJson(json['fieldInt'] as Map<String, dynamic>)
+    ..fieldT =
+        GenericClass._dataFromJson(json['fieldT'] as Map<String, dynamic>)
+    ..fieldS =
+        GenericClass._dataFromJson(json['fieldS'] as Map<String, dynamic>);
 }
 
 Map<String, dynamic> _$GenericClassToJson<T extends num, S>(
         GenericClass<T, S> instance) =>
     <String, dynamic>{
-      'fieldObject': instance.fieldObject == null
-          ? null
-          : GenericClass._dataToJson(instance.fieldObject),
-      'fieldDynamic': instance.fieldDynamic == null
-          ? null
-          : GenericClass._dataToJson(instance.fieldDynamic),
-      'fieldInt': instance.fieldInt == null
-          ? null
-          : GenericClass._dataToJson(instance.fieldInt),
-      'fieldT': instance.fieldT == null
-          ? null
-          : GenericClass._dataToJson(instance.fieldT),
-      'fieldS': instance.fieldS == null
-          ? null
-          : GenericClass._dataToJson(instance.fieldS)
+      'fieldObject': GenericClass._dataToJson(instance.fieldObject),
+      'fieldDynamic': GenericClass._dataToJson(instance.fieldDynamic),
+      'fieldInt': GenericClass._dataToJson(instance.fieldInt),
+      'fieldT': GenericClass._dataToJson(instance.fieldT),
+      'fieldS': GenericClass._dataToJson(instance.fieldS)
     };
 
 GenericClassWithConverter<T, S>
@@ -55,20 +38,14 @@ GenericClassWithConverter<T, S>
     ..fieldObject = json['fieldObject']
     ..fieldDynamic = json['fieldDynamic']
     ..fieldInt = json['fieldInt'] as int
-    ..fieldT = json['fieldT'] == null
-        ? null
-        : _SimpleConverter<T>().fromJson(json['fieldT'] as Map<String, dynamic>)
-    ..fieldS = json['fieldS'] == null
-        ? null
-        : _SimpleConverter<S>().fromJson(json['fieldS'] as Map<String, dynamic>)
-    ..duration = json['duration'] == null
-        ? null
-        : const _DurationMillisecondConverter()
-            .fromJson(json['duration'] as int)
-    ..listDuration = json['listDuration'] == null
-        ? null
-        : const _DurationListMillisecondConverter()
-            .fromJson(json['listDuration'] as int);
+    ..fieldT =
+        _SimpleConverter<T>().fromJson(json['fieldT'] as Map<String, dynamic>)
+    ..fieldS =
+        _SimpleConverter<S>().fromJson(json['fieldS'] as Map<String, dynamic>)
+    ..duration =
+        const _DurationMillisecondConverter().fromJson(json['duration'] as int)
+    ..listDuration = const _DurationListMillisecondConverter()
+        .fromJson(json['listDuration'] as int);
 }
 
 Map<String, dynamic> _$GenericClassWithConverterToJson<T extends num, S>(
@@ -77,17 +54,10 @@ Map<String, dynamic> _$GenericClassWithConverterToJson<T extends num, S>(
       'fieldObject': instance.fieldObject,
       'fieldDynamic': instance.fieldDynamic,
       'fieldInt': instance.fieldInt,
-      'fieldT': instance.fieldT == null
-          ? null
-          : _SimpleConverter<T>().toJson(instance.fieldT),
-      'fieldS': instance.fieldS == null
-          ? null
-          : _SimpleConverter<S>().toJson(instance.fieldS),
-      'duration': instance.duration == null
-          ? null
-          : const _DurationMillisecondConverter().toJson(instance.duration),
-      'listDuration': instance.listDuration == null
-          ? null
-          : const _DurationListMillisecondConverter()
-              .toJson(instance.listDuration)
+      'fieldT': _SimpleConverter<T>().toJson(instance.fieldT),
+      'fieldS': _SimpleConverter<S>().toJson(instance.fieldS),
+      'duration':
+          const _DurationMillisecondConverter().toJson(instance.duration),
+      'listDuration': const _DurationListMillisecondConverter()
+          .toJson(instance.listDuration)
     };

--- a/json_serializable/test/integration/json_test_common.dart
+++ b/json_serializable/test/integration/json_test_common.dart
@@ -25,11 +25,15 @@ enum StatusCode {
   notFound
 }
 
-Duration durationFromInt(int ms) => Duration(milliseconds: ms);
-int durationToInt(Duration duration) => duration.inMilliseconds;
+Duration durationFromInt(int ms) =>
+    ms == null ? null : Duration(milliseconds: ms);
 
-DateTime dateTimeFromEpochUs(int us) => DateTime.fromMicrosecondsSinceEpoch(us);
-int dateTimeToEpochUs(DateTime dateTime) => dateTime.microsecondsSinceEpoch;
+int durationToInt(Duration duration) => duration?.inMilliseconds;
+
+DateTime dateTimeFromEpochUs(int us) =>
+    us == null ? null : DateTime.fromMicrosecondsSinceEpoch(us);
+
+int dateTimeToEpochUs(DateTime dateTime) => dateTime?.microsecondsSinceEpoch;
 
 bool deepEquals(a, b) => const DeepCollectionEquality().equals(a, b);
 
@@ -38,6 +42,7 @@ class Platform {
 
   static const Platform foo = Platform._('foo');
   static const Platform undefined = Platform._('undefined');
+
   const Platform._(this.description);
 
   factory Platform.fromJson(String value) {

--- a/json_serializable/test/integration/json_test_example.g.dart
+++ b/json_serializable/test/integration/json_test_example.g.dart
@@ -159,11 +159,8 @@ Numbers _$NumbersFromJson(Map<String, dynamic> json) {
         (json['doubles'] as List)?.map((e) => (e as num)?.toDouble())?.toList()
     ..nnDoubles =
         (json['nnDoubles'] as List).map((e) => (e as num).toDouble()).toList()
-    ..duration = json['duration'] == null
-        ? null
-        : durationFromInt(json['duration'] as int)
-    ..date =
-        json['date'] == null ? null : dateTimeFromEpochUs(json['date'] as int);
+    ..duration = durationFromInt(json['duration'] as int)
+    ..date = dateTimeFromEpochUs(json['date'] as int);
 }
 
 Map<String, dynamic> _$NumbersToJson(Numbers instance) => <String, dynamic>{
@@ -171,7 +168,6 @@ Map<String, dynamic> _$NumbersToJson(Numbers instance) => <String, dynamic>{
       'nums': instance.nums,
       'doubles': instance.doubles,
       'nnDoubles': instance.nnDoubles,
-      'duration':
-          instance.duration == null ? null : durationToInt(instance.duration),
-      'date': instance.date == null ? null : dateTimeToEpochUs(instance.date)
+      'duration': durationToInt(instance.duration),
+      'date': dateTimeToEpochUs(instance.date)
     };

--- a/json_serializable/test/kitchen_sink/json_converters.dart
+++ b/json_serializable/test/kitchen_sink/json_converters.dart
@@ -29,17 +29,17 @@ class TrivialNumberConverter implements JsonConverter<TrivialNumber, int> {
   TrivialNumber fromJson(int json) => TrivialNumber(json);
 
   @override
-  int toJson(TrivialNumber object) => object.value;
+  int toJson(TrivialNumber object) => object?.value;
 }
 
 class BigIntStringConverter implements JsonConverter<BigInt, String> {
   const BigIntStringConverter();
 
   @override
-  BigInt fromJson(String json) => BigInt.parse(json);
+  BigInt fromJson(String json) => json == null ? null : BigInt.parse(json);
 
   @override
-  String toJson(BigInt object) => object.toString();
+  String toJson(BigInt object) => object?.toString();
 }
 
 const durationConverter = DurationMillisecondConverter();
@@ -48,18 +48,20 @@ class DurationMillisecondConverter implements JsonConverter<Duration, int> {
   const DurationMillisecondConverter();
 
   @override
-  Duration fromJson(int json) => Duration(milliseconds: json);
+  Duration fromJson(int json) =>
+      json == null ? null : Duration(milliseconds: json);
 
   @override
-  int toJson(Duration object) => object.inMilliseconds;
+  int toJson(Duration object) => object?.inMilliseconds;
 }
 
 class EpochDateTimeConverter implements JsonConverter<DateTime, int> {
   const EpochDateTimeConverter();
 
   @override
-  DateTime fromJson(int json) => DateTime.fromMillisecondsSinceEpoch(json);
+  DateTime fromJson(int json) =>
+      json == null ? null : DateTime.fromMillisecondsSinceEpoch(json);
 
   @override
-  int toJson(DateTime object) => object.millisecondsSinceEpoch;
+  int toJson(DateTime object) => object?.millisecondsSinceEpoch;
 }

--- a/json_serializable/test/kitchen_sink/kitchen_sink.g.dart
+++ b/json_serializable/test/kitchen_sink/kitchen_sink.g.dart
@@ -126,90 +126,61 @@ Map<String, dynamic> _$KitchenSinkToJson(KitchenSink instance) =>
 JsonConverterTestClass _$JsonConverterTestClassFromJson(
     Map<String, dynamic> json) {
   return JsonConverterTestClass()
-    ..duration = json['duration'] == null
-        ? null
-        : durationConverter.fromJson(json['duration'] as int)
+    ..duration = durationConverter.fromJson(json['duration'] as int)
     ..durationList = (json['durationList'] as List)
-        ?.map((e) => e == null ? null : durationConverter.fromJson(e as int))
+        ?.map((e) => durationConverter.fromJson(e as int))
         ?.toList()
-    ..bigInt = json['bigInt'] == null
-        ? null
-        : const BigIntStringConverter().fromJson(json['bigInt'] as String)
+    ..bigInt = const BigIntStringConverter().fromJson(json['bigInt'] as String)
     ..bigIntMap = (json['bigIntMap'] as Map<String, dynamic>)?.map(
-      (k, e) => MapEntry(
-          k,
-          e == null
-              ? null
-              : const BigIntStringConverter().fromJson(e as String)),
+      (k, e) =>
+          MapEntry(k, const BigIntStringConverter().fromJson(e as String)),
     )
-    ..numberSilly = json['numberSilly'] == null
-        ? null
-        : TrivialNumberConverter.instance.fromJson(json['numberSilly'] as int)
+    ..numberSilly =
+        TrivialNumberConverter.instance.fromJson(json['numberSilly'] as int)
     ..numberSillySet = (json['numberSillySet'] as List)
-        ?.map((e) => e == null
-            ? null
-            : TrivialNumberConverter.instance.fromJson(e as int))
+        ?.map((e) => TrivialNumberConverter.instance.fromJson(e as int))
         ?.toSet()
-    ..dateTime = json['dateTime'] == null
-        ? null
-        : const EpochDateTimeConverter().fromJson(json['dateTime'] as int);
+    ..dateTime =
+        const EpochDateTimeConverter().fromJson(json['dateTime'] as int);
 }
 
 Map<String, dynamic> _$JsonConverterTestClassToJson(
         JsonConverterTestClass instance) =>
     <String, dynamic>{
-      'duration': instance.duration == null
-          ? null
-          : durationConverter.toJson(instance.duration),
-      'durationList': instance.durationList
-          ?.map((e) => e == null ? null : durationConverter.toJson(e))
-          ?.toList(),
-      'bigInt': instance.bigInt == null
-          ? null
-          : const BigIntStringConverter().toJson(instance.bigInt),
-      'bigIntMap': instance.bigIntMap?.map((k, e) => MapEntry(
-          k, e == null ? null : const BigIntStringConverter().toJson(e))),
-      'numberSilly': instance.numberSilly == null
-          ? null
-          : TrivialNumberConverter.instance.toJson(instance.numberSilly),
+      'duration': durationConverter.toJson(instance.duration),
+      'durationList':
+          instance.durationList?.map(durationConverter.toJson)?.toList(),
+      'bigInt': const BigIntStringConverter().toJson(instance.bigInt),
+      'bigIntMap': instance.bigIntMap
+          ?.map((k, e) => MapEntry(k, const BigIntStringConverter().toJson(e))),
+      'numberSilly':
+          TrivialNumberConverter.instance.toJson(instance.numberSilly),
       'numberSillySet': instance.numberSillySet
-          ?.map((e) =>
-              e == null ? null : TrivialNumberConverter.instance.toJson(e))
+          ?.map(TrivialNumberConverter.instance.toJson)
           ?.toList(),
-      'dateTime': instance.dateTime == null
-          ? null
-          : const EpochDateTimeConverter().toJson(instance.dateTime)
+      'dateTime': const EpochDateTimeConverter().toJson(instance.dateTime)
     };
 
 JsonConverterGeneric<S, T, U> _$JsonConverterGenericFromJson<S, T, U>(
     Map<String, dynamic> json) {
   return JsonConverterGeneric<S, T, U>()
-    ..item = json['item'] == null
-        ? null
-        : GenericConverter<S>().fromJson(json['item'] as Map<String, dynamic>)
+    ..item =
+        GenericConverter<S>().fromJson(json['item'] as Map<String, dynamic>)
     ..itemList = (json['itemList'] as List)
-        ?.map((e) => e == null
-            ? null
-            : GenericConverter<T>().fromJson(e as Map<String, dynamic>))
+        ?.map((e) => GenericConverter<T>().fromJson(e as Map<String, dynamic>))
         ?.toList()
     ..itemMap = (json['itemMap'] as Map<String, dynamic>)?.map(
       (k, e) => MapEntry(
-          k,
-          e == null
-              ? null
-              : GenericConverter<U>().fromJson(e as Map<String, dynamic>)),
+          k, GenericConverter<U>().fromJson(e as Map<String, dynamic>)),
     );
 }
 
 Map<String, dynamic> _$JsonConverterGenericToJson<S, T, U>(
         JsonConverterGeneric<S, T, U> instance) =>
     <String, dynamic>{
-      'item': instance.item == null
-          ? null
-          : GenericConverter<S>().toJson(instance.item),
-      'itemList': instance.itemList
-          ?.map((e) => e == null ? null : GenericConverter<T>().toJson(e))
-          ?.toList(),
-      'itemMap': instance.itemMap?.map((k, e) =>
-          MapEntry(k, e == null ? null : GenericConverter<U>().toJson(e)))
+      'item': GenericConverter<S>().toJson(instance.item),
+      'itemList':
+          instance.itemList?.map(GenericConverter<T>().toJson)?.toList(),
+      'itemMap': instance.itemMap
+          ?.map((k, e) => MapEntry(k, GenericConverter<U>().toJson(e)))
     };

--- a/json_serializable/test/kitchen_sink/kitchen_sink.g_any_map.g.dart
+++ b/json_serializable/test/kitchen_sink/kitchen_sink.g_any_map.g.dart
@@ -123,90 +123,61 @@ Map<String, dynamic> _$KitchenSinkToJson(KitchenSink instance) =>
 
 JsonConverterTestClass _$JsonConverterTestClassFromJson(Map json) {
   return JsonConverterTestClass()
-    ..duration = json['duration'] == null
-        ? null
-        : durationConverter.fromJson(json['duration'] as int)
+    ..duration = durationConverter.fromJson(json['duration'] as int)
     ..durationList = (json['durationList'] as List)
-        ?.map((e) => e == null ? null : durationConverter.fromJson(e as int))
+        ?.map((e) => durationConverter.fromJson(e as int))
         ?.toList()
-    ..bigInt = json['bigInt'] == null
-        ? null
-        : const BigIntStringConverter().fromJson(json['bigInt'] as String)
+    ..bigInt = const BigIntStringConverter().fromJson(json['bigInt'] as String)
     ..bigIntMap = (json['bigIntMap'] as Map)?.map(
       (k, e) => MapEntry(
-          k as String,
-          e == null
-              ? null
-              : const BigIntStringConverter().fromJson(e as String)),
+          k as String, const BigIntStringConverter().fromJson(e as String)),
     )
-    ..numberSilly = json['numberSilly'] == null
-        ? null
-        : TrivialNumberConverter.instance.fromJson(json['numberSilly'] as int)
+    ..numberSilly =
+        TrivialNumberConverter.instance.fromJson(json['numberSilly'] as int)
     ..numberSillySet = (json['numberSillySet'] as List)
-        ?.map((e) => e == null
-            ? null
-            : TrivialNumberConverter.instance.fromJson(e as int))
+        ?.map((e) => TrivialNumberConverter.instance.fromJson(e as int))
         ?.toSet()
-    ..dateTime = json['dateTime'] == null
-        ? null
-        : const EpochDateTimeConverter().fromJson(json['dateTime'] as int);
+    ..dateTime =
+        const EpochDateTimeConverter().fromJson(json['dateTime'] as int);
 }
 
 Map<String, dynamic> _$JsonConverterTestClassToJson(
         JsonConverterTestClass instance) =>
     <String, dynamic>{
-      'duration': instance.duration == null
-          ? null
-          : durationConverter.toJson(instance.duration),
-      'durationList': instance.durationList
-          ?.map((e) => e == null ? null : durationConverter.toJson(e))
-          ?.toList(),
-      'bigInt': instance.bigInt == null
-          ? null
-          : const BigIntStringConverter().toJson(instance.bigInt),
-      'bigIntMap': instance.bigIntMap?.map((k, e) => MapEntry(
-          k, e == null ? null : const BigIntStringConverter().toJson(e))),
-      'numberSilly': instance.numberSilly == null
-          ? null
-          : TrivialNumberConverter.instance.toJson(instance.numberSilly),
+      'duration': durationConverter.toJson(instance.duration),
+      'durationList':
+          instance.durationList?.map(durationConverter.toJson)?.toList(),
+      'bigInt': const BigIntStringConverter().toJson(instance.bigInt),
+      'bigIntMap': instance.bigIntMap
+          ?.map((k, e) => MapEntry(k, const BigIntStringConverter().toJson(e))),
+      'numberSilly':
+          TrivialNumberConverter.instance.toJson(instance.numberSilly),
       'numberSillySet': instance.numberSillySet
-          ?.map((e) =>
-              e == null ? null : TrivialNumberConverter.instance.toJson(e))
+          ?.map(TrivialNumberConverter.instance.toJson)
           ?.toList(),
-      'dateTime': instance.dateTime == null
-          ? null
-          : const EpochDateTimeConverter().toJson(instance.dateTime)
+      'dateTime': const EpochDateTimeConverter().toJson(instance.dateTime)
     };
 
 JsonConverterGeneric<S, T, U> _$JsonConverterGenericFromJson<S, T, U>(
     Map json) {
   return JsonConverterGeneric<S, T, U>()
-    ..item = json['item'] == null
-        ? null
-        : GenericConverter<S>().fromJson(json['item'] as Map<String, dynamic>)
+    ..item =
+        GenericConverter<S>().fromJson(json['item'] as Map<String, dynamic>)
     ..itemList = (json['itemList'] as List)
-        ?.map((e) => e == null
-            ? null
-            : GenericConverter<T>().fromJson(e as Map<String, dynamic>))
+        ?.map((e) => GenericConverter<T>().fromJson(e as Map<String, dynamic>))
         ?.toList()
     ..itemMap = (json['itemMap'] as Map)?.map(
-      (k, e) => MapEntry(
-          k as String,
-          e == null
-              ? null
-              : GenericConverter<U>().fromJson(e as Map<String, dynamic>)),
+      (k, e) => MapEntry(k as String,
+          GenericConverter<U>().fromJson(e as Map<String, dynamic>)),
     );
 }
 
 Map<String, dynamic> _$JsonConverterGenericToJson<S, T, U>(
         JsonConverterGeneric<S, T, U> instance) =>
     <String, dynamic>{
-      'item': instance.item == null
-          ? null
-          : GenericConverter<S>().toJson(instance.item),
-      'itemList': instance.itemList
-          ?.map((e) => e == null ? null : GenericConverter<T>().toJson(e))
-          ?.toList(),
-      'itemMap': instance.itemMap?.map((k, e) =>
-          MapEntry(k, e == null ? null : GenericConverter<U>().toJson(e)))
+      'item': GenericConverter<S>().toJson(instance.item),
+      'itemList':
+          instance.itemList?.map(GenericConverter<T>().toJson)?.toList(),
+      'itemMap': instance.itemMap
+          ?.map((k, e) => MapEntry(k, GenericConverter<U>().toJson(e)))
     };

--- a/json_serializable/test/kitchen_sink/kitchen_sink.g_exclude_null.g.dart
+++ b/json_serializable/test/kitchen_sink/kitchen_sink.g_exclude_null.g.dart
@@ -138,33 +138,22 @@ Map<String, dynamic> _$KitchenSinkToJson(KitchenSink instance) {
 JsonConverterTestClass _$JsonConverterTestClassFromJson(
     Map<String, dynamic> json) {
   return JsonConverterTestClass()
-    ..duration = json['duration'] == null
-        ? null
-        : durationConverter.fromJson(json['duration'] as int)
+    ..duration = durationConverter.fromJson(json['duration'] as int)
     ..durationList = (json['durationList'] as List)
-        ?.map((e) => e == null ? null : durationConverter.fromJson(e as int))
+        ?.map((e) => durationConverter.fromJson(e as int))
         ?.toList()
-    ..bigInt = json['bigInt'] == null
-        ? null
-        : const BigIntStringConverter().fromJson(json['bigInt'] as String)
+    ..bigInt = const BigIntStringConverter().fromJson(json['bigInt'] as String)
     ..bigIntMap = (json['bigIntMap'] as Map<String, dynamic>)?.map(
-      (k, e) => MapEntry(
-          k,
-          e == null
-              ? null
-              : const BigIntStringConverter().fromJson(e as String)),
+      (k, e) =>
+          MapEntry(k, const BigIntStringConverter().fromJson(e as String)),
     )
-    ..numberSilly = json['numberSilly'] == null
-        ? null
-        : TrivialNumberConverter.instance.fromJson(json['numberSilly'] as int)
+    ..numberSilly =
+        TrivialNumberConverter.instance.fromJson(json['numberSilly'] as int)
     ..numberSillySet = (json['numberSillySet'] as List)
-        ?.map((e) => e == null
-            ? null
-            : TrivialNumberConverter.instance.fromJson(e as int))
+        ?.map((e) => TrivialNumberConverter.instance.fromJson(e as int))
         ?.toSet()
-    ..dateTime = json['dateTime'] == null
-        ? null
-        : const EpochDateTimeConverter().fromJson(json['dateTime'] as int);
+    ..dateTime =
+        const EpochDateTimeConverter().fromJson(json['dateTime'] as int);
 }
 
 Map<String, dynamic> _$JsonConverterTestClassToJson(
@@ -177,61 +166,37 @@ Map<String, dynamic> _$JsonConverterTestClassToJson(
     }
   }
 
-  writeNotNull(
-      'duration',
-      instance.duration == null
-          ? null
-          : durationConverter.toJson(instance.duration));
-  writeNotNull(
-      'durationList',
-      instance.durationList
-          ?.map((e) => e == null ? null : durationConverter.toJson(e))
-          ?.toList());
-  writeNotNull(
-      'bigInt',
-      instance.bigInt == null
-          ? null
-          : const BigIntStringConverter().toJson(instance.bigInt));
+  writeNotNull('duration', durationConverter.toJson(instance.duration));
+  writeNotNull('durationList',
+      instance.durationList?.map(durationConverter.toJson)?.toList());
+  writeNotNull('bigInt', const BigIntStringConverter().toJson(instance.bigInt));
   writeNotNull(
       'bigIntMap',
-      instance.bigIntMap?.map((k, e) => MapEntry(
-          k, e == null ? null : const BigIntStringConverter().toJson(e))));
-  writeNotNull(
-      'numberSilly',
-      instance.numberSilly == null
-          ? null
-          : TrivialNumberConverter.instance.toJson(instance.numberSilly));
+      instance.bigIntMap?.map(
+          (k, e) => MapEntry(k, const BigIntStringConverter().toJson(e))));
+  writeNotNull('numberSilly',
+      TrivialNumberConverter.instance.toJson(instance.numberSilly));
   writeNotNull(
       'numberSillySet',
       instance.numberSillySet
-          ?.map((e) =>
-              e == null ? null : TrivialNumberConverter.instance.toJson(e))
+          ?.map(TrivialNumberConverter.instance.toJson)
           ?.toList());
   writeNotNull(
-      'dateTime',
-      instance.dateTime == null
-          ? null
-          : const EpochDateTimeConverter().toJson(instance.dateTime));
+      'dateTime', const EpochDateTimeConverter().toJson(instance.dateTime));
   return val;
 }
 
 JsonConverterGeneric<S, T, U> _$JsonConverterGenericFromJson<S, T, U>(
     Map<String, dynamic> json) {
   return JsonConverterGeneric<S, T, U>()
-    ..item = json['item'] == null
-        ? null
-        : GenericConverter<S>().fromJson(json['item'] as Map<String, dynamic>)
+    ..item =
+        GenericConverter<S>().fromJson(json['item'] as Map<String, dynamic>)
     ..itemList = (json['itemList'] as List)
-        ?.map((e) => e == null
-            ? null
-            : GenericConverter<T>().fromJson(e as Map<String, dynamic>))
+        ?.map((e) => GenericConverter<T>().fromJson(e as Map<String, dynamic>))
         ?.toList()
     ..itemMap = (json['itemMap'] as Map<String, dynamic>)?.map(
       (k, e) => MapEntry(
-          k,
-          e == null
-              ? null
-              : GenericConverter<U>().fromJson(e as Map<String, dynamic>)),
+          k, GenericConverter<U>().fromJson(e as Map<String, dynamic>)),
     );
 }
 
@@ -245,19 +210,12 @@ Map<String, dynamic> _$JsonConverterGenericToJson<S, T, U>(
     }
   }
 
-  writeNotNull(
-      'item',
-      instance.item == null
-          ? null
-          : GenericConverter<S>().toJson(instance.item));
-  writeNotNull(
-      'itemList',
-      instance.itemList
-          ?.map((e) => e == null ? null : GenericConverter<T>().toJson(e))
-          ?.toList());
+  writeNotNull('item', GenericConverter<S>().toJson(instance.item));
+  writeNotNull('itemList',
+      instance.itemList?.map(GenericConverter<T>().toJson)?.toList());
   writeNotNull(
       'itemMap',
-      instance.itemMap?.map((k, e) =>
-          MapEntry(k, e == null ? null : GenericConverter<U>().toJson(e))));
+      instance.itemMap
+          ?.map((k, e) => MapEntry(k, GenericConverter<U>().toJson(e))));
   return val;
 }

--- a/json_serializable/test/kitchen_sink/kitchen_sink.g_explicit_to_json.g.dart
+++ b/json_serializable/test/kitchen_sink/kitchen_sink.g_explicit_to_json.g.dart
@@ -126,90 +126,61 @@ Map<String, dynamic> _$KitchenSinkToJson(KitchenSink instance) =>
 JsonConverterTestClass _$JsonConverterTestClassFromJson(
     Map<String, dynamic> json) {
   return JsonConverterTestClass()
-    ..duration = json['duration'] == null
-        ? null
-        : durationConverter.fromJson(json['duration'] as int)
+    ..duration = durationConverter.fromJson(json['duration'] as int)
     ..durationList = (json['durationList'] as List)
-        ?.map((e) => e == null ? null : durationConverter.fromJson(e as int))
+        ?.map((e) => durationConverter.fromJson(e as int))
         ?.toList()
-    ..bigInt = json['bigInt'] == null
-        ? null
-        : const BigIntStringConverter().fromJson(json['bigInt'] as String)
+    ..bigInt = const BigIntStringConverter().fromJson(json['bigInt'] as String)
     ..bigIntMap = (json['bigIntMap'] as Map<String, dynamic>)?.map(
-      (k, e) => MapEntry(
-          k,
-          e == null
-              ? null
-              : const BigIntStringConverter().fromJson(e as String)),
+      (k, e) =>
+          MapEntry(k, const BigIntStringConverter().fromJson(e as String)),
     )
-    ..numberSilly = json['numberSilly'] == null
-        ? null
-        : TrivialNumberConverter.instance.fromJson(json['numberSilly'] as int)
+    ..numberSilly =
+        TrivialNumberConverter.instance.fromJson(json['numberSilly'] as int)
     ..numberSillySet = (json['numberSillySet'] as List)
-        ?.map((e) => e == null
-            ? null
-            : TrivialNumberConverter.instance.fromJson(e as int))
+        ?.map((e) => TrivialNumberConverter.instance.fromJson(e as int))
         ?.toSet()
-    ..dateTime = json['dateTime'] == null
-        ? null
-        : const EpochDateTimeConverter().fromJson(json['dateTime'] as int);
+    ..dateTime =
+        const EpochDateTimeConverter().fromJson(json['dateTime'] as int);
 }
 
 Map<String, dynamic> _$JsonConverterTestClassToJson(
         JsonConverterTestClass instance) =>
     <String, dynamic>{
-      'duration': instance.duration == null
-          ? null
-          : durationConverter.toJson(instance.duration),
-      'durationList': instance.durationList
-          ?.map((e) => e == null ? null : durationConverter.toJson(e))
-          ?.toList(),
-      'bigInt': instance.bigInt == null
-          ? null
-          : const BigIntStringConverter().toJson(instance.bigInt),
-      'bigIntMap': instance.bigIntMap?.map((k, e) => MapEntry(
-          k, e == null ? null : const BigIntStringConverter().toJson(e))),
-      'numberSilly': instance.numberSilly == null
-          ? null
-          : TrivialNumberConverter.instance.toJson(instance.numberSilly),
+      'duration': durationConverter.toJson(instance.duration),
+      'durationList':
+          instance.durationList?.map(durationConverter.toJson)?.toList(),
+      'bigInt': const BigIntStringConverter().toJson(instance.bigInt),
+      'bigIntMap': instance.bigIntMap
+          ?.map((k, e) => MapEntry(k, const BigIntStringConverter().toJson(e))),
+      'numberSilly':
+          TrivialNumberConverter.instance.toJson(instance.numberSilly),
       'numberSillySet': instance.numberSillySet
-          ?.map((e) =>
-              e == null ? null : TrivialNumberConverter.instance.toJson(e))
+          ?.map(TrivialNumberConverter.instance.toJson)
           ?.toList(),
-      'dateTime': instance.dateTime == null
-          ? null
-          : const EpochDateTimeConverter().toJson(instance.dateTime)
+      'dateTime': const EpochDateTimeConverter().toJson(instance.dateTime)
     };
 
 JsonConverterGeneric<S, T, U> _$JsonConverterGenericFromJson<S, T, U>(
     Map<String, dynamic> json) {
   return JsonConverterGeneric<S, T, U>()
-    ..item = json['item'] == null
-        ? null
-        : GenericConverter<S>().fromJson(json['item'] as Map<String, dynamic>)
+    ..item =
+        GenericConverter<S>().fromJson(json['item'] as Map<String, dynamic>)
     ..itemList = (json['itemList'] as List)
-        ?.map((e) => e == null
-            ? null
-            : GenericConverter<T>().fromJson(e as Map<String, dynamic>))
+        ?.map((e) => GenericConverter<T>().fromJson(e as Map<String, dynamic>))
         ?.toList()
     ..itemMap = (json['itemMap'] as Map<String, dynamic>)?.map(
       (k, e) => MapEntry(
-          k,
-          e == null
-              ? null
-              : GenericConverter<U>().fromJson(e as Map<String, dynamic>)),
+          k, GenericConverter<U>().fromJson(e as Map<String, dynamic>)),
     );
 }
 
 Map<String, dynamic> _$JsonConverterGenericToJson<S, T, U>(
         JsonConverterGeneric<S, T, U> instance) =>
     <String, dynamic>{
-      'item': instance.item == null
-          ? null
-          : GenericConverter<S>().toJson(instance.item),
-      'itemList': instance.itemList
-          ?.map((e) => e == null ? null : GenericConverter<T>().toJson(e))
-          ?.toList(),
-      'itemMap': instance.itemMap?.map((k, e) =>
-          MapEntry(k, e == null ? null : GenericConverter<U>().toJson(e)))
+      'item': GenericConverter<S>().toJson(instance.item),
+      'itemList':
+          instance.itemList?.map(GenericConverter<T>().toJson)?.toList(),
+      'itemMap': instance.itemMap
+          ?.map((k, e) => MapEntry(k, GenericConverter<U>().toJson(e)))
     };

--- a/json_serializable/test/src/default_value_input.dart
+++ b/json_serializable/test/src/default_value_input.dart
@@ -99,21 +99,22 @@ class DefaultWithNonNullableClass {
   DefaultWithNonNullableClass();
 }
 
-@ShouldGenerate(r'''
+@ShouldGenerate(
+  r'''
 DefaultWithToJsonClass _$DefaultWithToJsonClassFromJson(
     Map<String, dynamic> json) {
   return DefaultWithToJsonClass()
-    ..fieldDefaultValueToJson = json['fieldDefaultValueToJson'] == null
-        ? null
-        : DefaultWithToJsonClass._fromJson(
-                json['fieldDefaultValueToJson'] as String) ??
-            7;
+    ..fieldDefaultValueToJson = DefaultWithToJsonClass._fromJson(
+            json['fieldDefaultValueToJson'] as String) ??
+        7;
 }
-''', expectedLogItems: [
-  '''
+''',
+  expectedLogItems: [
+    '''
 The field `fieldDefaultValueToJson` has both `defaultValue` and `fromJson` defined which likely won't work for your scenario.
 Instead of using `defaultValue`, set `nullable: false` and handle `null` in the `fromJson` function.'''
-])
+  ],
+)
 @JsonSerializable(createToJson: false)
 class DefaultWithToJsonClass {
   @JsonKey(defaultValue: 7, fromJson: _fromJson)

--- a/json_serializable/test/src/generic_test_input.dart
+++ b/json_serializable/test/src/generic_test_input.dart
@@ -4,36 +4,29 @@
 
 part of '_json_serializable_test_input.dart';
 
-@ShouldGenerate(r'''
+@ShouldGenerate(
+  r'''
 GenericClass<T, S> _$GenericClassFromJson<T extends num, S>(
     Map<String, dynamic> json) {
   return GenericClass<T, S>()
-    ..fieldObject =
-        json['fieldObject'] == null ? null : _dataFromJson(json['fieldObject'])
-    ..fieldDynamic = json['fieldDynamic'] == null
-        ? null
-        : _dataFromJson(json['fieldDynamic'])
-    ..fieldInt =
-        json['fieldInt'] == null ? null : _dataFromJson(json['fieldInt'])
-    ..fieldT = json['fieldT'] == null ? null : _dataFromJson(json['fieldT'])
-    ..fieldS = json['fieldS'] == null ? null : _dataFromJson(json['fieldS']);
+    ..fieldObject = _dataFromJson(json['fieldObject'])
+    ..fieldDynamic = _dataFromJson(json['fieldDynamic'])
+    ..fieldInt = _dataFromJson(json['fieldInt'])
+    ..fieldT = _dataFromJson(json['fieldT'])
+    ..fieldS = _dataFromJson(json['fieldS']);
 }
 
 Map<String, dynamic> _$GenericClassToJson<T extends num, S>(
         GenericClass<T, S> instance) =>
     <String, dynamic>{
-      'fieldObject': instance.fieldObject == null
-          ? null
-          : _dataToJson(instance.fieldObject),
-      'fieldDynamic': instance.fieldDynamic == null
-          ? null
-          : _dataToJson(instance.fieldDynamic),
-      'fieldInt':
-          instance.fieldInt == null ? null : _dataToJson(instance.fieldInt),
-      'fieldT': instance.fieldT == null ? null : _dataToJson(instance.fieldT),
-      'fieldS': instance.fieldS == null ? null : _dataToJson(instance.fieldS)
+      'fieldObject': _dataToJson(instance.fieldObject),
+      'fieldDynamic': _dataToJson(instance.fieldDynamic),
+      'fieldInt': _dataToJson(instance.fieldInt),
+      'fieldT': _dataToJson(instance.fieldT),
+      'fieldS': _dataToJson(instance.fieldS)
     };
-''')
+''',
+)
 @JsonSerializable()
 class GenericClass<T extends num, S> {
   @JsonKey(fromJson: _dataFromJson, toJson: _dataToJson)

--- a/json_serializable/test/src/json_converter_test_input.dart
+++ b/json_serializable/test/src/json_converter_test_input.dart
@@ -9,30 +9,23 @@ part of '_json_serializable_test_input.dart';
 JsonConverterNamedCtor<E> _$JsonConverterNamedCtorFromJson<E>(
     Map<String, dynamic> json) {
   return JsonConverterNamedCtor<E>()
-    ..value = json['value'] == null
-        ? null
-        : const _DurationMillisecondConverter.named()
-            .fromJson(json['value'] as int)
-    ..genericValue = json['genericValue'] == null
-        ? null
-        : _GenericConverter<E>.named().fromJson(json['genericValue'] as int)
-    ..keyAnnotationFirst = json['keyAnnotationFirst'] == null
-        ? null
-        : JsonConverterNamedCtor._fromJson(json['keyAnnotationFirst'] as int);
+    ..value = const _DurationMillisecondConverter.named()
+        .fromJson(json['value'] as int)
+    ..genericValue =
+        _GenericConverter<E>.named().fromJson(json['genericValue'] as int)
+    ..keyAnnotationFirst =
+        JsonConverterNamedCtor._fromJson(json['keyAnnotationFirst'] as int);
 }
 
 Map<String, dynamic> _$JsonConverterNamedCtorToJson<E>(
         JsonConverterNamedCtor<E> instance) =>
     <String, dynamic>{
-      'value': instance.value == null
-          ? null
-          : const _DurationMillisecondConverter.named().toJson(instance.value),
-      'genericValue': instance.genericValue == null
-          ? null
-          : _GenericConverter<E>.named().toJson(instance.genericValue),
-      'keyAnnotationFirst': instance.keyAnnotationFirst == null
-          ? null
-          : JsonConverterNamedCtor._toJson(instance.keyAnnotationFirst)
+      'value':
+          const _DurationMillisecondConverter.named().toJson(instance.value),
+      'genericValue':
+          _GenericConverter<E>.named().toJson(instance.genericValue),
+      'keyAnnotationFirst':
+          JsonConverterNamedCtor._toJson(instance.keyAnnotationFirst)
     };
 ''',
   configurations: ['default'],
@@ -58,39 +51,26 @@ class JsonConverterNamedCtor<E> {
 JsonConvertOnField<E> _$JsonConvertOnFieldFromJson<E>(
     Map<String, dynamic> json) {
   return JsonConvertOnField<E>()
-    ..annotatedField = json['annotatedField'] == null
-        ? null
-        : const _DurationMillisecondConverter()
-            .fromJson(json['annotatedField'] as int)
-    ..annotatedWithNamedCtor = json['annotatedWithNamedCtor'] == null
-        ? null
-        : const _DurationMillisecondConverter.named()
-            .fromJson(json['annotatedWithNamedCtor'] as int)
-    ..classAnnotatedWithField = json['classAnnotatedWithField'] == null
-        ? null
-        : _durationConverter.fromJson(json['classAnnotatedWithField'] as int)
-    ..genericValue = json['genericValue'] == null
-        ? null
-        : _GenericConverter<E>().fromJson(json['genericValue'] as int);
+    ..annotatedField = const _DurationMillisecondConverter()
+        .fromJson(json['annotatedField'] as int)
+    ..annotatedWithNamedCtor = const _DurationMillisecondConverter.named()
+        .fromJson(json['annotatedWithNamedCtor'] as int)
+    ..classAnnotatedWithField =
+        _durationConverter.fromJson(json['classAnnotatedWithField'] as int)
+    ..genericValue =
+        _GenericConverter<E>().fromJson(json['genericValue'] as int);
 }
 
 Map<String, dynamic> _$JsonConvertOnFieldToJson<E>(
         JsonConvertOnField<E> instance) =>
     <String, dynamic>{
-      'annotatedField': instance.annotatedField == null
-          ? null
-          : const _DurationMillisecondConverter()
-              .toJson(instance.annotatedField),
-      'annotatedWithNamedCtor': instance.annotatedWithNamedCtor == null
-          ? null
-          : const _DurationMillisecondConverter.named()
-              .toJson(instance.annotatedWithNamedCtor),
-      'classAnnotatedWithField': instance.classAnnotatedWithField == null
-          ? null
-          : _durationConverter.toJson(instance.classAnnotatedWithField),
-      'genericValue': instance.genericValue == null
-          ? null
-          : _GenericConverter<E>().toJson(instance.genericValue)
+      'annotatedField':
+          const _DurationMillisecondConverter().toJson(instance.annotatedField),
+      'annotatedWithNamedCtor': const _DurationMillisecondConverter.named()
+          .toJson(instance.annotatedWithNamedCtor),
+      'classAnnotatedWithField':
+          _durationConverter.toJson(instance.classAnnotatedWithField),
+      'genericValue': _GenericConverter<E>().toJson(instance.genericValue)
     };
 ''',
   configurations: ['default'],

--- a/json_serializable/test/src/to_from_json_test_input.dart
+++ b/json_serializable/test/src/to_from_json_test_input.dart
@@ -39,17 +39,13 @@ class InvalidFromFunc2Args {
 ValidToFromFuncClassStatic _$ValidToFromFuncClassStaticFromJson(
     Map<String, dynamic> json) {
   return ValidToFromFuncClassStatic()
-    ..field = json['field'] == null
-        ? null
-        : ValidToFromFuncClassStatic._staticFunc(json['field'] as String);
+    ..field = ValidToFromFuncClassStatic._staticFunc(json['field'] as String);
 }
 
 Map<String, dynamic> _$ValidToFromFuncClassStaticToJson(
         ValidToFromFuncClassStatic instance) =>
     <String, dynamic>{
-      'field': instance.field == null
-          ? null
-          : ValidToFromFuncClassStatic._staticFunc(instance.field)
+      'field': ValidToFromFuncClassStatic._staticFunc(instance.field)
     };
 ''',
   configurations: ['default'],
@@ -134,6 +130,11 @@ Map<String, dynamic> _$ToJsonNullableFalseIncludeIfNullFalseToJson(
   return val;
 }
 ''',
+  expectedLogItems: [
+    'The `JsonKey.nullable` value on '
+        '`ToJsonNullableFalseIncludeIfNullFalse.field` will be ignored because '
+        'a custom conversion function is being used.',
+  ],
   configurations: ['default'],
 )
 @JsonSerializable(createFactory: false)
@@ -153,15 +154,9 @@ String _fromDynamicIterable(Iterable input) => null;
 FromDynamicCollection _$FromDynamicCollectionFromJson(
     Map<String, dynamic> json) {
   return FromDynamicCollection()
-    ..mapField = json['mapField'] == null
-        ? null
-        : _fromDynamicMap(json['mapField'] as Map)
-    ..listField = json['listField'] == null
-        ? null
-        : _fromDynamicList(json['listField'] as List)
-    ..iterableField = json['iterableField'] == null
-        ? null
-        : _fromDynamicIterable(json['iterableField'] as List);
+    ..mapField = _fromDynamicMap(json['mapField'] as Map)
+    ..listField = _fromDynamicList(json['listField'] as List)
+    ..iterableField = _fromDynamicIterable(json['iterableField'] as List);
 }
 ''',
   configurations: ['default'],

--- a/json_serializable/test/src/unknown_type_test_input.dart
+++ b/json_serializable/test/src/unknown_type_test_input.dart
@@ -56,15 +56,12 @@ class UnknownFieldTypeToJsonOnly {
 UnknownFieldTypeWithConvert _$UnknownFieldTypeWithConvertFromJson(
     Map<String, dynamic> json) {
   return UnknownFieldTypeWithConvert()
-    ..number = json['number'] == null ? null : _everythingIs42(json['number']);
+    ..number = _everythingIs42(json['number']);
 }
 
 Map<String, dynamic> _$UnknownFieldTypeWithConvertToJson(
         UnknownFieldTypeWithConvert instance) =>
-    <String, dynamic>{
-      'number':
-          instance.number == null ? null : _everythingIs42(instance.number)
-    };
+    <String, dynamic>{'number': _everythingIs42(instance.number)};
 ''',
   configurations: ['default'],
 )


### PR DESCRIPTION
Fixes https://github.com/dart-lang/json_serializable/issues/442

This allows these functions to provide alternative values for `null` – such as an empty collection – which replaces the functionality provided by the removed `encodeEmptyCollection`.