### PR TITLE
Don't use DartType.toString() to build Dart code for types.

### DIFF
--- a/json_serializable/lib/src/helper_core.dart
+++ b/json_serializable/lib/src/helper_core.dart
@@ -110,7 +110,9 @@ String genericClassArguments(ClassElement element, bool withConstraints) {
 /// only [InterfaceType]s, with optional type arguments that are also should
 /// be [InterfaceType]s.
 String typeToCode(DartType type) {
-  if (type is InterfaceType) {
+  if (type.isDynamic) {
+    return 'dynamic';
+  } else if (type is InterfaceType) {
     final typeArguments = type.typeArguments;
     if (typeArguments.isEmpty) {
       return type.element.name;

--- a/json_serializable/lib/src/shared_checkers.dart
+++ b/json_serializable/lib/src/shared_checkers.dart
@@ -5,6 +5,8 @@
 import 'package:analyzer/dart/element/type.dart';
 import 'package:source_gen/source_gen.dart' show TypeChecker;
 
+import 'helper_core.dart';
+
 /// A [TypeChecker] for [Iterable].
 const coreIterableTypeChecker = TypeChecker.fromUrl('dart:core#Iterable');
 
@@ -56,7 +58,8 @@ String asStatement(DartType type) {
     }
   }
 
-  return ' as $type';
+  final typeCode = typeToCode(type);
+  return ' as $typeCode';
 }
 
 /// Returns all of the [DartType] types that [type] implements, mixes-in, and

--- a/json_serializable/lib/src/type_helper_ctx.dart
+++ b/json_serializable/lib/src/type_helper_ctx.dart
@@ -129,10 +129,13 @@ ConvertData _convertData(DartObject obj, FieldElement element, bool isFrom) {
         // TODO: dart-lang/json_serializable#531 - fix deprecated API usage
         // ignore: deprecated_member_use
         (!returnType.isAssignableTo(element.type)) {
+      final returnTypeCode = typeToCode(returnType);
+      final elementTypeCode = typeToCode(element.type);
       throwUnsupported(
           element,
           'The `$paramName` function `${executableElement.name}` return type '
-          '`$returnType` is not compatible with field type `${element.type}`.');
+          '`$returnTypeCode` is not compatible with field type '
+          '`$elementTypeCode`.');
     }
   } else {
     if (argType is TypeParameterType) {
@@ -143,11 +146,13 @@ ConvertData _convertData(DartObject obj, FieldElement element, bool isFrom) {
         // TODO: dart-lang/json_serializable#531 - fix deprecated API usage
         // ignore: deprecated_member_use
         (!element.type.isAssignableTo(argType)) {
+      final argTypeCode = typeToCode(argType);
+      final elementTypeCode = typeToCode(element.type);
       throwUnsupported(
           element,
           'The `$paramName` function `${executableElement.name}` argument type '
-          '`$argType` is not compatible with field type'
-          ' `${element.type}`.');
+          '`$argTypeCode` is not compatible with field type'
+          ' `$elementTypeCode`.');
     }
   }
 

--- a/json_serializable/lib/src/type_helpers/json_converter_helper.dart
+++ b/json_serializable/lib/src/type_helpers/json_converter_helper.dart
@@ -8,6 +8,7 @@ import 'package:analyzer/dart/element/type.dart';
 import 'package:json_annotation/json_annotation.dart';
 import 'package:source_gen/source_gen.dart';
 
+import '../helper_core.dart';
 import '../json_key_utils.dart';
 import '../lambda_result.dart';
 import '../shared_checkers.dart';
@@ -94,8 +95,9 @@ _JsonConvertData _typeConverterFrom(
   }
 
   if (matchingAnnotations.length > 1) {
+    final targetTypeCode = typeToCode(targetType);
     throw InvalidGenerationSourceError(
-        'Found more than one matching converter for `$targetType`.',
+        'Found more than one matching converter for `$targetTypeCode`.',
         element: matchingAnnotations[1].elementAnnotation.element);
   }
 

--- a/json_serializable/lib/src/type_helpers/value_helper.dart
+++ b/json_serializable/lib/src/type_helpers/value_helper.dart
@@ -5,6 +5,7 @@
 import 'package:analyzer/dart/element/type.dart';
 import 'package:source_gen/source_gen.dart' show TypeChecker;
 
+import '../helper_core.dart';
 import '../shared_checkers.dart';
 import '../type_helper.dart';
 
@@ -33,7 +34,8 @@ class ValueHelper extends TypeHelper {
         .isExactlyType(targetType)) {
       return '($expression as num)${context.nullable ? '?' : ''}.toDouble()';
     } else if (simpleJsonTypeChecker.isAssignableFromType(targetType)) {
-      return '$expression as $targetType';
+      final typeCode = typeToCode(targetType);
+      return '$expression as $typeCode';
     }
 
     return null;

--- a/json_serializable/lib/src/utils.dart
+++ b/json_serializable/lib/src/utils.dart
@@ -9,6 +9,8 @@ import 'package:json_annotation/json_annotation.dart';
 import 'package:meta/meta.dart' show alwaysThrows;
 import 'package:source_gen/source_gen.dart';
 
+import 'helper_core.dart';
+
 final _jsonKeyChecker = const TypeChecker.fromRuntime(JsonKey);
 
 DartObject jsonKeyAnnotation(FieldElement element) =>
@@ -137,8 +139,9 @@ Map<FieldElement, dynamic> enumFieldsMap(DartType targetType) {
       if (valueReader.isString || valueReader.isNull || valueReader.isInt) {
         fieldValue = valueReader.literalValue;
       } else {
+        final targetTypeCode = typeToCode(targetType);
         throw InvalidGenerationSourceError(
-            'The `JsonValue` annotation on `$targetType.${fe.name}` does '
+            'The `JsonValue` annotation on `$targetTypeCode.${fe.name}` does '
             'not have a value of type String, int, or null.',
             element: fe);
       }


### PR DESCRIPTION
We would like to change `DartType.toString()` to include nullability suffixes.
It has never been a really good idea to use `toString()` as a way to generate valid Dart code.
So, I'm replacing it with a custom-made `typeToCode` in this package.

This PR has enough changes to pass all tests with these future `analyzer` changes.