### PR TITLE
Update min SDK to 2.3, use UI-as-code collection features

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,18 +17,18 @@ jobs:
       env: PKGS="_test_yaml checked_yaml example json_annotation json_serializable"
       script: ./tool/travis.sh dartfmt dartanalyzer_0
     - stage: analyzer_and_format
-      name: "SDK: 2.2.0; PKGS: _test_yaml, checked_yaml, json_serializable; TASKS: `dartanalyzer --fatal-warnings .`"
-      dart: "2.2.0"
+      name: "SDK: 2.3.0; PKGS: _test_yaml, checked_yaml, json_serializable; TASKS: `dartanalyzer --fatal-warnings .`"
+      dart: "2.3.0"
       env: PKGS="_test_yaml checked_yaml json_serializable"
       script: ./tool/travis.sh dartanalyzer_1
     - stage: analyzer_and_format
-      name: "SDK: 2.2.0; PKGS: example, json_annotation; TASKS: [`dartfmt -n --set-exit-if-changed .`, `dartanalyzer --fatal-warnings .`]"
-      dart: "2.2.0"
+      name: "SDK: 2.3.0; PKGS: example, json_annotation; TASKS: [`dartfmt -n --set-exit-if-changed .`, `dartanalyzer --fatal-warnings .`]"
+      dart: "2.3.0"
       env: PKGS="example json_annotation"
       script: ./tool/travis.sh dartfmt dartanalyzer_1
     - stage: unit_test
-      name: "SDK: 2.2.0; PKGS: _test_yaml, checked_yaml, example, json_serializable; TASKS: `pub run test`"
-      dart: "2.2.0"
+      name: "SDK: 2.3.0; PKGS: _test_yaml, checked_yaml, example, json_serializable; TASKS: `pub run test`"
+      dart: "2.3.0"
       env: PKGS="_test_yaml checked_yaml example json_serializable"
       script: ./tool/travis.sh test_0
     - stage: unit_test
@@ -37,8 +37,8 @@ jobs:
       env: PKGS="_test_yaml checked_yaml example json_serializable"
       script: ./tool/travis.sh test_0
     - stage: unit_test
-      name: "SDK: 2.2.0; PKG: json_serializable; TASKS: `pub run build_runner test --delete-conflicting-outputs -- -p chrome`"
-      dart: "2.2.0"
+      name: "SDK: 2.3.0; PKG: json_serializable; TASKS: `pub run build_runner test --delete-conflicting-outputs -- -p chrome`"
+      dart: "2.3.0"
       env: PKGS="json_serializable"
       script: ./tool/travis.sh command
     - stage: unit_test
@@ -47,8 +47,8 @@ jobs:
       env: PKGS="json_serializable"
       script: ./tool/travis.sh command
     - stage: ensure_build
-      name: "SDK: 2.2.0; PKGS: _test_yaml, checked_yaml, example, json_serializable; TASKS: `pub run test --run-skipped -t presubmit-only test/ensure_build_test.dart`"
-      dart: "2.2.0"
+      name: "SDK: 2.3.0; PKGS: _test_yaml, checked_yaml, example, json_serializable; TASKS: `pub run test --run-skipped -t presubmit-only test/ensure_build_test.dart`"
+      dart: "2.3.0"
       env: PKGS="_test_yaml checked_yaml example json_serializable"
       script: ./tool/travis.sh test_1
     - stage: ensure_build

--- a/_test_yaml/mono_pkg.yaml
+++ b/_test_yaml/mono_pkg.yaml
@@ -1,6 +1,6 @@
 # See https://github.com/dart-lang/mono_repo for details
 dart:
-- 2.2.0
+- 2.3.0
 - dev
 
 stages:
@@ -11,7 +11,7 @@ stages:
     dart: [dev]
   - group:
     - dartanalyzer: --fatal-warnings .
-    dart: [2.2.0]
+    dart: [2.3.0]
 - unit_test:
   - test
 - ensure_build:

--- a/_test_yaml/pubspec.yaml
+++ b/_test_yaml/pubspec.yaml
@@ -2,7 +2,7 @@ name: _test_yaml
 publish_to: none
 
 environment:
-  sdk: '>=2.2.0 <3.0.0'
+  sdk: '>=2.3.0 <3.0.0'
 
 dev_dependencies:
   build_runner: ^1.0.0

--- a/checked_yaml/changelog.md
+++ b/checked_yaml/changelog.md
@@ -1,3 +1,7 @@
+## 1.0.2
+
+- Require at least Dart `2.3.0`.
+
 ## 1.0.1
 
 - Fix readme.

--- a/checked_yaml/mono_pkg.yaml
+++ b/checked_yaml/mono_pkg.yaml
@@ -1,6 +1,6 @@
 # See https://github.com/dart-lang/mono_repo for details
 dart:
