### PR TITLE
Export TypeHelperContextWithConfig in json_serializable/type_helper.dart

### DIFF
--- a/json_serializable/CHANGELOG.md
+++ b/json_serializable/CHANGELOG.md
@@ -1,3 +1,10 @@
+## unreleased
+
+- Export the following `TypeHelper` implementations and interfaces in
+  `package:json_serializable/type_helper.dart`:
+  - `DurationHelper`
+  - `TypeHelperContextWithConfig`
+
 ## 3.2.5
 
 - Fix lint affecting `pub.dev` score.

--- a/json_serializable/lib/type_helper.dart
+++ b/json_serializable/lib/type_helper.dart
@@ -3,7 +3,8 @@
 // BSD-style license that can be found in the LICENSE file.
 
 export 'src/shared_checkers.dart' show simpleJsonTypeChecker, typeArgumentsOf;
-export 'src/type_helper.dart' show TypeHelperContext, TypeHelper;
+export 'src/type_helper.dart'
+    show TypeHelperContext, TypeHelperContextWithConfig, TypeHelper;
 export 'src/type_helpers/big_int_helper.dart';
 export 'src/type_helpers/convert_helper.dart';
 export 'src/type_helpers/date_time_helper.dart';


### PR DESCRIPTION
Looks like this is the only one not exported - `TypeHelperContextWithConvert` is exported implicitly from `convert_helper.dart`.

refs #602 