### PR TITLE
Method to allow some de-serialisation checks to be overriden at runtime.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@
 .pub
 packages
 pubspec.lock
+.vscode/launch.json

--- a/checked_yaml/pubspec.yaml
+++ b/checked_yaml/pubspec.yaml
@@ -9,12 +9,12 @@ environment:
   sdk: '>=2.3.0 <3.0.0'
 
 dependencies:
-  json_annotation: '>=2.2.0 <4.0.0'
+  json_annotation: '>=3.0.1 <4.0.0'
   source_span: ^1.0.0
   yaml: ^2.1.13
 
 dev_dependencies:
-  json_serializable: ^3.0.0
+  json_serializable: ^3.2.5
   build_runner: ^1.0.0
   build_verify: ^1.1.0
   path: ^1.0.0

--- a/example/pubspec-dev.yaml
+++ b/example/pubspec-dev.yaml
@@ -5,7 +5,7 @@ environment:
   sdk: '>=2.3.0 <3.0.0'
 
 dependencies:
-  json_annotation: ^3.0.0
+  json_annotation: ^3.0.1
 
 dependency_overrides:
   json_annotation:

--- a/example/pubspec-dev.yaml
+++ b/example/pubspec-dev.yaml
@@ -1,0 +1,26 @@
+name: example
+author: Dart Team <misc@dartlang.org>
+
+environment:
+  sdk: '>=2.3.0 <3.0.0'
+
+dependencies:
+  json_annotation: ^3.0.0
+
+dependency_overrides:
+  json_annotation:
+    path: ../json_annotation
+
+dev_dependencies:
+  build_runner: ^1.0.0
+  json_serializable:   ^3.2.0
+
+  # Used by tests. Not required to use `json_serializable`.
+  build_verify: ^1.0.0
+  path: ^1.5.1
+  test: ^1.6.0
+
+
+dev_dependency_overrides:
+  json_serializable:
+    path: ../json_serializable

--- a/json_annotation/lib/json_annotation.dart
+++ b/json_annotation/lib/json_annotation.dart
@@ -15,5 +15,6 @@ export 'src/checked_helpers.dart';
 export 'src/json_converter.dart';
 export 'src/json_key.dart';
 export 'src/json_literal.dart';
+export 'src/json_overrides.dart';
 export 'src/json_serializable.dart';
 export 'src/json_value.dart';

--- a/json_annotation/lib/src/allowed_keys_helpers.dart
+++ b/json_annotation/lib/src/allowed_keys_helpers.dart
@@ -2,6 +2,8 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
+import 'json_overrides.dart';
+
 /// Helper function used in generated `fromJson` code when
 /// `JsonSerializable.disallowUnrecognizedKeys` is true for an annotated type or
 /// `JsonKey.required` is `true` for any annotated fields.
