### PR TITLE
support latest pkg:analyzer, prepare to release 3.2.1

### DIFF
--- a/json_serializable/CHANGELOG.md
+++ b/json_serializable/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 3.2.1
+
+* Support `package:analyzer` `>=0.33.3 <0.39.0`
+
 ## 3.2.0
 
 - Require `package:json_annotation` `^3.0.0`.

--- a/json_serializable/lib/src/field_helpers.dart
+++ b/json_serializable/lib/src/field_helpers.dart
@@ -37,7 +37,10 @@ class _FieldSet implements Comparable<_FieldSet> {
   int compareTo(_FieldSet other) => _sortByLocation(sortField, other.sortField);
 
   static int _sortByLocation(FieldElement a, FieldElement b) {
-    final checkerA = TypeChecker.fromStatic(a.enclosingElement.type);
+    final checkerA = TypeChecker.fromStatic(
+        // TODO: remove `ignore` when min pkg:analyzer >= 0.38.0
+        // ignore: unnecessary_cast
+        (a.enclosingElement as ClassElement).type);
 
     if (!checkerA.isExactly(b.enclosingElement)) {
       // in this case, you want to prioritize the enclosingElement that is more
@@ -47,7 +50,10 @@ class _FieldSet implements Comparable<_FieldSet> {
         return -1;
       }
 
-      final checkerB = TypeChecker.fromStatic(b.enclosingElement.type);
+      final checkerB = TypeChecker.fromStatic(
+          // TODO: remove `ignore` when min pkg:analyzer >= 0.38.0
+          // ignore: unnecessary_cast
+          (b.enclosingElement as ClassElement).type);
 
       if (checkerB.isAssignableFrom(a.enclosingElement)) {
         return 1;

--- a/json_serializable/pubspec.yaml
+++ b/json_serializable/pubspec.yaml
@@ -1,5 +1,5 @@
 name: json_serializable
-version: 3.2.0
+version: 3.2.1
 author: Dart Team <misc@dartlang.org>
 description: >-
   Automatically generate code for converting to and from JSON by annotating
@@ -9,7 +9,7 @@ environment:
   sdk: '>=2.3.0 <3.0.0'
 
 dependencies:
-  analyzer: '>=0.33.3 <0.38.0'
+  analyzer: '>=0.33.3 <0.39.0'
   build: '>=0.12.6 <2.0.0'
   build_config: '>=0.2.6 <0.5.0'
 


### PR DESCRIPTION
Note: doing a cast because `enclosingElement` is now `Element` as of
pkg:analyzer v0.38.0