### PR TITLE
Upgrade to analyzer 0.39.x

### DIFF
--- a/json_serializable/CHANGELOG.md
+++ b/json_serializable/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 3.2.4-dev
+
+* Support `package:analyzer` version `0.39.x`.
+
 ## 3.2.3
 
 * Bug fix for analyzer 0.38.5.

--- a/json_serializable/lib/src/helper_core.dart
+++ b/json_serializable/lib/src/helper_core.dart
@@ -4,6 +4,8 @@
 
 import 'package:analyzer/dart/element/element.dart';
 import 'package:analyzer/dart/element/type.dart';
+// ignore: implementation_imports
+import 'package:analyzer/src/generated/type_system.dart';
 import 'package:json_annotation/json_annotation.dart';
 import 'package:meta/meta.dart';
 import 'package:source_gen/source_gen.dart';
@@ -17,8 +19,9 @@ import 'utils.dart';
 abstract class HelperCore {
   final ClassElement element;
   final JsonSerializable config;
+  final TypeSystem typeSystem;
 
-  HelperCore(this.element, this.config);
+  HelperCore(this.element, this.config, this.typeSystem);
 
   Iterable<TypeHelper> get allTypeHelpers;
 

--- a/json_serializable/lib/src/type_helpers/convert_helper.dart
+++ b/json_serializable/lib/src/type_helpers/convert_helper.dart
@@ -36,10 +36,6 @@ class ConvertHelper extends TypeHelper<TypeHelperContextWithConvert> {
 
     logFieldWithConversionFunction(context.fieldElement);
 
-    assert(toJsonData.paramType is TypeParameterType ||
-        // TODO: dart-lang/json_serializable#531 - fix deprecated API usage
-        // ignore: deprecated_member_use
-        targetType.isAssignableTo(toJsonData.paramType));
     return '${toJsonData.name}($expression)';
   }
 

--- a/json_serializable/lib/src/type_helpers/json_converter_helper.dart
+++ b/json_serializable/lib/src/type_helpers/json_converter_helper.dart
@@ -165,10 +165,11 @@ _ConverterMatch _compatibleMatch(
 
   // TODO: dart-lang/json_serializable#531 - fix deprecated API usage
   // ignore: deprecated_member_use
-  if (fieldType.isEquivalentTo(targetType)) {
-    return _ConverterMatch(
-        annotation, constantValue, jsonConverterSuper.typeArguments[1], null);
-  }
+  // TODO: Is there a replacement? What does this break?
+  //if (fieldType.isEquivalentTo(targetType)) {
+  //  return _ConverterMatch(
+  //      annotation, constantValue, jsonConverterSuper.typeArguments[1], null);
+  //}
 
   if (fieldType is TypeParameterType && targetType is TypeParameterType) {
     assert(annotation.element is! PropertyAccessorElement);

--- a/json_serializable/pubspec.yaml
+++ b/json_serializable/pubspec.yaml
@@ -1,5 +1,5 @@
 name: json_serializable
-version: 3.2.3
+version: 3.2.4-dev
 author: Dart Team <misc@dartlang.org>
 description: >-
   Automatically generate code for converting to and from JSON by annotating
@@ -9,7 +9,7 @@ environment:
   sdk: '>=2.3.0 <3.0.0'
 
 dependencies:
-  analyzer: '>=0.37.1 <0.39.0'
+  analyzer: ^0.39.0
   build: '>=0.12.6 <2.0.0'
   build_config: '>=0.2.6 <0.5.0'
 
@@ -33,3 +33,11 @@ dev_dependencies:
   source_gen_test: ^0.1.0
   test: ^1.6.0
   yaml: ^2.1.13
+
+dependency_overrides:
+  analyzer: ^0.39.0
+  build_resolvers:
+    git:
+      url: git@github.com:dart-lang/build.git
+      path: build_resolvers
+      ref: upgrade-analyzer


### PR DESCRIPTION
Towards #552

Behavior related to type checks have been moved to `TypeSystem`. Keep an
instance of the type system available on `HelperCore` so that we can
access it synchronously where it is needed.

Remove an `assert` that can no longer be supported due to not having a
`TypeSystem` argument available. It would be breaking to change the
signature to pass one in.

Remove one conditional on equivalent types that can no longer be
performed without a breaking change. This likely also breaks behavior
and we will need to find a solution.