@@ -10,8 +12,13 @@
 void $checkKeys(Map map,
     {List<String> allowedKeys,
     List<String> requiredKeys,
-    List<String> disallowNullValues}) {
-  if (map != null && allowedKeys != null) {
+    List<String> disallowNullValues,
+    JsonOverrides overrides}) {
+  final resolved = JsonOverrides.resolveOverrides(overrides);
+
+  if (map != null &&
+      allowedKeys != null &&
+      resolved.allowedKeys == JsonOverride.none) {
     final invalidKeys =
         map.keys.cast<String>().where((k) => !allowedKeys.contains(k)).toList();
     if (invalidKeys.isNotEmpty) {
@@ -19,7 +26,7 @@ void $checkKeys(Map map,
     }
   }
 
-  if (requiredKeys != null) {
+  if (requiredKeys != null && resolved.requiredKeys == JsonOverride.none) {
     final missingKeys =
         requiredKeys.where((k) => !map.keys.contains(k)).toList();
     if (missingKeys.isNotEmpty) {
@@ -27,7 +34,9 @@ void $checkKeys(Map map,
     }
   }
 
-  if (map != null && disallowNullValues != null) {
+  if (map != null &&
+      disallowNullValues != null &&
+      resolved.disallowNullValues == JsonOverride.none) {
     final nullValuedKeys = map.entries
         .where((entry) =>
             disallowNullValues.contains(entry.key) && entry.value == null)

--- a/json_annotation/lib/src/json_overrides.dart
+++ b/json_annotation/lib/src/json_overrides.dart
@@ -1,0 +1,77 @@
+/// provides control over how runtime overrides
+/// affect serialization/deserialization
+/// [none] - the default generated action is applied
+/// [off] - the default action is ignored and the feature is forced [off].
+enum JsonOverride { none, off }
+
+///
+/// A collection of overrides that can be individually enabled.
+///
+/// The overrides allow you to change the deserialisation/serialization
+/// behaviour at run time.
+///
+/// An example usage would be to generate code with the [allowedKeys]
+/// option disabled which assists in a debug environment but then
+/// remove the rule for production.
+///
+/// If and override isn't set then [JsonOverride.none] is
+/// applied and the default generation rules apply.
+class JsonOverrides {
+  static JsonOverrides _global = JsonOverrides._internal();
+
+  JsonOverride allowedKeys;
+  JsonOverride requiredKeys;
+  JsonOverride disallowNullValues;
+
+  /// Passed to the toJson/fromJson
+  /// methods to override settings for individual types.
+  /// If passed these settings override the global settings
+  /// and the generated settings.
+  JsonOverrides({this.allowedKeys, this.requiredKeys, this.disallowNullValues});
+
+  ///
+  ///[global] allows you to set the default overrides
+  ///which will be applied to all calls to [toJson/fromJson]
+  ///unless an individual [override] has been pass to those
+  ///methods.
+  static set global(JsonOverrides global) {
+    _global = JsonOverrides.from(global);
+  }
+
+  ///
+  ///Set the default global overrides to [JsonOverride.none]
+  JsonOverrides._internal(
+      {this.allowedKeys = JsonOverride.none,
+      this.requiredKeys = JsonOverride.none,
+      this.disallowNullValues = JsonOverride.none});
+
+  JsonOverrides.from(JsonOverrides overrides)
+      : allowedKeys = overrides.allowedKeys,
+        requiredKeys = overrides.requiredKeys,
+        disallowNullValues = overrides.disallowNullValues;
+
+  ///
+  /// Takes a [local] set of [JsonOverrides] (pass to toJson/fromJson)
+  /// and combines them with the global settings to
+  /// generate a resolved set of overrides.
+  /// This calls is responsibe for defining the precedence
+  /// of overrides.
+  static JsonOverrides resolveOverrides(JsonOverrides local) {
+    final resolved = JsonOverrides.from(_global);
+
+    if (local != null) {
+      if (local.allowedKeys == JsonOverride.off) {
+        resolved.allowedKeys = JsonOverride.off;
+      }
+
+      if (local.requiredKeys == JsonOverride.off) {
+        resolved.requiredKeys = JsonOverride.off;
+      }
+
+      if (local.disallowNullValues == JsonOverride.off) {
+        resolved.disallowNullValues = JsonOverride.off;
+      }
+    }
+    return resolved;
+  }
+}

--- a/json_annotation/pubspec-dev.yaml
+++ b/json_annotation/pubspec-dev.yaml
@@ -1,0 +1,14 @@
+name: json_annotation
+version: 3.0.0
+description: >-
+  Classes and helper functions that support JSON code generation via the
+  `json_serializable` package.
+homepage: https://github.com/dart-lang/json_serializable
+author: Dart Team <misc@dartlang.org>
+environment:
+  sdk: '>=2.3.0 <3.0.0'
+
+# When changing JsonSerializable class.
+# dev_dependencies:
+#   build_runner: ^1.0.0
+#   json_serializable: ^3.1.0

--- a/json_annotation/pubspec.yaml
+++ b/json_annotation/pubspec.yaml
@@ -1,5 +1,5 @@
 name: json_annotation
-version: 3.0.0
+version: 3.0.1
 description: >-
   Classes and helper functions that support JSON code generation via the
   `json_serializable` package.

--- a/json_serializable/README.md
+++ b/json_serializable/README.md
@@ -123,6 +123,98 @@ is generated:
   `JsonSerializable`. In these cases, if a value is set explicitly via `JsonKey`
   it will take precedence over any value set on `JsonSerializable`.  
 
+# Runtime overrides
+There are times when you want to override a serialization setting at runtime.
+
+The `JsonOverrides` class allows you to suppress a range of setting on specific 
+classes or globally.
+
+A common use case is to run with a tight set of rules during development
+but relax those rules for production.
+
+You can check if you are running in production mode via:
+```dart
+const bool.fromEnvironment("dart.vm.product");
+ ```
+
+You may also have specific classes that need to run with a more relaxed set of rules in some specific circumstances. If your class should ALWAYs run with a relaxed rules, then look to set a property on  `@JsonSerializable`.
+
+`JsonOverrides` supports the following properties:
+
+```dart
+  JsonOverride allowedKeys;
+  JsonOverride requiredKeys;
+  JsonOverride disallowNullValues;
+```  
+
+with the following options for each property:
+
+```dart
+JsonOverride.none - there is no override, use the generated rule.
+JsonOverride.off - suppress the generated rule.
+```
+
+## Setting an override
+You have two ways of setting overrides.
+ > globally
+
+ > per class
+
+ ### Global override
+ To set a global override, call:
+ 
+ ```dart
+ import 'package:json_annotation/json_annotation.dart';
+
+ JsonOverrides global = JsonOverrides(allowedKeys: JsonOverride.off);
+
+ JsonOverrides.global(global);
+ ```
+Of course, you would normally make this call before doing any serialization,
+but you can set it at any time.
+
+To remove any global overrides call:
+
+```dart
+import 'package:json_annotation/json_annotation.dart';
+
+JsonOverrides global = JsonOverrides(
+    allowedKeys: JsonOverride.off,
+    requiredKeys: JsonOverride.off,
+    disallowNullValues: JsonOverride.off
+    );
+
+ JsonOverrides.global = global;
+```
+
+### Per class overrides
+To override settings for a specific class, you need to modify your classes fromJson method.
+
+if you have any class `User` with an existing fromJson
+
+```dart
+factory User.fromJson(Map<String, dynamic> json
+    ) => _$UserFromJson(json);
+```    
+
+you can override one or more options by passing an override:
+
+```dart
+import 'package:json_annotation/json_annotation.dart';
+
+JsonOverrides override = JsonOverrides(
+    allowedKeys: JsonOverride.off,
+    requiredKeys: JsonOverride.off,
+    disallowNullValues: JsonOverride.off
+    );
+
+factory User.fromJson(Map<String, dynamic> json
+    , overrides: override
+    ) => _$UserFromJson(json);
+
+```
+
+
 # Build configuration
 
 Besides setting arguments on the associated annotation classes, you can also

--- a/json_serializable/lib/src/decode_helper.dart
+++ b/json_serializable/lib/src/decode_helper.dart
@@ -30,7 +30,7 @@ abstract class DecodeHelper implements HelperCore {
     final mapType = config.anyMap ? 'Map' : 'Map<String, dynamic>';
     _buffer.write('$targetClassReference '
         '${prefix}FromJson${genericClassArgumentsImpl(true)}'
-        '($mapType json) {\n');
+        '($mapType json, {JsonOverrides overrides}) {\n');
 
     String deserializeFun(String paramOrFieldName,
             {ParameterElement ctorParam}) =>
@@ -157,6 +157,8 @@ abstract class DecodeHelper implements HelperCore {
     }
 
     if (args.isNotEmpty) {
+      // custom_configuration_test
+      args.add('overrides: overrides');
       _buffer.writeln('${' ' * indent}\$checkKeys(json, ${args.join(', ')});');
     }
   }

--- a/json_serializable/pubspec-dev.yaml
+++ b/json_serializable/pubspec-dev.yaml
@@ -1,5 +1,5 @@
 name: json_serializable
-version: 3.2.4-dev
+version: 3.2.5-dev
 author: Dart Team <misc@dartlang.org>
 description: >-
   Automatically generate code for converting to and from JSON by annotating

--- a/json_serializable/pubspec-dev.yaml
+++ b/json_serializable/pubspec-dev.yaml
@@ -1,0 +1,39 @@
+name: json_serializable
+version: 3.2.4-dev
+author: Dart Team <misc@dartlang.org>
+description: >-
+  Automatically generate code for converting to and from JSON by annotating
+  Dart classes.
+homepage: https://github.com/dart-lang/json_serializable
+environment:
+  sdk: '>=2.3.0 <3.0.0'
+
+dependencies:
+  analyzer: '>=0.37.1 <0.39.0'
+  build: '>=0.12.6 <2.0.0'
+  build_config: '>=0.2.6 <0.5.0'
+
+  # Use a tight version constraint to ensure that a constraint on
+  # `json_annotation` properly constrains all features it provides.
+  # For v3 only – allow a wide range since the only change was to REMOVE things
+  # from json_annotation
+  json_annotation: '>=3.0.0 <3.1.0'
+  meta: ^1.1.0
+  path: ^1.3.2
+  source_gen: ^0.9.0
+
+dependency_overrides:
+  json_annotation:
+    path: ../json_annotation
+
+dev_dependencies:
+  build_runner: ^1.0.0
+  build_verify: ^1.1.0
+  build_web_compilers: '>=1.0.0 <3.0.0'
+  collection: ^1.14.0
+  dart_style: ^1.2.0
+  logging: ^0.11.3+1
+  pub_semver: ^1.4.0
+  source_gen_test: ^0.1.0
+  test: ^1.6.0
+  yaml: ^2.1.13

--- a/json_serializable/pubspec-prod.yaml
+++ b/json_serializable/pubspec-prod.yaml
@@ -1,0 +1,35 @@
+name: json_serializable
+version: 3.2.5
+author: Dart Team <misc@dartlang.org>
+description: >-
+  Automatically generate code for converting to and from JSON by annotating
+  Dart classes.
+homepage: https://github.com/dart-lang/json_serializable
+environment:
+  sdk: '>=2.3.0 <3.0.0'
+
+dependencies:
+  analyzer: '>=0.37.1 <0.39.0'
+  build: '>=0.12.6 <2.0.0'
+  build_config: '>=0.2.6 <0.5.0'
+
+  # Use a tight version constraint to ensure that a constraint on
+  # `json_annotation` properly constrains all features it provides.
+  # For v3 only – allow a wide range since the only change was to REMOVE things
+  # from json_annotation
+  json_annotation: '>=3.0.0 <3.1.0'
+  meta: ^1.1.0
+  path: ^1.3.2
+  source_gen: ^0.9.0
+
+dev_dependencies:
+  build_runner: ^1.0.0
+  build_verify: ^1.1.0
+  build_web_compilers: '>=1.0.0 <3.0.0'
+  collection: ^1.14.0
+  dart_style: ^1.2.0
+  logging: ^0.11.3+1
+  pub_semver: ^1.4.0
+  source_gen_test: ^0.1.0
+  test: ^1.6.0
+  yaml: ^2.1.13

--- a/json_serializable/pubspec-prod.yaml
+++ b/json_serializable/pubspec-prod.yaml
@@ -17,7 +17,7 @@ dependencies:
   # `json_annotation` properly constrains all features it provides.
   # For v3 only – allow a wide range since the only change was to REMOVE things
   # from json_annotation
-  json_annotation: '>=3.0.0 <3.1.0'
+  json_annotation: '>=3.0.1 <3.1.0'
   meta: ^1.1.0
   path: ^1.3.2
   source_gen: ^0.9.0

--- a/json_serializable/pubspec.yaml
+++ b/json_serializable/pubspec.yaml
@@ -1,5 +1,5 @@
 name: json_serializable
-version: 3.2.4-dev
+version: 3.2.5-dev
 author: Dart Team <misc@dartlang.org>
 description: >-
   Automatically generate code for converting to and from JSON by annotating

--- a/json_serializable/pubspec.yaml
+++ b/json_serializable/pubspec.yaml
@@ -1,5 +1,5 @@
 name: json_serializable
-version: 3.2.5-dev
+version: 3.2.5
 author: Dart Team <misc@dartlang.org>
 description: >-
   Automatically generate code for converting to and from JSON by annotating
@@ -17,7 +17,7 @@ dependencies:
   # `json_annotation` properly constrains all features it provides.
   # For v3 only – allow a wide range since the only change was to REMOVE things
   # from json_annotation
-  json_annotation: '>=3.0.0 <3.1.0'
+  json_annotation: '>=3.0.1 <3.1.0'
   meta: ^1.1.0
   path: ^1.3.2
   source_gen: ^0.9.0

--- a/json_serializable/test/integration/integration_test.dart
+++ b/json_serializable/test/integration/integration_test.dart
@@ -2,6 +2,7 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
+import 'package:json_annotation/json_annotation.dart';
 import 'package:test/test.dart';
 
 import '../test_utils.dart';
@@ -186,6 +187,60 @@ void main() {
             microseconds: 12,
           )));
       roundTripOrder(order);
+    });
+  });
+
+  group('SecureOrder', () {
+    void roundTripSecureOrder(SecureOrder p, JsonOverrides overrides) {
+      roundTripObject(p, (json) => SecureOrder.fromJson(json, overrides));
+    }
+
+    void orderToSecureOrder(Order order, JsonOverrides overrides) {
+      final extraKeys = <String, dynamic>{};
+      extraKeys['isRushed'] = null;
+      roundTripDisparateObjects(
+          order, (json) => SecureOrder.fromJson(json, overrides), extraKeys);
+    }
+
+    test('Check SecureOrder working', () {
+      roundTripSecureOrder(
+          SecureOrder(Category.charmed)..statusCode = StatusCode.success, null);
+    });
+
+    test('Succeed with mismatched keys', () {
+      final overrides = JsonOverrides(allowedKeys: JsonOverride.off);
+      orderToSecureOrder(
+          Order(Category.charmed)..statusCode = StatusCode.success, overrides);
+    });
+
+    test('Fail with mismatched keys', () {
+      final overrides = JsonOverrides(allowedKeys: JsonOverride.none);
+      expect(
+          () => orderToSecureOrder(
+              Order(Category.charmed)..statusCode = StatusCode.success,
+              overrides),
+          throwsA(const TypeMatcher<UnrecognizedKeysException>()));
+    });
+
+    test('Local Ingore invalid key', () {
+      final overrides = JsonOverrides(allowedKeys: JsonOverride.off);
+      orderToSecureOrder(
+          Order(Category.charmed)..statusCode = StatusCode.success, overrides);
+    });
+
+    test('Global Ingore invalid key', () {
+      JsonOverrides.global = JsonOverrides(allowedKeys: JsonOverride.off);
+
+      orderToSecureOrder(
+          Order(Category.charmed)..statusCode = StatusCode.success, null);
+
+      // now fail with global set to none
+      JsonOverrides.global = JsonOverrides(allowedKeys: JsonOverride.none);
+
+      expect(
+          () => orderToSecureOrder(
+              Order(Category.charmed)..statusCode = StatusCode.success, null),
+          throwsA(const TypeMatcher<UnrecognizedKeysException>()));
     });
   });
 

