### PR TITLE
Add an explicit type on enumMaps

### DIFF
--- a/json_serializable/lib/src/type_helpers/enum_helper.dart
+++ b/json_serializable/lib/src/type_helpers/enum_helper.dart
@@ -81,7 +81,8 @@ String _enumValueMapFromType(DartType targetType) {
           '${jsonLiteralAsDart(e.value)},')
       .join();
 
-  return 'const ${_constMapName(targetType)} = {\n$items\n};';
+  return 'const ${_constMapName(targetType)} = '
+      '<${targetType.element.name}, dynamic>{\n$items\n};';
 }
 
 const _enumDecodeHelper = r'''

--- a/json_serializable/test/default_value/default_value.g.dart
+++ b/json_serializable/test/default_value/default_value.g.dart
@@ -88,7 +88,7 @@ T _$enumDecodeNullable<T>(
   return _$enumDecode<T>(enumValues, source, unknownValue: unknownValue);
 }
 
-const _$GreekEnumMap = {
+const _$GreekEnumMap = <Greek, dynamic>{
   Greek.alpha: 'alpha',
   Greek.beta: 'beta',
   Greek.gamma: 'gamma',

--- a/json_serializable/test/default_value/default_value.g_any_map__checked.g.dart
+++ b/json_serializable/test/default_value/default_value.g_any_map__checked.g.dart
@@ -106,7 +106,7 @@ T _$enumDecodeNullable<T>(
   return _$enumDecode<T>(enumValues, source, unknownValue: unknownValue);
 }
 
-const _$GreekEnumMap = {
+const _$GreekEnumMap = <Greek, dynamic>{
   Greek.alpha: 'alpha',
   Greek.beta: 'beta',
   Greek.gamma: 'gamma',

--- a/json_serializable/test/integration/json_test_example.g.dart
+++ b/json_serializable/test/integration/json_test_example.g.dart
@@ -79,7 +79,7 @@ T _$enumDecodeNullable<T>(
   return _$enumDecode<T>(enumValues, source, unknownValue: unknownValue);
 }
 
-const _$CategoryEnumMap = {
+const _$CategoryEnumMap = <Category, dynamic>{
   Category.top: 'top',
   Category.bottom: 'bottom',
   Category.strange: 'strange',
@@ -136,7 +136,7 @@ Map<String, dynamic> _$OrderToJson(Order instance) {
   return val;
 }
 
-const _$StatusCodeEnumMap = {
+const _$StatusCodeEnumMap = <StatusCode, dynamic>{
   StatusCode.success: 200,
   StatusCode.notFound: 404,
   StatusCode.weird: '500',

--- a/json_serializable/test/integration/json_test_example.g_any_map.g.dart
+++ b/json_serializable/test/integration/json_test_example.g_any_map.g.dart
@@ -85,7 +85,7 @@ T _$enumDecodeNullable<T>(
   return _$enumDecode<T>(enumValues, source, unknownValue: unknownValue);
 }
 
-const _$CategoryEnumMap = {
+const _$CategoryEnumMap = <Category, dynamic>{
   Category.top: 'top',
   Category.bottom: 'bottom',
   Category.strange: 'strange',
@@ -146,7 +146,7 @@ Map<String, dynamic> _$OrderToJson(Order instance) {
   return val;
 }
 
-const _$StatusCodeEnumMap = {
+const _$StatusCodeEnumMap = <StatusCode, dynamic>{
   StatusCode.success: 200,
   StatusCode.notFound: 404,
   StatusCode.weird: '500',

--- a/json_serializable/test/integration/json_test_example.g_non_nullable.g.dart
+++ b/json_serializable/test/integration/json_test_example.g_non_nullable.g.dart
@@ -61,7 +61,7 @@ T _$enumDecode<T>(
   return value ?? unknownValue;
 }
 
-const _$CategoryEnumMap = {
+const _$CategoryEnumMap = <Category, dynamic>{
   Category.top: 'top',
   Category.bottom: 'bottom',
   Category.strange: 'strange',
@@ -115,7 +115,7 @@ T _$enumDecodeNullable<T>(
   return _$enumDecode<T>(enumValues, source, unknownValue: unknownValue);
 }
 
-const _$StatusCodeEnumMap = {
+const _$StatusCodeEnumMap = <StatusCode, dynamic>{
   StatusCode.success: 200,
   StatusCode.notFound: 404,
   StatusCode.weird: '500',


### PR DESCRIPTION
This works around a bug in the NNBD SDKs. It should not be necessary in
the long term, but also shouldn't hurt anything.

Work around https://github.com/dart-lang/sdk/issues/41180