-- 2.2.0
+- 2.3.0
 - dev
 
 stages:
@@ -11,7 +11,7 @@ stages:
     dart: [dev]
   - group:
     - dartanalyzer: --fatal-warnings .
-    dart: [2.2.0]
+    dart: [2.3.0]
 
 - unit_test:
   - test

--- a/checked_yaml/pubspec.yaml
+++ b/checked_yaml/pubspec.yaml
@@ -6,7 +6,7 @@ description: >-
   package:json_serializable and package:yaml.
 homepage: https://github.com/dart-lang/json_serializable
 environment:
-  sdk: '>=2.2.0 <3.0.0'
+  sdk: '>=2.3.0 <3.0.0'
 
 dependencies:
   json_annotation: ^2.2.0

--- a/example/mono_pkg.yaml
+++ b/example/mono_pkg.yaml
@@ -1,6 +1,6 @@
 # See https://github.com/dart-lang/mono_repo for details
 dart:
-- 2.2.0
+- 2.3.0
 - dev
 
 stages:
@@ -12,7 +12,7 @@ stages:
   - group:
     - dartfmt
     - dartanalyzer: --fatal-warnings .
-    dart: [2.2.0]
+    dart: [2.3.0]
 - unit_test:
   - test
 - ensure_build:

--- a/example/pubspec.yaml
+++ b/example/pubspec.yaml
@@ -2,7 +2,7 @@ name: example
 author: Dart Team <misc@dartlang.org>
 
 environment:
-  sdk: '>=2.2.0 <3.0.0'
+  sdk: '>=2.3.0 <3.0.0'
 
 dependencies:
   json_annotation: ^2.4.0

--- a/json_annotation/CHANGELOG.md
+++ b/json_annotation/CHANGELOG.md
@@ -7,6 +7,7 @@
   `JsonKey`.
 - Added `JsonSerializable.ignoreUnannotated`.
 - Added `JsonKey.unknownEnumValue`.
+- Require at least Dart `2.3.0`.
 
 ## 2.4.0
 

--- a/json_annotation/lib/src/checked_helpers.dart
+++ b/json_annotation/lib/src/checked_helpers.dart
@@ -121,20 +121,11 @@ class CheckedFromJsonException implements Exception {
   }
 
   @override
-  String toString() {
-    final lines = <String>['CheckedFromJsonException'];
-
-    if (_className != null) {
-      lines.add('Could not create `$_className`.');
-    }
-    if (key != null) {
-      lines.add('There is a problem with "$key".');
-    }
-    if (message != null) {
-      lines.add(message);
-    } else if (innerError != null) {
-      lines.add(innerError.toString());
-    }
-    return lines.join('\n');
-  }
+  String toString() => <String>[
+        'CheckedFromJsonException',
+        if (_className != null) 'Could not create `$_className`.',
+        if (key != null) 'There is a problem with "$key".',
+        if (message != null) message,
+        if (message == null && innerError != null) innerError.toString(),
+      ].join('\n');
 }

--- a/json_annotation/mono_pkg.yaml
+++ b/json_annotation/mono_pkg.yaml
@@ -8,4 +8,4 @@ stages:
   - group:
     - dartfmt
     - dartanalyzer: --fatal-warnings .
-    dart: [2.2.0]
+    dart: [2.3.0]

--- a/json_annotation/pubspec.yaml
+++ b/json_annotation/pubspec.yaml
@@ -6,7 +6,7 @@ description: >-
 homepage: https://github.com/dart-lang/json_serializable
 author: Dart Team <misc@dartlang.org>
 environment:
-  sdk: '>=2.2.0 <3.0.0'
+  sdk: '>=2.3.0 <3.0.0'
 
 # When changing JsonSerializable class.
 # dev_dependencies:

--- a/json_serializable/CHANGELOG.md
+++ b/json_serializable/CHANGELOG.md
@@ -4,6 +4,7 @@
 - Added support for `JsonSerializable.ignoreUnannotated`.
 - Added support for `JsonKey.unknownEnumValue`.
 - Small change to how `enum` support code is generated.
+- Require at least Dart `2.3.0`.
 
 ## 3.1.0
 

