### PR TITLE
Ignore implicit_dynamic_parameter in generated code

### DIFF
--- a/example/analysis_options.yaml
+++ b/example/analysis_options.yaml
@@ -1,0 +1,3 @@
+analyzer:
+  strong-mode:
+    implicit-dynamic: false

--- a/example/lib/example.g.dart
+++ b/example/lib/example.g.dart
@@ -6,6 +6,8 @@ part of 'example.dart';
 // JsonSerializableGenerator
 // **************************************************************************
 
+// ignore_for_file: implicit_dynamic_parameter
+
 Person _$PersonFromJson(Map<String, dynamic> json) {
   return Person(
     json['firstName'] as String,

--- a/example/lib/json_converter_example.g.dart
+++ b/example/lib/json_converter_example.g.dart
@@ -6,6 +6,8 @@ part of 'json_converter_example.dart';
 // JsonSerializableGenerator
 // **************************************************************************
 
+// ignore_for_file: implicit_dynamic_parameter
+
 GenericCollection<T> _$GenericCollectionFromJson<T>(Map<String, dynamic> json) {
   return GenericCollection<T>(
     page: json['page'] as int,

--- a/example/test/json_convert_example_test.dart
+++ b/example/test/json_convert_example_test.dart
@@ -64,8 +64,8 @@ void main() {
             jsonDecode(encoded) as Map<String, dynamic>),
         _throwsCastSomething);
 
-    final collection2 =
-        GenericCollection.fromJson(jsonDecode(encoded) as Map<String, dynamic>);
+    final collection2 = GenericCollection<dynamic>.fromJson(
+        jsonDecode(encoded) as Map<String, dynamic>);
 
     expect(collection2.results, [
       1,

--- a/json_serializable/lib/src/json_serializable_generator.dart
+++ b/json_serializable/lib/src/json_serializable_generator.dart
@@ -98,6 +98,11 @@ class _GeneratorHelper extends HelperCore with EncodeHelper, DecodeHelper {
   final JsonSerializableGenerator _generator;
   final _addedMembers = <String>{};
 
+  // Comment to disable analysis errors not currently supported in generated
+  // output. Added to the top of all generated files.
+  static const _ignoredWarningsComment =
+      '// ignore_for_file: implicit_dynamic_parameter';
+
   _GeneratorHelper(
       this._generator, ClassElement element, ConstantReader annotation)
       : super(element, mergeConfig(_generator.config, annotation));
@@ -113,7 +118,7 @@ class _GeneratorHelper extends HelperCore with EncodeHelper, DecodeHelper {
   Iterable<String> _generate() sync* {
     assert(_addedMembers.isEmpty);
 
-    yield ignoredWarningsComment;
+    yield _ignoredWarningsComment;
 
     final sortedFields = createSortedFieldSet(element);
 

--- a/json_serializable/lib/src/json_serializable_generator.dart
+++ b/json_serializable/lib/src/json_serializable_generator.dart
@@ -112,6 +112,9 @@ class _GeneratorHelper extends HelperCore with EncodeHelper, DecodeHelper {
 
   Iterable<String> _generate() sync* {
     assert(_addedMembers.isEmpty);
+
+    yield ignoredWarningsComment;
+
     final sortedFields = createSortedFieldSet(element);
 
     // Used to keep track of why a field is ignored. Useful for providing

--- a/json_serializable/lib/src/utils.dart
+++ b/json_serializable/lib/src/utils.dart
@@ -256,3 +256,7 @@ extension DartTypeExtension on DartType {
       element.library == null ||
       element.library.typeSystem.isAssignableTo(this, other);
 }
+
+/// Comment to disable analysis errors not currently supported in generated
+/// output. Added to the top of all generated files.
+const ignoredWarningsComment = '// ignore_for_file: implicit_dynamic_parameter';

--- a/json_serializable/lib/src/utils.dart
+++ b/json_serializable/lib/src/utils.dart
@@ -256,7 +256,3 @@ extension DartTypeExtension on DartType {
       element.library == null ||
       element.library.typeSystem.isAssignableTo(this, other);
 }
-
-/// Comment to disable analysis errors not currently supported in generated
-/// output. Added to the top of all generated files.
-const ignoredWarningsComment = '// ignore_for_file: implicit_dynamic_parameter';

--- a/json_serializable/test/src/default_value_input.dart
+++ b/json_serializable/test/src/default_value_input.dart
@@ -126,6 +126,8 @@ class DefaultWithToJsonClass {
 }
 
 @ShouldGenerate(r'''
+// ignore_for_file: implicit_dynamic_parameter
+
 DefaultWithDisallowNullRequiredClass
     _$DefaultWithDisallowNullRequiredClassFromJson(Map<String, dynamic> json) {
   $checkKeys(json,


### PR DESCRIPTION
**Done and looking for feedback on**
- Resolved #557 by ignoring specific warning in `json_serializable` generated code
- Updated `example` generated code
- Added `implicit-dynamic: false` to `example` to demo, let me know if this should be removed

**Need advisement**
- Updating tests. I have fixed 1 test out of ~40 that fail because the expected output is no longer correct. I'm happy to update them (see the one I updated), but I am wondering if we would prefer to do a contains check instead of an exact match check (which would make all these tests pass without having to update the expected outputs). Or if the inner test code should strip out the warning before comparing. May want to consider future lints we need to disable (NNDB as one example, other Strong Mode stuff, etc)
