### PR TITLE
Support JsonConverter annotations on property getters

### DIFF
--- a/json_serializable/CHANGELOG.md
+++ b/json_serializable/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 3.2.2
+
+* Support `JsonConverter` annotations on property getters
+
 ## 3.2.1
 
 * Support `package:analyzer` `>=0.33.3 <0.39.0`

--- a/json_serializable/lib/src/type_helpers/json_converter_helper.dart
+++ b/json_serializable/lib/src/type_helpers/json_converter_helper.dart
@@ -76,7 +76,11 @@ _JsonConvertData _typeConverter(DartType targetType, TypeHelperContext ctx) {
   var matchingAnnotations = converterMatches(ctx.fieldElement.metadata);
 
   if (matchingAnnotations.isEmpty) {
-    matchingAnnotations = converterMatches(ctx.classElement.metadata);
+    matchingAnnotations = converterMatches(ctx.fieldElement.getter?.metadata ?? []);
+
+    if (matchingAnnotations.isEmpty) {
+      matchingAnnotations = converterMatches(ctx.classElement.metadata);
+    }
   }
 
   return _typeConverterFrom(matchingAnnotations, targetType);

--- a/json_serializable/lib/src/type_helpers/json_converter_helper.dart
+++ b/json_serializable/lib/src/type_helpers/json_converter_helper.dart
@@ -76,7 +76,8 @@ _JsonConvertData _typeConverter(DartType targetType, TypeHelperContext ctx) {
   var matchingAnnotations = converterMatches(ctx.fieldElement.metadata);
 
   if (matchingAnnotations.isEmpty) {
-    matchingAnnotations = converterMatches(ctx.fieldElement.getter?.metadata ?? []);
+    matchingAnnotations =
+        converterMatches(ctx.fieldElement.getter?.metadata ?? []);
 
     if (matchingAnnotations.isEmpty) {
       matchingAnnotations = converterMatches(ctx.classElement.metadata);

--- a/json_serializable/pubspec.yaml
+++ b/json_serializable/pubspec.yaml
@@ -1,5 +1,5 @@
 name: json_serializable
-version: 3.2.1
+version: 3.2.2
 author: Dart Team <misc@dartlang.org>
 description: >-
   Automatically generate code for converting to and from JSON by annotating

--- a/json_serializable/test/json_serializable_test.dart
+++ b/json_serializable/test/json_serializable_test.dart
@@ -61,6 +61,7 @@ const _expectedAnnotatedTests = [
   'JsonConverterCtorParams',
   'JsonConverterDuplicateAnnotations',
   'JsonConverterNamedCtor',
+  'JsonConverterOnGetter',
   'JsonConverterWithBadTypeArg',
   'JsonConvertOnField',
   'JsonValueValid',

--- a/json_serializable/test/src/json_converter_test_input.dart
+++ b/json_serializable/test/src/json_converter_test_input.dart
@@ -164,3 +164,30 @@ class _ConverterWithCtorParams implements JsonConverter<Duration, int> {
   @override
   int toJson(Duration object) => 0;
 }
+
+@ShouldGenerate(r'''
+Map<String, dynamic> _$JsonConverterOnGetterToJson(
+        JsonConverterOnGetter instance) =>
+    <String, dynamic>{
+      'annotatedGetter':
+          const _NeedsConversionConverter().toJson(instance.annotatedGetter),
+    };
+''')
+@JsonSerializable(createFactory: false)
+class JsonConverterOnGetter {
+  @JsonKey()
+  @_NeedsConversionConverter()
+  _NeedsConversion get annotatedGetter => _NeedsConversion();
+}
+
+class _NeedsConversion {}
+
+class _NeedsConversionConverter implements JsonConverter<_NeedsConversion, int> {
+  const _NeedsConversionConverter();
+
+  @override
+  _NeedsConversion fromJson(int json) => _NeedsConversion();
+
+  @override
+  int toJson(_NeedsConversion object) => 0;
+}

--- a/json_serializable/test/src/json_converter_test_input.dart
+++ b/json_serializable/test/src/json_converter_test_input.dart
@@ -182,7 +182,8 @@ class JsonConverterOnGetter {
 
 class _NeedsConversion {}
 
-class _NeedsConversionConverter implements JsonConverter<_NeedsConversion, int> {
+class _NeedsConversionConverter
+    implements JsonConverter<_NeedsConversion, int> {
   const _NeedsConversionConverter();
 
   @override


### PR DESCRIPTION
This fixes a bug whereby the following code:

```dart
@JsonSerializable(createFactory: false)
class JsonConverterOnGetter {
  @JsonKey()
  @NeedsConversionConverter()
  NeedsConversion get annotatedGetter => NeedsConversion();
}
```

would yield the following error:

```
  Could not generate `toJson` code for `annotatedGetter`.
  None of the provided `TypeHelper` instances support the defined type.
  package:<file>:<line>:<column>
      ╷
  ... │   NeedsConversion get annotatedGetter => NeedsConversion();
      │                       ^^^^^^^^^^^^^^^
      ╵
```