--- a/json_serializable/test/integration/json_test_example.dart
+++ b/json_serializable/test/integration/json_test_example.dart
@@ -174,3 +174,65 @@ class MapKeyVariety {
       deepEquals(other.dateTimeIntMap, dateTimeIntMap) &&
       deepEquals(other.bigIntMap, bigIntMap);
 }
+
+/// Used to test that `disallowUnrecognizedKeys: true` can be turned off via JsonOverrides
+@JsonSerializable(disallowUnrecognizedKeys: true)
+class SecureOrder {
+  @JsonKey(disallowNullValue: true)
+  int count;
+
+  // we remove the isRushed field which [Order]
+  // contains so we should get an error if we try
+  // to pass an [Order] as a [SecureOrder] unless
+  // the override is on.
+  // bool isRushed;
+
+  Duration duration;
+
+  @JsonKey(nullable: false)
+  final Category category;
+  final UnmodifiableListView<Item> items;
+  Platform platform;
+  Map<String, Platform> altPlatforms;
+
+  Uri homepage;
+
+  @JsonKey(
+    name: 'status_code',
+    defaultValue: StatusCode.success,
+    nullable: true,
+    unknownEnumValue: StatusCode.unknown,
+  )
+  StatusCode statusCode;
+
+  @JsonKey(ignore: true)
+  String get platformValue => platform?.description;
+
+  set platformValue(String value) {
+    throw UnimplementedError('not impld');
+  }
+
+  // Ignored getter without value set in ctor
+  int get price => items.fold(0, (total, item) => item.price + total);
+
+  @JsonKey(ignore: true)
+  bool shouldBeCached;
+
+  SecureOrder(this.category, [Iterable<Item> items])
+      : items = UnmodifiableListView<Item>(
+            List<Item>.unmodifiable(items ?? const <Item>[]));
+
+  factory SecureOrder.fromJson(
+          Map<String, dynamic> json, JsonOverrides overrides) =>
+      _$SecureOrderFromJson(json, overrides: overrides);
+
+  Map<String, dynamic> toJson() => _$SecureOrderToJson(this);
+
+  @override
+  bool operator ==(Object other) =>
+      other is SecureOrder &&
+      count == other.count &&
+      // isRushed == other.isRushed &&
+      deepEquals(items, other.items) &&
+      deepEquals(altPlatforms, other.altPlatforms);
+}

