### PR TITLE
Refactor return of boolean literals

### DIFF
--- a/json_serializable/lib/src/encoder_helper.dart
+++ b/json_serializable/lib/src/encoder_helper.dart
@@ -121,16 +121,8 @@ abstract class EncodeHelper implements HelperCore {
   /// we can avoid checking for `null`.
   bool _writeJsonValueNaive(FieldElement field) {
     final jsonKey = jsonKeyFor(field);
-
-    if (jsonKey.includeIfNull) {
-      return true;
-    }
-
-    if (!jsonKey.nullable && !_fieldHasCustomEncoder(field)) {
-      return true;
-    }
-
-    return false;
+    return jsonKey.includeIfNull ||
+        (!jsonKey.nullable && !_fieldHasCustomEncoder(field));
   }
 
   /// Returns `true` if [field] has a user-defined encoder.
@@ -139,17 +131,9 @@ abstract class EncodeHelper implements HelperCore {
   /// annotation.
   bool _fieldHasCustomEncoder(FieldElement field) {
     final helperContext = getHelperContext(field);
-
-    if (helperContext.serializeConvertData != null) {
-      return true;
-    }
-
-    final output = const JsonConverterHelper()
-        .serialize(field.type, 'test', helperContext);
-
-    if (output != null) {
-      return true;
-    }
-    return false;
+    return helperContext.serializeConvertData != null ||
+        const JsonConverterHelper()
+                .serialize(field.type, 'test', helperContext) !=
+            null;
   }
 }

--- a/json_serializable/pubspec.yaml
+++ b/json_serializable/pubspec.yaml
@@ -1,5 +1,5 @@
 name: json_serializable
-version: 3.2.3
+version: 3.2.4-dev
 author: Dart Team <misc@dartlang.org>
 description: >-
   Automatically generate code for converting to and from JSON by annotating


### PR DESCRIPTION
For simple conditions without side effects `return condition` is more
straightforward than `if (condition) {return true;} return false;`