### PR TITLE
FromJson function can used in constructor instead factory

### DIFF
--- a/json_annotation/lib/src/json_serializable.dart
+++ b/json_annotation/lib/src/json_serializable.dart
@@ -62,6 +62,8 @@ class JsonSerializable {
   /// ```
   final bool createFactory;
 
+  final bool createConstructor;
+
   /// If `true` (the default), A top-level function is created that you can
   /// reference from your class.
   ///
@@ -137,6 +139,7 @@ class JsonSerializable {
     this.anyMap,
     this.checked,
     this.createFactory,
+    this.createConstructor,
     this.createToJson,
     this.disallowUnrecognizedKeys,
     this.explicitToJson,
@@ -154,6 +157,7 @@ class JsonSerializable {
     anyMap: false,
     checked: false,
     createFactory: true,
+    createConstructor: false,
     createToJson: true,
     disallowUnrecognizedKeys: false,
     explicitToJson: false,
@@ -171,6 +175,7 @@ class JsonSerializable {
       anyMap: anyMap ?? defaults.anyMap,
       checked: checked ?? defaults.checked,
       createFactory: createFactory ?? defaults.createFactory,
+      createConstructor: createConstructor ?? defaults.createConstructor,
       createToJson: createToJson ?? defaults.createToJson,
       disallowUnrecognizedKeys:
           disallowUnrecognizedKeys ?? defaults.disallowUnrecognizedKeys,

--- a/json_serializable/lib/src/utils.dart
+++ b/json_serializable/lib/src/utils.dart
@@ -74,6 +74,7 @@ JsonSerializable _valueForAnnotation(ConstantReader reader) => JsonSerializable(
       anyMap: reader.read('anyMap').literalValue as bool,
       checked: reader.read('checked').literalValue as bool,
       createFactory: reader.read('createFactory').literalValue as bool,
+      createConstructor: reader.read('createConstructor').literalValue as bool,
       createToJson: reader.read('createToJson').literalValue as bool,
       disallowUnrecognizedKeys:
           reader.read('disallowUnrecognizedKeys').literalValue as bool,
@@ -95,6 +96,7 @@ JsonSerializable mergeConfig(JsonSerializable config, ConstantReader reader) {
     anyMap: annotation.anyMap ?? config.anyMap,
     checked: annotation.checked ?? config.checked,
     createFactory: annotation.createFactory ?? config.createFactory,
+    createConstructor: annotation.createConstructor ?? config.createConstructor,
     createToJson: annotation.createToJson ?? config.createToJson,
     disallowUnrecognizedKeys:
         annotation.disallowUnrecognizedKeys ?? config.disallowUnrecognizedKeys,

--- a/json_serializable/test/shared_config.dart
+++ b/json_serializable/test/shared_config.dart
@@ -15,6 +15,7 @@ final generatorConfigNonDefaultJson =
   anyMap: true,
   checked: true,
   createFactory: false,
+  createConstructor: false,
   createToJson: false,
   disallowUnrecognizedKeys: true,
   explicitToJson: true,

--- a/json_serializable/test/test_sources/test_sources.dart
+++ b/json_serializable/test/test_sources/test_sources.dart
@@ -9,6 +9,7 @@ class ConfigurationImplicitDefaults {
   anyMap: false,
   checked: false,
   createFactory: true,
+  createConstructor: false,
   createToJson: true,
   disallowUnrecognizedKeys: false,
   explicitToJson: false,


### PR DESCRIPTION
This change help use FromJson method in method and constructor;

```
@JsonSerializable(createConstructor: true)
class Example {
  Example();
  Example.fromJson(Map<String, dynamic> json) {
    parseJson(json);
  }

  String id;
  String name;

  void parseJson(Map<String, dynamic> json) {
    _$ExampleFromJson(this, json);
  }
}
```