### PR TITLE
Ignore deprecated pkg:analyzer API usage

### DIFF
--- a/json_serializable/lib/src/type_helper_ctx.dart
+++ b/json_serializable/lib/src/type_helper_ctx.dart
@@ -127,7 +127,10 @@ ConvertData _convertData(DartObject obj, FieldElement element, bool isFrom) {
       // We keep things simple in this case. We rely on inferred type arguments
       // to the `fromJson` function.
       // TODO: consider adding error checking here if there is confusion.
-    } else if (!returnType.isAssignableTo(element.type)) {
+    } else if
+        // TODO: dart-lang/json_serializable#531 - fix deprecated API usage
+        // ignore: deprecated_member_use
+        (!returnType.isAssignableTo(element.type)) {
       throwUnsupported(
           element,
           'The `$paramName` function `${executableElement.name}` return type '
@@ -138,7 +141,10 @@ ConvertData _convertData(DartObject obj, FieldElement element, bool isFrom) {
       // We keep things simple in this case. We rely on inferred type arguments
       // to the `fromJson` function.
       // TODO: consider adding error checking here if there is confusion.
-    } else if (!element.type.isAssignableTo(argType)) {
+    } else if
+        // TODO: dart-lang/json_serializable#531 - fix deprecated API usage
+        // ignore: deprecated_member_use
+        (!element.type.isAssignableTo(argType)) {
       throwUnsupported(
           element,
           'The `$paramName` function `${executableElement.name}` argument type '

--- a/json_serializable/lib/src/type_helpers/convert_helper.dart
+++ b/json_serializable/lib/src/type_helpers/convert_helper.dart
@@ -37,6 +37,8 @@ class ConvertHelper extends TypeHelper<TypeHelperContextWithConvert> {
     logFieldWithConversionFunction(context.fieldElement);
 
     assert(toJsonData.paramType is TypeParameterType ||
+        // TODO: dart-lang/json_serializable#531 - fix deprecated API usage
+        // ignore: deprecated_member_use
         targetType.isAssignableTo(toJsonData.paramType));
     return '${toJsonData.name}($expression)';
   }

--- a/json_serializable/lib/src/type_helpers/json_converter_helper.dart
+++ b/json_serializable/lib/src/type_helpers/json_converter_helper.dart
@@ -156,6 +156,8 @@ _ConverterMatch _compatibleMatch(
 
   final fieldType = jsonConverterSuper.typeArguments[0];
 
+  // TODO: dart-lang/json_serializable#531 - fix deprecated API usage
+  // ignore: deprecated_member_use
   if (fieldType.isEquivalentTo(targetType)) {
     return _ConverterMatch(
         annotation, constantValue, jsonConverterSuper.typeArguments[1], null);


### PR DESCRIPTION
Follow-up issue: https://github.com/dart-lang/json_serializable/issues/531