### PR TITLE
Allow specifying ignore_for_file option in build.yaml

### DIFF
--- a/_test_yaml/build.yaml
+++ b/_test_yaml/build.yaml
@@ -1,0 +1,9 @@
+# Read about `build.yaml` at https://pub.dev/packages/build_config
+targets:
+  $default:
+    builders:
+      json_serializable:
+        options:
+          ignore_for_file:
+          - lines_longer_than_80_chars
+          - prefer_expression_function_bodies

--- a/_test_yaml/test/src/build_config.g.dart
+++ b/_test_yaml/test/src/build_config.g.dart
@@ -6,6 +6,8 @@ part of 'build_config.dart';
 // JsonSerializableGenerator
 // **************************************************************************
 
+// ignore_for_file: lines_longer_than_80_chars, prefer_expression_function_bodies
+
 Config _$ConfigFromJson(Map json) {
   return $checkedNew('Config', json, () {
     $checkKeys(json, requiredKeys: const ['builders']);

--- a/analysis_options.yaml
+++ b/analysis_options.yaml
@@ -44,6 +44,7 @@ linter:
     - join_return_with_assignment
     - library_names
     - library_prefixes
+    - lines_longer_than_80_chars
     - list_remove_unrelated_type
     - literal_only_boolean_expressions
     - no_duplicate_case_values
@@ -64,6 +65,7 @@ linter:
     - prefer_const_declarations
     - prefer_contains
     - prefer_equal_for_default_values
+    - prefer_expression_function_bodies
     - prefer_final_fields
     - prefer_final_locals
     - prefer_for_elements_to_map_fromIterable

--- a/checked_yaml/build.yaml
+++ b/checked_yaml/build.yaml
@@ -1,0 +1,9 @@
+# Read about `build.yaml` at https://pub.dev/packages/build_config
+targets:
+  $default:
+    builders:
+      json_serializable:
+        options:
+          ignore_for_file:
+          - lines_longer_than_80_chars
+          - prefer_expression_function_bodies

--- a/checked_yaml/example/example.g.dart
+++ b/checked_yaml/example/example.g.dart
@@ -6,6 +6,8 @@ part of 'example.dart';
 // JsonSerializableGenerator
 // **************************************************************************
 
+// ignore_for_file: lines_longer_than_80_chars, prefer_expression_function_bodies
+
 Configuration _$ConfigurationFromJson(Map json) {
   return $checkedNew('Configuration', json, () {
     $checkKeys(json,

--- a/checked_yaml/pubspec.yaml
+++ b/checked_yaml/pubspec.yaml
@@ -14,9 +14,13 @@ dependencies:
   yaml: ^2.1.13
 
 dev_dependencies:
-  json_serializable: ^3.0.0
+  json_serializable: ^3.3.0
   build_runner: ^1.0.0
   build_verify: ^1.1.0
   path: ^1.0.0
   test: ^1.6.0
   test_process: ^1.0.1
+
+dependency_overrides:
+  json_serializable:
+    path: ../json_serializable

--- a/example/README.md
+++ b/example/README.md
@@ -9,7 +9,7 @@ dependencies:
 
 dev_dependencies:
   build_runner: ^1.0.0
-  json_serializable: ^3.2.0
+  json_serializable: ^3.3.0
 ```
 
 Annotate your code with classes defined in

--- a/example/build.yaml
+++ b/example/build.yaml
@@ -1,0 +1,9 @@
+# Read about `build.yaml` at https://pub.dev/packages/build_config
+targets:
+  $default:
+    builders:
+      json_serializable:
+        options:
+          ignore_for_file:
+          - lines_longer_than_80_chars
+          - prefer_expression_function_bodies

--- a/example/lib/example.g.dart
+++ b/example/lib/example.g.dart
@@ -6,6 +6,8 @@ part of 'example.dart';
 // JsonSerializableGenerator
 // **************************************************************************
 
+// ignore_for_file: lines_longer_than_80_chars, prefer_expression_function_bodies
+
 Person _$PersonFromJson(Map<String, dynamic> json) {
   return Person(
     json['firstName'] as String,
@@ -87,6 +89,8 @@ Map<String, dynamic> _$ItemToJson(Item instance) => <String, dynamic>{
 // **************************************************************************
 // JsonLiteralGenerator
 // **************************************************************************
+
+// ignore_for_file: lines_longer_than_80_chars, prefer_expression_function_bodies
 
 final _$glossaryDataJsonLiteral = {
   'glossary': {

--- a/example/lib/json_converter_example.dart
+++ b/example/lib/json_converter_example.dart
@@ -47,12 +47,11 @@ class _Converter<T> implements JsonConverter<T, Object> {
   }
 
   @override
-  Object toJson(T object) {
-    // This will only work if `object` is a native JSON type:
-    //   num, String, bool, null, etc
-    // Or if it has a `toJson()` function`.
-    return object;
-  }
+  Object toJson(T object) =>
+      // This will only work if `object` is a native JSON type:
+      //   num, String, bool, null, etc
+      // Or if it has a `toJson()` function`.
+      object;
 }
 
 @JsonSerializable()

--- a/example/lib/json_converter_example.g.dart
+++ b/example/lib/json_converter_example.g.dart
@@ -6,6 +6,8 @@ part of 'json_converter_example.dart';
 // JsonSerializableGenerator
 // **************************************************************************
 
+// ignore_for_file: lines_longer_than_80_chars, prefer_expression_function_bodies
+
 GenericCollection<T> _$GenericCollectionFromJson<T>(Map<String, dynamic> json) {
   return GenericCollection<T>(
     page: json['page'] as int,

--- a/example/pubspec.yaml
+++ b/example/pubspec.yaml
@@ -9,7 +9,7 @@ dependencies:
 
 dev_dependencies:
   build_runner: ^1.0.0
-  json_serializable: ^3.2.0
+  json_serializable: ^3.3.0
 
   # Used by tests. Not required to use `json_serializable`.
   build_verify: ^1.0.0

--- a/example/test/readme_test.dart
+++ b/example/test/readme_test.dart
@@ -24,5 +24,5 @@ dependencies:
 
 dev_dependencies:
   build_runner: ^1.0.0
-  json_serializable: ^3.2.0
+  json_serializable: ^3.3.0
 ''';

--- a/json_annotation/build.yaml
+++ b/json_annotation/build.yaml
@@ -1,0 +1,9 @@
+# Read about `build.yaml` at https://pub.dev/packages/build_config
+targets:
+  $default:
+    builders:
+      json_serializable:
+        options:
+          ignore_for_file:
+          - lines_longer_than_80_chars
+          - prefer_expression_function_bodies

--- a/json_annotation/lib/src/json_serializable.g.dart
+++ b/json_annotation/lib/src/json_serializable.g.dart
@@ -6,6 +6,8 @@ part of 'json_serializable.dart';
 // JsonSerializableGenerator
 // **************************************************************************
 
+// ignore_for_file: lines_longer_than_80_chars, prefer_expression_function_bodies
+
 JsonSerializable _$JsonSerializableFromJson(Map<String, dynamic> json) {
   return $checkedNew('JsonSerializable', json, () {
     $checkKeys(json, allowedKeys: const [

--- a/json_annotation/pubspec.yaml
+++ b/json_annotation/pubspec.yaml
@@ -10,4 +10,4 @@ environment:
 # When changing JsonSerializable class.
 # dev_dependencies:
 #   build_runner: ^1.0.0
-#   json_serializable: ^3.1.0
+#   json_serializable: ^3.3.0

--- a/json_serializable/CHANGELOG.md
+++ b/json_serializable/CHANGELOG.md
@@ -1,7 +1,17 @@
-## unreleased
+## 3.3.0-dev
 
-- Export the following `TypeHelper` implementations and interfaces in
-  `package:json_serializable/type_helper.dart`:
+- Added the `ignore_for_file` `build.yaml` option. It allows a developer to
+  specify static analysis errors, warnings, and hints that should be ignored for
+  a generated file. If provided, the value must be specified as a Yaml list.
+
+- `json_serializable.dart`
+  - The return type of `JsonLiteralGenerator.generateForAnnotatedElement` is
+    now `Stream<String>` instead of `Future<String>`.
+    - While strictly a breaking change, we do not consider direct usage of this
+      API a supported use case of this package.
+
+- `type_helper.dart`: Export the following `TypeHelper` implementations and
+  interfaces:
   - `DurationHelper`
   - `TypeHelperContextWithConfig`
 

--- a/json_serializable/README.md
+++ b/json_serializable/README.md
@@ -72,6 +72,7 @@ is generated:
 
 | `build.yaml` key           | JsonSerializable                            | JsonKey                     |
 | -------------------------- | ------------------------------------------- | --------------------------- |
+| ignore_for_file            |                                             |                             |
 | any_map                    | [JsonSerializable.anyMap]                   |                             |
 | checked                    | [JsonSerializable.checked]                  |                             |
 | create_factory             | [JsonSerializable.createFactory]            |                             |
@@ -91,26 +92,26 @@ is generated:
 |                            |                                             | [JsonKey.toJson]            |
 |                            |                                             | [JsonKey.unknownEnumValue]  |
 
-[JsonSerializable.anyMap]: https://pub.dev/documentation/json_annotation/latest/json_annotation/JsonSerializable/anyMap.html
-[JsonSerializable.checked]: https://pub.dev/documentation/json_annotation/latest/json_annotation/JsonSerializable/checked.html
-[JsonSerializable.createFactory]: https://pub.dev/documentation/json_annotation/latest/json_annotation/JsonSerializable/createFactory.html
-[JsonSerializable.createToJson]: https://pub.dev/documentation/json_annotation/latest/json_annotation/JsonSerializable/createToJson.html
-[JsonSerializable.disallowUnrecognizedKeys]: https://pub.dev/documentation/json_annotation/latest/json_annotation/JsonSerializable/disallowUnrecognizedKeys.html
-[JsonSerializable.explicitToJson]: https://pub.dev/documentation/json_annotation/latest/json_annotation/JsonSerializable/explicitToJson.html
-[JsonSerializable.fieldRename]: https://pub.dev/documentation/json_annotation/latest/json_annotation/JsonSerializable/fieldRename.html
-[JsonSerializable.ignoreUnannotated]: https://pub.dev/documentation/json_annotation/latest/json_annotation/JsonSerializable/ignoreUnannotated.html
-[JsonSerializable.includeIfNull]: https://pub.dev/documentation/json_annotation/latest/json_annotation/JsonSerializable/includeIfNull.html
-[JsonKey.includeIfNull]: https://pub.dev/documentation/json_annotation/latest/json_annotation/JsonKey/includeIfNull.html
-[JsonSerializable.nullable]: https://pub.dev/documentation/json_annotation/latest/json_annotation/JsonSerializable/nullable.html
-[JsonKey.nullable]: https://pub.dev/documentation/json_annotation/latest/json_annotation/JsonKey/nullable.html
-[JsonKey.defaultValue]: https://pub.dev/documentation/json_annotation/latest/json_annotation/JsonKey/defaultValue.html
-[JsonKey.disallowNullValue]: https://pub.dev/documentation/json_annotation/latest/json_annotation/JsonKey/disallowNullValue.html
-[JsonKey.fromJson]: https://pub.dev/documentation/json_annotation/latest/json_annotation/JsonKey/fromJson.html
-[JsonKey.ignore]: https://pub.dev/documentation/json_annotation/latest/json_annotation/JsonKey/ignore.html
-[JsonKey.name]: https://pub.dev/documentation/json_annotation/latest/json_annotation/JsonKey/name.html
-[JsonKey.required]: https://pub.dev/documentation/json_annotation/latest/json_annotation/JsonKey/required.html
-[JsonKey.toJson]: https://pub.dev/documentation/json_annotation/latest/json_annotation/JsonKey/toJson.html
-[JsonKey.unknownEnumValue]: https://pub.dev/documentation/json_annotation/latest/json_annotation/JsonKey/unknownEnumValue.html
+[JsonSerializable.anyMap]: https://pub.dev/documentation/json_annotation/3.0.1/json_annotation/JsonSerializable/anyMap.html
+[JsonSerializable.checked]: https://pub.dev/documentation/json_annotation/3.0.1/json_annotation/JsonSerializable/checked.html
+[JsonSerializable.createFactory]: https://pub.dev/documentation/json_annotation/3.0.1/json_annotation/JsonSerializable/createFactory.html
+[JsonSerializable.createToJson]: https://pub.dev/documentation/json_annotation/3.0.1/json_annotation/JsonSerializable/createToJson.html
+[JsonSerializable.disallowUnrecognizedKeys]: https://pub.dev/documentation/json_annotation/3.0.1/json_annotation/JsonSerializable/disallowUnrecognizedKeys.html
+[JsonSerializable.explicitToJson]: https://pub.dev/documentation/json_annotation/3.0.1/json_annotation/JsonSerializable/explicitToJson.html
+[JsonSerializable.fieldRename]: https://pub.dev/documentation/json_annotation/3.0.1/json_annotation/JsonSerializable/fieldRename.html
+[JsonSerializable.ignoreUnannotated]: https://pub.dev/documentation/json_annotation/3.0.1/json_annotation/JsonSerializable/ignoreUnannotated.html
+[JsonSerializable.includeIfNull]: https://pub.dev/documentation/json_annotation/3.0.1/json_annotation/JsonSerializable/includeIfNull.html
+[JsonKey.includeIfNull]: https://pub.dev/documentation/json_annotation/3.0.1/json_annotation/JsonKey/includeIfNull.html
+[JsonSerializable.nullable]: https://pub.dev/documentation/json_annotation/3.0.1/json_annotation/JsonSerializable/nullable.html
+[JsonKey.nullable]: https://pub.dev/documentation/json_annotation/3.0.1/json_annotation/JsonKey/nullable.html
+[JsonKey.defaultValue]: https://pub.dev/documentation/json_annotation/3.0.1/json_annotation/JsonKey/defaultValue.html
+[JsonKey.disallowNullValue]: https://pub.dev/documentation/json_annotation/3.0.1/json_annotation/JsonKey/disallowNullValue.html
+[JsonKey.fromJson]: https://pub.dev/documentation/json_annotation/3.0.1/json_annotation/JsonKey/fromJson.html
+[JsonKey.ignore]: https://pub.dev/documentation/json_annotation/3.0.1/json_annotation/JsonKey/ignore.html
+[JsonKey.name]: https://pub.dev/documentation/json_annotation/3.0.1/json_annotation/JsonKey/name.html
+[JsonKey.required]: https://pub.dev/documentation/json_annotation/3.0.1/json_annotation/JsonKey/required.html
+[JsonKey.toJson]: https://pub.dev/documentation/json_annotation/3.0.1/json_annotation/JsonKey/toJson.html
+[JsonKey.unknownEnumValue]: https://pub.dev/documentation/json_annotation/3.0.1/json_annotation/JsonKey/unknownEnumValue.html
 
 > Note: every `JsonSerializable` field is configurable via `build.yaml` –
   see the table for the corresponding key.
@@ -138,6 +139,7 @@ targets:
           # `@JsonSerializable`-annotated class in the package.
           #
           # The default value for each is listed.
+          ignore_for_file: null
           any_map: false
           checked: false
           create_factory: true
@@ -149,6 +151,11 @@ targets:
           include_if_null: true
           nullable: true
 ```
+
+`ignore_for_file` allows a developer to specify static analysis errors,
+warnings, and hints that should be ignored for a generated file. If provided,
+the value must be specified as a Yaml list. `ignore_for_file` is the only 
+`build.yaml` option that does not also exist on the `JsonSerializable` class. 
 
 [example]: https://github.com/dart-lang/json_serializable/blob/master/example
 [Dart Build System]: https://github.com/dart-lang/build

--- a/json_serializable/build.yaml
+++ b/json_serializable/build.yaml
@@ -3,6 +3,11 @@ targets:
   $default:
     builders:
       json_serializable:
+        options:
+          ignore_for_file:
+          - lines_longer_than_80_chars
+          - prefer_expression_function_bodies
+
         generate_for:
         - example/*
         - test/default_value/*

--- a/json_serializable/doc/doc.md
+++ b/json_serializable/doc/doc.md
@@ -1,5 +1,6 @@
 | `build.yaml` key           | JsonSerializable                            | JsonKey                     |
 | -------------------------- | ------------------------------------------- | --------------------------- |
+| ignore_for_file            |                                             |                             |
 | any_map                    | [JsonSerializable.anyMap]                   |                             |
 | checked                    | [JsonSerializable.checked]                  |                             |
 | create_factory             | [JsonSerializable.createFactory]            |                             |
@@ -19,23 +20,23 @@
 |                            |                                             | [JsonKey.toJson]            |
 |                            |                                             | [JsonKey.unknownEnumValue]  |
 
-[JsonSerializable.anyMap]: https://pub.dev/documentation/json_annotation/latest/json_annotation/JsonSerializable/anyMap.html
-[JsonSerializable.checked]: https://pub.dev/documentation/json_annotation/latest/json_annotation/JsonSerializable/checked.html
-[JsonSerializable.createFactory]: https://pub.dev/documentation/json_annotation/latest/json_annotation/JsonSerializable/createFactory.html
-[JsonSerializable.createToJson]: https://pub.dev/documentation/json_annotation/latest/json_annotation/JsonSerializable/createToJson.html
-[JsonSerializable.disallowUnrecognizedKeys]: https://pub.dev/documentation/json_annotation/latest/json_annotation/JsonSerializable/disallowUnrecognizedKeys.html
-[JsonSerializable.explicitToJson]: https://pub.dev/documentation/json_annotation/latest/json_annotation/JsonSerializable/explicitToJson.html
-[JsonSerializable.fieldRename]: https://pub.dev/documentation/json_annotation/latest/json_annotation/JsonSerializable/fieldRename.html
-[JsonSerializable.ignoreUnannotated]: https://pub.dev/documentation/json_annotation/latest/json_annotation/JsonSerializable/ignoreUnannotated.html
-[JsonSerializable.includeIfNull]: https://pub.dev/documentation/json_annotation/latest/json_annotation/JsonSerializable/includeIfNull.html
-[JsonKey.includeIfNull]: https://pub.dev/documentation/json_annotation/latest/json_annotation/JsonKey/includeIfNull.html
-[JsonSerializable.nullable]: https://pub.dev/documentation/json_annotation/latest/json_annotation/JsonSerializable/nullable.html
-[JsonKey.nullable]: https://pub.dev/documentation/json_annotation/latest/json_annotation/JsonKey/nullable.html
-[JsonKey.defaultValue]: https://pub.dev/documentation/json_annotation/latest/json_annotation/JsonKey/defaultValue.html
-[JsonKey.disallowNullValue]: https://pub.dev/documentation/json_annotation/latest/json_annotation/JsonKey/disallowNullValue.html
-[JsonKey.fromJson]: https://pub.dev/documentation/json_annotation/latest/json_annotation/JsonKey/fromJson.html
-[JsonKey.ignore]: https://pub.dev/documentation/json_annotation/latest/json_annotation/JsonKey/ignore.html
-[JsonKey.name]: https://pub.dev/documentation/json_annotation/latest/json_annotation/JsonKey/name.html
-[JsonKey.required]: https://pub.dev/documentation/json_annotation/latest/json_annotation/JsonKey/required.html
-[JsonKey.toJson]: https://pub.dev/documentation/json_annotation/latest/json_annotation/JsonKey/toJson.html
-[JsonKey.unknownEnumValue]: https://pub.dev/documentation/json_annotation/latest/json_annotation/JsonKey/unknownEnumValue.html
+[JsonSerializable.anyMap]: https://pub.dev/documentation/json_annotation/3.0.1/json_annotation/JsonSerializable/anyMap.html
+[JsonSerializable.checked]: https://pub.dev/documentation/json_annotation/3.0.1/json_annotation/JsonSerializable/checked.html
+[JsonSerializable.createFactory]: https://pub.dev/documentation/json_annotation/3.0.1/json_annotation/JsonSerializable/createFactory.html
+[JsonSerializable.createToJson]: https://pub.dev/documentation/json_annotation/3.0.1/json_annotation/JsonSerializable/createToJson.html
+[JsonSerializable.disallowUnrecognizedKeys]: https://pub.dev/documentation/json_annotation/3.0.1/json_annotation/JsonSerializable/disallowUnrecognizedKeys.html
+[JsonSerializable.explicitToJson]: https://pub.dev/documentation/json_annotation/3.0.1/json_annotation/JsonSerializable/explicitToJson.html
+[JsonSerializable.fieldRename]: https://pub.dev/documentation/json_annotation/3.0.1/json_annotation/JsonSerializable/fieldRename.html
+[JsonSerializable.ignoreUnannotated]: https://pub.dev/documentation/json_annotation/3.0.1/json_annotation/JsonSerializable/ignoreUnannotated.html
+[JsonSerializable.includeIfNull]: https://pub.dev/documentation/json_annotation/3.0.1/json_annotation/JsonSerializable/includeIfNull.html
+[JsonKey.includeIfNull]: https://pub.dev/documentation/json_annotation/3.0.1/json_annotation/JsonKey/includeIfNull.html
+[JsonSerializable.nullable]: https://pub.dev/documentation/json_annotation/3.0.1/json_annotation/JsonSerializable/nullable.html
+[JsonKey.nullable]: https://pub.dev/documentation/json_annotation/3.0.1/json_annotation/JsonKey/nullable.html
+[JsonKey.defaultValue]: https://pub.dev/documentation/json_annotation/3.0.1/json_annotation/JsonKey/defaultValue.html
+[JsonKey.disallowNullValue]: https://pub.dev/documentation/json_annotation/3.0.1/json_annotation/JsonKey/disallowNullValue.html
+[JsonKey.fromJson]: https://pub.dev/documentation/json_annotation/3.0.1/json_annotation/JsonKey/fromJson.html
+[JsonKey.ignore]: https://pub.dev/documentation/json_annotation/3.0.1/json_annotation/JsonKey/ignore.html
+[JsonKey.name]: https://pub.dev/documentation/json_annotation/3.0.1/json_annotation/JsonKey/name.html
+[JsonKey.required]: https://pub.dev/documentation/json_annotation/3.0.1/json_annotation/JsonKey/required.html
+[JsonKey.toJson]: https://pub.dev/documentation/json_annotation/3.0.1/json_annotation/JsonKey/toJson.html
+[JsonKey.unknownEnumValue]: https://pub.dev/documentation/json_annotation/3.0.1/json_annotation/JsonKey/unknownEnumValue.html

--- a/json_serializable/example/example.g.dart
+++ b/json_serializable/example/example.g.dart
@@ -6,6 +6,8 @@ part of 'example.dart';
 // JsonSerializableGenerator
 // **************************************************************************
 
+// ignore_for_file: lines_longer_than_80_chars, prefer_expression_function_bodies
+
 Person _$PersonFromJson(Map<String, dynamic> json) {
   return Person(
     firstName: json['firstName'] as String,

--- a/json_serializable/lib/builder.dart
+++ b/json_serializable/lib/builder.dart
@@ -23,8 +23,12 @@ import 'src/json_part_builder.dart';
 /// Not meant to be invoked by hand-authored code.
 Builder jsonSerializable(BuilderOptions options) {
   try {
-    final config = JsonSerializable.fromJson(options.config);
-    return jsonPartBuilder(config: config);
+    final configOptions = Map<String, dynamic>.of(options.config);
+    final ignoreForFile = Set<String>.from(
+      configOptions.remove('ignore_for_file') as List ?? <String>[],
+    );
+    final config = JsonSerializable.fromJson(configOptions);
+    return jsonPartBuilder(config: config, ignoreForFile: ignoreForFile);
   } on CheckedFromJsonException catch (e) {
     final lines = <String>[
       'Could not parse the options provided for `json_serializable`.'

--- a/json_serializable/lib/src/json_literal_generator.dart
+++ b/json_serializable/lib/src/json_literal_generator.dart
@@ -14,14 +14,25 @@ import 'package:source_gen/source_gen.dart';
 import 'utils.dart';
 
 class JsonLiteralGenerator extends GeneratorForAnnotation<JsonLiteral> {
-  const JsonLiteralGenerator();
+  final Set<String> _ignoreForFile;
+
+  const JsonLiteralGenerator({
+    Set<String> ignoreForFile,
+  }) : _ignoreForFile = ignoreForFile ?? const <String>{};
 
   @override
-  Future<String> generateForAnnotatedElement(
-      Element element, ConstantReader annotation, BuildStep buildStep) async {
+  Stream<String> generateForAnnotatedElement(
+    Element element,
+    ConstantReader annotation,
+    BuildStep buildStep,
+  ) async* {
     if (p.isAbsolute(annotation.read('path').stringValue)) {
       throw ArgumentError(
           '`annotation.path` must be relative path to the source file.');
+    }
+
+    if (_ignoreForFile.isNotEmpty) {
+      yield '// ignore_for_file: ${_ignoreForFile.join(', ')}';
     }
 
     final sourcePathDir = p.dirname(buildStep.inputId.path);
@@ -34,7 +45,7 @@ class JsonLiteralGenerator extends GeneratorForAnnotation<JsonLiteral> {
     final thing = jsonLiteralAsDart(content).toString();
     final marked = asConst ? 'const' : 'final';
 
-    return '$marked _\$${element.name}JsonLiteral = $thing;';
+    yield '$marked _\$${element.name}JsonLiteral = $thing;';
   }
 }
 

--- a/json_serializable/lib/src/json_part_builder.dart
+++ b/json_serializable/lib/src/json_part_builder.dart
@@ -17,9 +17,20 @@ import 'json_serializable_generator.dart';
 Builder jsonPartBuilder({
   String Function(String code) formatOutput,
   JsonSerializable config,
-}) =>
-    SharedPartBuilder(
-      [JsonSerializableGenerator(config: config), const JsonLiteralGenerator()],
-      'json_serializable',
-      formatOutput: formatOutput,
-    );
+  Set<String> ignoreForFile,
+}) {
+  ignoreForFile ??= const <String>{};
+  return SharedPartBuilder(
+    [
+      JsonSerializableGenerator(
+        config: config,
+        ignoreForFile: ignoreForFile,
+      ),
+      JsonLiteralGenerator(
+        ignoreForFile: ignoreForFile,
+      ),
+    ],
+    'json_serializable',
+    formatOutput: formatOutput,
+  );
+}

--- a/json_serializable/lib/src/type_helpers/enum_helper.dart
+++ b/json_serializable/lib/src/type_helpers/enum_helper.dart
@@ -77,8 +77,8 @@ String _enumValueMapFromType(DartType targetType) {
   }
 
   final items = enumMap.entries
-      .map((e) =>
-          '  ${targetType.element.name}.${e.key.name}: ${jsonLiteralAsDart(e.value)},')
+      .map((e) => '  ${targetType.element.name}.${e.key.name}: '
+          '${jsonLiteralAsDart(e.value)},')
       .join();
 
   return 'const ${_constMapName(targetType)} = {\n$items\n};';

--- a/json_serializable/lib/src/type_helpers/map_helper.dart
+++ b/json_serializable/lib/src/type_helpers/map_helper.dart
@@ -41,8 +41,8 @@ class MapHelper extends TypeHelper<TypeHelperContextWithConfig> {
 
     final optionalQuestion = context.nullable ? '?' : '';
 
-    return '$expression$optionalQuestion'
-        '.map(($_keyParam, $closureArg) => MapEntry($subKeyValue, $subFieldValue))';
+    return '$expression$optionalQuestion.map(($_keyParam, $closureArg) => '
+        'MapEntry($subKeyValue, $subFieldValue))';
   }
 
   @override
@@ -69,8 +69,8 @@ class MapHelper extends TypeHelper<TypeHelperContextWithConfig> {
             return '$expression as Map';
           }
         } else {
-          // this is the trivial case. Do a runtime cast to the known type of JSON
-          // map values - `Map<String, dynamic>`
+          // this is the trivial case. Do a runtime cast to the known type of
+          // JSON map values - `Map<String, dynamic>`
           return '$expression as Map<String, dynamic>';
         }
       }

--- a/json_serializable/pubspec.yaml
+++ b/json_serializable/pubspec.yaml
@@ -1,5 +1,5 @@
 name: json_serializable
-version: 3.2.5
+version: 3.3.0-dev
 description: >-
   Automatically generate code for converting to and from JSON by annotating
   Dart classes.

--- a/json_serializable/test/default_value/default_value.g.dart
+++ b/json_serializable/test/default_value/default_value.g.dart
@@ -6,6 +6,8 @@ part of 'default_value.dart';
 // JsonSerializableGenerator
 // **************************************************************************
 
+// ignore_for_file: lines_longer_than_80_chars, prefer_expression_function_bodies
+
 DefaultValue _$DefaultValueFromJson(Map<String, dynamic> json) {
   return DefaultValue()
     ..fieldBool = json['fieldBool'] as bool ?? true

--- a/json_serializable/test/default_value/default_value.g_any_map__checked.g.dart
+++ b/json_serializable/test/default_value/default_value.g_any_map__checked.g.dart
@@ -6,6 +6,8 @@ part of 'default_value.g_any_map__checked.dart';
 // JsonSerializableGenerator
 // **************************************************************************
 
+// ignore_for_file: lines_longer_than_80_chars, prefer_expression_function_bodies
+
 DefaultValue _$DefaultValueFromJson(Map json) {
   return $checkedNew('DefaultValue', json, () {
     final val = DefaultValue();

--- a/json_serializable/test/generic_files/generic_class.dart
+++ b/json_serializable/test/generic_files/generic_class.dart
@@ -101,7 +101,6 @@ class _DurationListMillisecondConverter
   List<Duration> fromJson(int json) => [Duration(milliseconds: json)];
 
   @override
-  int toJson(List<Duration> object) => object?.fold<int>(0, (sum, obj) {
-        return sum + obj.inMilliseconds;
-      });
+  int toJson(List<Duration> object) =>
+      object?.fold<int>(0, (sum, obj) => sum + obj.inMilliseconds);
 }

--- a/json_serializable/test/generic_files/generic_class.g.dart
+++ b/json_serializable/test/generic_files/generic_class.g.dart
@@ -6,6 +6,8 @@ part of 'generic_class.dart';
 // JsonSerializableGenerator
 // **************************************************************************
 
+// ignore_for_file: lines_longer_than_80_chars, prefer_expression_function_bodies
+
 GenericClass<T, S> _$GenericClassFromJson<T extends num, S>(
     Map<String, dynamic> json) {
   return GenericClass<T, S>()

--- a/json_serializable/test/integration/json_test_example.g.dart
+++ b/json_serializable/test/integration/json_test_example.g.dart
@@ -6,6 +6,8 @@ part of 'json_test_example.dart';
 // JsonSerializableGenerator
 // **************************************************************************
 
+// ignore_for_file: lines_longer_than_80_chars, prefer_expression_function_bodies
+
 Person _$PersonFromJson(Map<String, dynamic> json) {
   return Person(
     json['firstName'] as String,

--- a/json_serializable/test/integration/json_test_example.g_any_map.g.dart
+++ b/json_serializable/test/integration/json_test_example.g_any_map.g.dart
@@ -6,6 +6,8 @@ part of 'json_test_example.g_any_map.dart';
 // JsonSerializableGenerator
 // **************************************************************************
 
+// ignore_for_file: lines_longer_than_80_chars, prefer_expression_function_bodies
+
 Person _$PersonFromJson(Map json) {
   return Person(
     json['firstName'] as String,

--- a/json_serializable/test/integration/json_test_example.g_non_nullable.g.dart
+++ b/json_serializable/test/integration/json_test_example.g_non_nullable.g.dart
@@ -6,6 +6,8 @@ part of 'json_test_example.g_non_nullable.dart';
 // JsonSerializableGenerator
 // **************************************************************************
 
+// ignore_for_file: lines_longer_than_80_chars, prefer_expression_function_bodies
+
 Person _$PersonFromJson(Map<String, dynamic> json) {
   return Person(
     json['firstName'] as String,

--- a/json_serializable/test/kitchen_sink/kitchen_sink.g.dart
+++ b/json_serializable/test/kitchen_sink/kitchen_sink.g.dart
@@ -6,6 +6,8 @@ part of 'kitchen_sink.dart';
 // JsonSerializableGenerator
 // **************************************************************************
 
+// ignore_for_file: lines_longer_than_80_chars, prefer_expression_function_bodies
+
 KitchenSink _$KitchenSinkFromJson(Map<String, dynamic> json) {
   return KitchenSink(
     ctorValidatedNo42: json['no-42'] as int,

--- a/json_serializable/test/kitchen_sink/kitchen_sink.g_any_map.g.dart
+++ b/json_serializable/test/kitchen_sink/kitchen_sink.g_any_map.g.dart
@@ -6,6 +6,8 @@ part of 'kitchen_sink.g_any_map.dart';
 // JsonSerializableGenerator
 // **************************************************************************
 
+// ignore_for_file: lines_longer_than_80_chars, prefer_expression_function_bodies
+
 KitchenSink _$KitchenSinkFromJson(Map json) {
   return KitchenSink(
     ctorValidatedNo42: json['no-42'] as int,

--- a/json_serializable/test/kitchen_sink/kitchen_sink.g_any_map__checked__non_nullable.g.dart
+++ b/json_serializable/test/kitchen_sink/kitchen_sink.g_any_map__checked__non_nullable.g.dart
@@ -6,6 +6,8 @@ part of 'kitchen_sink.g_any_map__checked__non_nullable.dart';
 // JsonSerializableGenerator
 // **************************************************************************
 
+// ignore_for_file: lines_longer_than_80_chars, prefer_expression_function_bodies
+
 KitchenSink _$KitchenSinkFromJson(Map json) {
   return $checkedNew('KitchenSink', json, () {
     final val = KitchenSink(

--- a/json_serializable/test/kitchen_sink/kitchen_sink.g_any_map__non_nullable.g.dart
+++ b/json_serializable/test/kitchen_sink/kitchen_sink.g_any_map__non_nullable.g.dart
@@ -6,6 +6,8 @@ part of 'kitchen_sink.g_any_map__non_nullable.dart';
 // JsonSerializableGenerator
 // **************************************************************************
 
+// ignore_for_file: lines_longer_than_80_chars, prefer_expression_function_bodies
+
 KitchenSink _$KitchenSinkFromJson(Map json) {
   return KitchenSink(
     ctorValidatedNo42: json['no-42'] as int,

--- a/json_serializable/test/kitchen_sink/kitchen_sink.g_exclude_null.g.dart
+++ b/json_serializable/test/kitchen_sink/kitchen_sink.g_exclude_null.g.dart
@@ -6,6 +6,8 @@ part of 'kitchen_sink.g_exclude_null.dart';
 // JsonSerializableGenerator
 // **************************************************************************
 
+// ignore_for_file: lines_longer_than_80_chars, prefer_expression_function_bodies
+
 KitchenSink _$KitchenSinkFromJson(Map<String, dynamic> json) {
   return KitchenSink(
     ctorValidatedNo42: json['no-42'] as int,

--- a/json_serializable/test/kitchen_sink/kitchen_sink.g_exclude_null__non_nullable.g.dart
+++ b/json_serializable/test/kitchen_sink/kitchen_sink.g_exclude_null__non_nullable.g.dart
@@ -6,6 +6,8 @@ part of 'kitchen_sink.g_exclude_null__non_nullable.dart';
 // JsonSerializableGenerator
 // **************************************************************************
 
+// ignore_for_file: lines_longer_than_80_chars, prefer_expression_function_bodies
+
 KitchenSink _$KitchenSinkFromJson(Map<String, dynamic> json) {
   return KitchenSink(
     ctorValidatedNo42: json['no-42'] as int,

--- a/json_serializable/test/kitchen_sink/kitchen_sink.g_explicit_to_json.g.dart
+++ b/json_serializable/test/kitchen_sink/kitchen_sink.g_explicit_to_json.g.dart
@@ -6,6 +6,8 @@ part of 'kitchen_sink.g_explicit_to_json.dart';
 // JsonSerializableGenerator
 // **************************************************************************
 
+// ignore_for_file: lines_longer_than_80_chars, prefer_expression_function_bodies
+
 KitchenSink _$KitchenSinkFromJson(Map<String, dynamic> json) {
   return KitchenSink(
     ctorValidatedNo42: json['no-42'] as int,

--- a/json_serializable/test/kitchen_sink/kitchen_sink.g_non_nullable.g.dart
+++ b/json_serializable/test/kitchen_sink/kitchen_sink.g_non_nullable.g.dart
@@ -6,6 +6,8 @@ part of 'kitchen_sink.g_non_nullable.dart';
 // JsonSerializableGenerator
 // **************************************************************************
 
+// ignore_for_file: lines_longer_than_80_chars, prefer_expression_function_bodies
+
 KitchenSink _$KitchenSinkFromJson(Map<String, dynamic> json) {
   return KitchenSink(
     ctorValidatedNo42: json['no-42'] as int,

--- a/json_serializable/test/kitchen_sink/simple_object.g.dart
+++ b/json_serializable/test/kitchen_sink/simple_object.g.dart
@@ -6,6 +6,8 @@ part of 'simple_object.dart';
 // JsonSerializableGenerator
 // **************************************************************************
 
+// ignore_for_file: lines_longer_than_80_chars, prefer_expression_function_bodies
+
 SimpleObject _$SimpleObjectFromJson(Map json) {
   return SimpleObject(
     json['value'] as int,

--- a/json_serializable/test/kitchen_sink/strict_keys_object.g.dart
+++ b/json_serializable/test/kitchen_sink/strict_keys_object.g.dart
@@ -6,6 +6,8 @@ part of 'strict_keys_object.dart';
 // JsonSerializableGenerator
 // **************************************************************************
 
+// ignore_for_file: lines_longer_than_80_chars, prefer_expression_function_bodies
+
 StrictKeysObject _$StrictKeysObjectFromJson(Map json) {
   $checkKeys(json,
       allowedKeys: const ['value', 'custom_field'],

--- a/json_serializable/test/literal/json_literal.g.dart
+++ b/json_serializable/test/literal/json_literal.g.dart
@@ -6,6 +6,8 @@ part of 'json_literal.dart';
 // JsonLiteralGenerator
 // **************************************************************************
 
+// ignore_for_file: lines_longer_than_80_chars, prefer_expression_function_bodies
+
 final _$dataJsonLiteral = [
   {
     'backspace': '\b',

--- a/json_serializable/tool/build_only_options.dart
+++ b/json_serializable/tool/build_only_options.dart
@@ -1,0 +1,6 @@
+// Copyright (c) 2020, the Dart project authors. Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+/// Options that are only available in build.yaml and not `JsonSerializable`.
+const buildOnlyOptions = ['ignore_for_file'];

--- a/json_serializable/tool/doc_builder.dart
+++ b/json_serializable/tool/doc_builder.dart
@@ -1,6 +1,7 @@
 // Copyright (c) 2019, the Dart project authors. Please see the AUTHORS file
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
+
 import 'dart:async';
 
 import 'package:analyzer/dart/element/element.dart';
@@ -9,6 +10,8 @@ import 'package:json_serializable/src/utils.dart';
 import 'package:pub_semver/pub_semver.dart';
 import 'package:source_gen/source_gen.dart';
 import 'package:yaml/yaml.dart';
+
+import 'build_only_options.dart';
 
 Builder docBuilder([_]) => _DocBuilder();
 
@@ -55,7 +58,7 @@ class _DocBuilder extends Builder {
     final rows = <List<String>>[
       ['`build.yaml` key', _jsonSerializable, _jsonKey],
       ['-', '-', '-'],
-      ['ignore_for_file', '', ''],
+      for (var option in buildOnlyOptions) [option, '', ''],
       for (var info in sortedValues)
         [
           info.buildKey,

--- a/json_serializable/tool/doc_builder.dart
+++ b/json_serializable/tool/doc_builder.dart
@@ -55,6 +55,7 @@ class _DocBuilder extends Builder {
     final rows = <List<String>>[
       ['`build.yaml` key', _jsonSerializable, _jsonKey],
       ['-', '-', '-'],
+      ['ignore_for_file', '', ''],
       for (var info in sortedValues)
         [
           info.buildKey,


### PR DESCRIPTION
If provided, the builders for JSON serialization and literals will include
`// ignore_for_file:`` entries in generated files.

Fixes https://github.com/dart-lang/json_serializable/issues/557
Closes https://github.com/dart-lang/json_serializable/pull/604