--- a/json_serializable/lib/src/json_key_utils.dart
+++ b/json_serializable/lib/src/json_key_utils.dart
@@ -82,13 +82,24 @@ JsonKey _from(FieldElement element, JsonSerializable classAnnotation) {
     if (literal is num || literal is String || literal is bool) {
       return literal;
     } else if (literal is List<DartObject>) {
-      return literal
-          .map((e) => literalForObject(e, typeInformation.followedBy(['List'])))
-          .toList();
+      return [
+        for (var e in literal)
+          literalForObject(e, [
+            ...typeInformation,
+            'List',
+          ])
+      ];
     } else if (literal is Map<DartObject, DartObject>) {
-      final mapThings = typeInformation.followedBy(['Map']);
-      return literal.map((k, v) => MapEntry(
-          literalForObject(k, mapThings), literalForObject(v, mapThings)));
+      final mapTypeInformation = [
+        ...typeInformation,
+        'Map',
+      ];
+      return literal.map(
+        (k, v) => MapEntry(
+          literalForObject(k, mapTypeInformation),
+          literalForObject(v, mapTypeInformation),
+        ),
+      );
     }
 
     badType = typeInformation.followedBy(['$dartObject']).join(' > ');

--- a/json_serializable/lib/src/type_helpers/enum_helper.dart
+++ b/json_serializable/lib/src/type_helpers/enum_helper.dart
@@ -54,16 +54,13 @@ class EnumHelper extends TypeHelper<TypeHelperContextWithConfig> {
     final functionName =
         context.nullable ? r'_$enumDecodeNullable' : r'_$enumDecode';
 
+    final jsonKey = jsonKeyForField(context.fieldElement, context.config);
     final args = [
       _constMapName(targetType),
       expression,
+      if (jsonKey.unknownEnumValue != null)
+        'unknownValue: ${jsonKey.unknownEnumValue}',
     ];
-
-    final jsonKey = jsonKeyForField(context.fieldElement, context.config);
-    // TODO(kevmoo): use collection expressions once min-SDK is >= 2.3.0
-    if (jsonKey.unknownEnumValue != null) {
-      args.add('unknownValue: ${jsonKey.unknownEnumValue}');
-    }
 
     return '$functionName(${args.join(', ')})';
   }

--- a/json_serializable/mono_pkg.yaml
+++ b/json_serializable/mono_pkg.yaml
@@ -1,6 +1,6 @@
 # See https://github.com/dart-lang/mono_repo for details
 dart:
-- 2.2.0
+- 2.3.0
 - dev
 
 stages:
@@ -11,7 +11,7 @@ stages:
     dart: [dev]
   - group:
     - dartanalyzer: --fatal-warnings .
-    dart: [2.2.0]
+    dart: [2.3.0]
 - unit_test:
   - test
   - command: pub run build_runner test --delete-conflicting-outputs -- -p chrome

--- a/json_serializable/pubspec.yaml
+++ b/json_serializable/pubspec.yaml
@@ -6,7 +6,7 @@ description: >-
   Dart classes.
 homepage: https://github.com/dart-lang/json_serializable
 environment:
-  sdk: '>=2.2.0 <3.0.0'
+  sdk: '>=2.3.0 <3.0.0'
 
 dependencies:
   analyzer: '>=0.33.3 <0.38.0'

--- a/json_serializable/tool/doc_builder.dart
+++ b/json_serializable/tool/doc_builder.dart
@@ -50,20 +50,18 @@ class _DocBuilder extends Builder {
 
     final buffer = StringBuffer();
 
-    final rows = <List<String>>[];
-
-    rows.add(['`build.yaml` key', _jsonSerializable, _jsonKey]);
-    rows.add(['-', '-', '-']);
-
     final sortedValues = descriptionMap.values.toList()..sort();
 
-    for (var info in sortedValues) {
-      rows.add([
-        info.buildKey,
-        info.classAnnotationName,
-        info.fieldAnnotationName,
-      ]);
-    }
+    final rows = <List<String>>[
+      ['`build.yaml` key', _jsonSerializable, _jsonKey],
+      ['-', '-', '-'],
+      for (var info in sortedValues)
+        [
+          info.buildKey,
+          info.classAnnotationName,
+          info.fieldAnnotationName,
+        ],
+    ];
 
     final longest = List<int>.generate(rows.first.length, (_) => 0);
     for (var row in rows) {

--- a/json_serializable/tool/test_builder.dart
+++ b/json_serializable/tool/test_builder.dart
@@ -93,12 +93,12 @@ class _SmartBuilder implements Builder {
     if (baseName == _kitchenSinkBaseName) {
       final newId = buildStep.inputId.changeExtension('.factories.dart');
 
-      final lines = <String>[]..addAll(
-          factories.entries.map((e) => "import '${e.key}' as ${e.value};"));
-
-      lines.add('const factories = [');
-      lines.addAll(factories.values.map((e) => '$e.factory,'));
-      lines.add('];');
+      final lines = <String>[
+        ...factories.entries.map((e) => "import '${e.key}' as ${e.value};"),
+        'const factories = [',
+        ...factories.values.map((e) => '$e.factory,'),
+        '];',
+      ];
 
       await buildStep.writeAsString(newId, _formatter.format(lines.join('\n')));
     }


### PR DESCRIPTION
Updated all packages to `>=2.3.0` so we could keep merging tests across all of them.
Used ui-as-code features where it made sense.
Updated Travis testing accordingly