--- a/json_serializable/test/integration/json_test_example.g.dart
+++ b/json_serializable/test/integration/json_test_example.g.dart
@@ -89,8 +89,8 @@ const _$CategoryEnumMap = {
   Category.notDiscoveredYet: 'not_discovered_yet',
 };
 
-Order _$OrderFromJson(Map<String, dynamic> json) {
-  $checkKeys(json, disallowNullValues: const ['count']);
+Order _$OrderFromJson(Map<String, dynamic> json, {JsonOverrides overrides}) {
+  $checkKeys(json, disallowNullValues: const ['count'], overrides: overrides);
   return Order(
     _$enumDecode(_$CategoryEnumMap, json['category']),
     (json['items'] as List)?.map(
@@ -126,6 +126,63 @@ Map<String, dynamic> _$OrderToJson(Order instance) {
 
   writeNotNull('count', instance.count);
   val['isRushed'] = instance.isRushed;
+  val['duration'] = instance.duration?.inMicroseconds;
+  val['category'] = _$CategoryEnumMap[instance.category];
+  val['items'] = instance.items;
+  val['platform'] = instance.platform;
+  val['altPlatforms'] = instance.altPlatforms;
+  val['homepage'] = instance.homepage?.toString();
+  val['status_code'] = _$StatusCodeEnumMap[instance.statusCode];
+  return val;
+}
+
+SecureOrder _$SecureOrderFromJson(Map<String, dynamic> json,
+    {JsonOverrides overrides}) {
+  $checkKeys(json,
+      disallowNullValues: const ['count'],
+      allowedKeys: const [
+        'duration',
+        'category',
+        'items',
+        'platform',
+        'altPlatforms',
+        'homepage',
+        'status_code'
+      ],
+      overrides: overrides);
+  return SecureOrder(
+    _$enumDecode(_$CategoryEnumMap, json['category']),
+    (json['items'] as List)?.map(
+        (e) => e == null ? null : Item.fromJson(e as Map<String, dynamic>)),
+  )
+    ..count = json['count'] as int
+    ..duration = json['duration'] == null
+        ? null
+        : Duration(microseconds: json['duration'] as int)
+    ..platform = json['platform'] == null
+        ? null
+        : Platform.fromJson(json['platform'] as String)
+    ..altPlatforms = (json['altPlatforms'] as Map<String, dynamic>)?.map(
+      (k, e) => MapEntry(k, e == null ? null : Platform.fromJson(e as String)),
+    )
+    ..homepage =
+        json['homepage'] == null ? null : Uri.parse(json['homepage'] as String)
+    ..statusCode = _$enumDecodeNullable(
+            _$StatusCodeEnumMap, json['status_code'],
+            unknownValue: StatusCode.unknown) ??
+        StatusCode.success;
+}
+
+Map<String, dynamic> _$SecureOrderToJson(SecureOrder instance) {
+  final val = <String, dynamic>{};
+
+  void writeNotNull(String key, dynamic value) {
+    if (value != null) {
+      val[key] = value;
+    }
+  }
+
+  writeNotNull('count', instance.count);
   val['duration'] = instance.duration?.inMicroseconds;
   val['category'] = _$CategoryEnumMap[instance.category];
   val['items'] = instance.items;

--- a/json_serializable/test/integration/json_test_example.g_any_map.g.dart
+++ b/json_serializable/test/integration/json_test_example.g_any_map.g.dart
@@ -95,8 +95,8 @@ const _$CategoryEnumMap = {
   Category.notDiscoveredYet: 'not_discovered_yet',
 };
 
-Order _$OrderFromJson(Map json) {
-  $checkKeys(json, disallowNullValues: const ['count']);
+Order _$OrderFromJson(Map json, {JsonOverrides overrides}) {
+  $checkKeys(json, disallowNullValues: const ['count'], overrides: overrides);
   return Order(
     _$enumDecode(_$CategoryEnumMap, json['category']),
     (json['items'] as List)?.map((e) => e == null

--- a/json_serializable/test/integration/json_test_example.g_non_nullable.g.dart
+++ b/json_serializable/test/integration/json_test_example.g_non_nullable.g.dart
@@ -71,8 +71,8 @@ const _$CategoryEnumMap = {
   Category.notDiscoveredYet: 'not_discovered_yet',
 };
 
-Order _$OrderFromJson(Map<String, dynamic> json) {
-  $checkKeys(json, disallowNullValues: const ['count']);
+Order _$OrderFromJson(Map<String, dynamic> json, {JsonOverrides overrides}) {
+  $checkKeys(json, disallowNullValues: const ['count'], overrides: overrides);
   return Order(
     _$enumDecode(_$CategoryEnumMap, json['category']),
     (json['items'] as List)

--- a/json_serializable/test/src/_json_serializable_test_input.dart
+++ b/json_serializable/test/src/_json_serializable_test_input.dart
@@ -43,7 +43,8 @@ void annotatedMethod() => null;
 
 @ShouldGenerate(
   r'''
-OnlyStaticMembers _$OnlyStaticMembersFromJson(Map<String, dynamic> json) {
+OnlyStaticMembers _$OnlyStaticMembersFromJson(Map<String, dynamic> json,
+    {JsonOverrides overrides}) {
   return OnlyStaticMembers();
 }
 
@@ -62,7 +63,8 @@ class OnlyStaticMembers {
 }
 
 @ShouldGenerate(r'''
-GeneralTestClass1 _$GeneralTestClass1FromJson(Map<String, dynamic> json) {
+GeneralTestClass1 _$GeneralTestClass1FromJson(Map<String, dynamic> json,
+    {JsonOverrides overrides}) {
   return GeneralTestClass1()
     ..firstName = json['firstName'] as String
     ..lastName = json['lastName'] as String
@@ -100,7 +102,8 @@ class GeneralTestClass1 {
 }
 
 @ShouldGenerate(r'''
-GeneralTestClass2 _$GeneralTestClass2FromJson(Map<String, dynamic> json) {
+GeneralTestClass2 _$GeneralTestClass2FromJson(Map<String, dynamic> json,
+    {JsonOverrides overrides}) {
   return GeneralTestClass2(
     json['height'] as int,
     json['firstName'] as String,
@@ -131,7 +134,8 @@ class GeneralTestClass2 {
 }
 
 @ShouldGenerate(r'''
-FinalFields _$FinalFieldsFromJson(Map<String, dynamic> json) {
+FinalFields _$FinalFieldsFromJson(Map<String, dynamic> json,
+    {JsonOverrides overrides}) {
   return FinalFields(
     json['a'] as int,
   );
@@ -154,7 +158,8 @@ class FinalFields {
 @ShouldGenerate(
   r'''
 FinalFieldsNotSetInCtor _$FinalFieldsNotSetInCtorFromJson(
-    Map<String, dynamic> json) {
+    Map<String, dynamic> json,
+    {JsonOverrides overrides}) {
   return FinalFieldsNotSetInCtor();
 }
 
@@ -172,7 +177,8 @@ class FinalFieldsNotSetInCtor {
 }
 
 @ShouldGenerate(r'''
-SetSupport _$SetSupportFromJson(Map<String, dynamic> json) {
+SetSupport _$SetSupportFromJson(Map<String, dynamic> json,
+    {JsonOverrides overrides}) {
   return SetSupport(
     (json['values'] as List)?.map((e) => e as int)?.toSet(),
   );
@@ -397,7 +403,8 @@ enum GoodEnum {
 
 @ShouldGenerate(r'''
 FieldWithFromJsonCtorAndTypeParams _$FieldWithFromJsonCtorAndTypeParamsFromJson(
-    Map<String, dynamic> json) {
+    Map<String, dynamic> json,
+    {JsonOverrides overrides}) {
   return FieldWithFromJsonCtorAndTypeParams()
     ..customOrders = json['customOrders'] == null
         ? null
@@ -444,7 +451,8 @@ mixin _PropInMixinI448RegressionMixin {
 
 @ShouldGenerate(r'''
 PropInMixinI448Regression _$PropInMixinI448RegressionFromJson(
-    Map<String, dynamic> json) {
+    Map<String, dynamic> json,
+    {JsonOverrides overrides}) {
   return PropInMixinI448Regression()
     ..nullable = json['nullable'] as int
     ..notNullable = json['notNullable'] as int;
@@ -465,7 +473,8 @@ class PropInMixinI448Regression with _PropInMixinI448RegressionMixin {
 
 @ShouldGenerate(
   r'''
-IgnoreUnannotated _$IgnoreUnannotatedFromJson(Map<String, dynamic> json) {
+IgnoreUnannotated _$IgnoreUnannotatedFromJson(Map<String, dynamic> json,
+    {JsonOverrides overrides}) {
   return IgnoreUnannotated()..annotated = json['annotated'] as int;
 }
 

--- a/json_serializable/test/src/checked_test_input.dart
+++ b/json_serializable/test/src/checked_test_input.dart
@@ -2,12 +2,14 @@ part of '_json_serializable_test_input.dart';
 
 @ShouldGenerate(r'''
 WithANonCtorGetterChecked _$WithANonCtorGetterCheckedFromJson(
-    Map<String, dynamic> json) {
+    Map<String, dynamic> json,
+    {JsonOverrides overrides}) {
   return $checkedNew('WithANonCtorGetterChecked', json, () {
     $checkKeys(json,
         allowedKeys: const ['items'],
         requiredKeys: const ['items'],
-        disallowNullValues: const ['items']);
+        disallowNullValues: const ['items'],
+        overrides: overrides);
     final val = WithANonCtorGetterChecked(
       $checkedConvert(
           json, 'items', (v) => (v as List)?.map((e) => e as String)?.toList()),
@@ -31,11 +33,13 @@ class WithANonCtorGetterChecked {
 }
 
 @ShouldGenerate(r'''
-WithANonCtorGetter _$WithANonCtorGetterFromJson(Map<String, dynamic> json) {
+WithANonCtorGetter _$WithANonCtorGetterFromJson(Map<String, dynamic> json,
+    {JsonOverrides overrides}) {
   $checkKeys(json,
       allowedKeys: const ['items'],
       requiredKeys: const ['items'],
-      disallowNullValues: const ['items']);
+      disallowNullValues: const ['items'],
+      overrides: overrides);
   return WithANonCtorGetter(
     (json['items'] as List)?.map((e) => e as String)?.toList(),
   );

--- a/json_serializable/test/src/default_value_input.dart
+++ b/json_serializable/test/src/default_value_input.dart
@@ -102,7 +102,8 @@ class DefaultWithNonNullableClass {
 @ShouldGenerate(
   r'''
 DefaultWithToJsonClass _$DefaultWithToJsonClassFromJson(
-    Map<String, dynamic> json) {
+    Map<String, dynamic> json,
+    {JsonOverrides overrides}) {
   return DefaultWithToJsonClass()
     ..fieldDefaultValueToJson = DefaultWithToJsonClass._fromJson(
             json['fieldDefaultValueToJson'] as String) ??
@@ -127,9 +128,12 @@ class DefaultWithToJsonClass {
 
 @ShouldGenerate(r'''
 DefaultWithDisallowNullRequiredClass
-    _$DefaultWithDisallowNullRequiredClassFromJson(Map<String, dynamic> json) {
+    _$DefaultWithDisallowNullRequiredClassFromJson(Map<String, dynamic> json,
+        {JsonOverrides overrides}) {
   $checkKeys(json,
-      requiredKeys: const ['theField'], disallowNullValues: const ['theField']);
+      requiredKeys: const ['theField'],
+      disallowNullValues: const ['theField'],
+      overrides: overrides);
   return DefaultWithDisallowNullRequiredClass()
     ..theField = json['theField'] as int ?? 7;
 }

--- a/json_serializable/test/src/generic_test_input.dart
+++ b/json_serializable/test/src/generic_test_input.dart
@@ -6,7 +6,8 @@ part of '_json_serializable_test_input.dart';
 
 @ShouldGenerate(r'''
 GenericClass<T, S> _$GenericClassFromJson<T extends num, S>(
-    Map<String, dynamic> json) {
+    Map<String, dynamic> json,
+    {JsonOverrides overrides}) {
   return GenericClass<T, S>()
     ..fieldObject = _dataFromJson(json['fieldObject'])
     ..fieldDynamic = _dataFromJson(json['fieldDynamic'])

--- a/json_serializable/test/src/inheritance_test_input.dart
+++ b/json_serializable/test/src/inheritance_test_input.dart
@@ -1,7 +1,8 @@
 part of '_json_serializable_test_input.dart';
 
 @ShouldGenerate(r'''
-SubType _$SubTypeFromJson(Map<String, dynamic> json) {
+SubType _$SubTypeFromJson(Map<String, dynamic> json,
+    {JsonOverrides overrides}) {
   return SubType(
     json['subTypeViaCtor'] as int,
     json['super-final-field'] as int,

--- a/json_serializable/test/src/json_converter_test_input.dart
+++ b/json_serializable/test/src/json_converter_test_input.dart
@@ -6,7 +6,8 @@ part of '_json_serializable_test_input.dart';
 
 @ShouldGenerate(r'''
 JsonConverterNamedCtor<E> _$JsonConverterNamedCtorFromJson<E>(
-    Map<String, dynamic> json) {
+    Map<String, dynamic> json,
+    {JsonOverrides overrides}) {
   return JsonConverterNamedCtor<E>()
     ..value = const _DurationMillisecondConverter.named()
         .fromJson(json['value'] as int)
@@ -44,8 +45,8 @@ class JsonConverterNamedCtor<E> {
 }
 
 @ShouldGenerate(r'''
-JsonConvertOnField<E> _$JsonConvertOnFieldFromJson<E>(
-    Map<String, dynamic> json) {
+JsonConvertOnField<E> _$JsonConvertOnFieldFromJson<E>(Map<String, dynamic> json,
+    {JsonOverrides overrides}) {
   return JsonConvertOnField<E>()
     ..annotatedField = const _DurationMillisecondConverter()
         .fromJson(json['annotatedField'] as int)

--- a/json_serializable/test/src/map_key_variety_test_input.dart
+++ b/json_serializable/test/src/map_key_variety_test_input.dart
@@ -1,7 +1,8 @@
 part of '_json_serializable_test_input.dart';
 
 @ShouldGenerate(r'''
-MapKeyVariety _$MapKeyVarietyFromJson(Map<String, dynamic> json) {
+MapKeyVariety _$MapKeyVarietyFromJson(Map<String, dynamic> json,
+    {JsonOverrides overrides}) {
   return MapKeyVariety()
     ..intIntMap = (json['intIntMap'] as Map<String, dynamic>)?.map(
       (k, e) => MapEntry(int.parse(k), e as int),

--- a/json_serializable/test/src/setter_test_input.dart
+++ b/json_serializable/test/src/setter_test_input.dart
@@ -2,7 +2,8 @@ part of '_json_serializable_test_input.dart';
 
 @ShouldGenerate(
   r'''
-JustSetter _$JustSetterFromJson(Map<String, dynamic> json) {
+JustSetter _$JustSetterFromJson(Map<String, dynamic> json,
+    {JsonOverrides overrides}) {
   return JustSetter();
 }
 
@@ -19,7 +20,8 @@ class JustSetter {
 
 @ShouldGenerate(
   r'''
-JustSetterNoToJson _$JustSetterNoToJsonFromJson(Map<String, dynamic> json) {
+JustSetterNoToJson _$JustSetterNoToJsonFromJson(Map<String, dynamic> json,
+    {JsonOverrides overrides}) {
   return JustSetterNoToJson();
 }
 ''',

--- a/json_serializable/test/src/to_from_json_test_input.dart
+++ b/json_serializable/test/src/to_from_json_test_input.dart
@@ -37,7 +37,8 @@ class InvalidFromFunc2Args {
 @ShouldGenerate(
   r'''
 ValidToFromFuncClassStatic _$ValidToFromFuncClassStaticFromJson(
-    Map<String, dynamic> json) {
+    Map<String, dynamic> json,
+    {JsonOverrides overrides}) {
   return ValidToFromFuncClassStatic()
     ..field = ValidToFromFuncClassStatic._staticFunc(json['field'] as String);
 }
@@ -151,8 +152,8 @@ String _fromDynamicIterable(Iterable input) => null;
 
 @ShouldGenerate(
   r'''
-FromDynamicCollection _$FromDynamicCollectionFromJson(
-    Map<String, dynamic> json) {
+FromDynamicCollection _$FromDynamicCollectionFromJson(Map<String, dynamic> json,
+    {JsonOverrides overrides}) {
   return FromDynamicCollection()
     ..mapField = _fromDynamicMap(json['mapField'] as Map)
     ..listField = _fromDynamicList(json['listField'] as List)

--- a/json_serializable/test/src/unknown_enum_value_test_input.dart
+++ b/json_serializable/test/src/unknown_enum_value_test_input.dart
@@ -2,7 +2,8 @@ part of '_json_serializable_test_input.dart';
 
 @ShouldGenerate(
   r'''
-UnknownEnumValue _$UnknownEnumValueFromJson(Map<String, dynamic> json) {
+UnknownEnumValue _$UnknownEnumValueFromJson(Map<String, dynamic> json,
+    {JsonOverrides overrides}) {
   return UnknownEnumValue()
     ..value = _$enumDecodeNullable(
             _$UnknownEnumValueItemsEnumMap, json['value'],

--- a/json_serializable/test/src/unknown_type_test_input.dart
+++ b/json_serializable/test/src/unknown_type_test_input.dart
@@ -1,7 +1,8 @@
 part of '_json_serializable_test_input.dart';
 
 @ShouldGenerate(r'''
-UnknownCtorParamType _$UnknownCtorParamTypeFromJson(Map<String, dynamic> json) {
+UnknownCtorParamType _$UnknownCtorParamTypeFromJson(Map<String, dynamic> json,
+    {JsonOverrides overrides}) {
   return UnknownCtorParamType(
     json['number'],
   );
@@ -22,7 +23,8 @@ class UnknownCtorParamType {
 }
 
 @ShouldGenerate(r'''
-UnknownFieldType _$UnknownFieldTypeFromJson(Map<String, dynamic> json) {
+UnknownFieldType _$UnknownFieldTypeFromJson(Map<String, dynamic> json,
+    {JsonOverrides overrides}) {
   return UnknownFieldType()..number = json['number'];
 }
 
@@ -52,7 +54,8 @@ class UnknownFieldTypeToJsonOnly {
 
 @ShouldGenerate(r'''
 UnknownFieldTypeWithConvert _$UnknownFieldTypeWithConvertFromJson(
-    Map<String, dynamic> json) {
+    Map<String, dynamic> json,
+    {JsonOverrides overrides}) {
   return UnknownFieldTypeWithConvert()
     ..number = _everythingIs42(json['number']);
 }

--- a/json_serializable/test/test_utils.dart
+++ b/json_serializable/test/test_utils.dart
@@ -21,6 +21,25 @@ T roundTripObject<T>(T object, T factory(Map<String, dynamic> json)) {
   return object2;
 }
 
+R roundTripDisparateObjects<R, T>(T input, R factory(Map<String, dynamic> json),
+    Map<String, dynamic> missingKeys) {
+  final data = loudEncode(input);
+
+  final inputMap = json.decode(data) as Map<String, dynamic>;
+
+  final result = factory(inputMap);
+
+  final output = loudEncode(result);
+
+  // now check the inputMap with the missing keys added back in
+  // match the output map.
+  final outputMap = json.decode(output) as Map<String, dynamic>;
+  outputMap.addAll(missingKeys);
+  expect(inputMap, equals(outputMap));
+
+  return result;
+}
+
 /// Prints out nested causes before throwing `JsonUnsupportedObjectError`.
 String loudEncode(Object object) {
   try {


### PR DESCRIPTION
The aim of this pull request is to provide a mechanism to allow a user to override a number of the deserialisation checks at runtime.
The technique used should allow the mechanism to extended to overriding other settings as need arises.

The mechanism allows overrides to be applied globally or on an individual class basis.

The changes are 100% backwards compatible.

I have updated all existing unit tests to work with the changes as well as introducing additional unit tests to ensure the mechanism works as published.

I've provided documentation in the json_serialization projects README.md file on how to use the new mechanism.

The mechanism is easy to use and can be ignored by existing users.

Motivation:
The motivation behind these changes was driven by a desire to use the 'allowedKeys/requiredKkeys' mechanism during development but to relax these settings during production.

I'm happy to make any changes to meet the projects standards.

Brett

