### PR TITLE
Ignore deprecated member usage from pkg:analyzer

### DIFF
--- a/json_serializable/lib/src/field_helpers.dart
+++ b/json_serializable/lib/src/field_helpers.dart
@@ -85,6 +85,7 @@ Iterable<FieldElement> createSortedFieldSet(ClassElement element) {
   final inheritedFields = <String, FieldElement>{};
   final manager = InheritanceManager3();
 
+  // ignore: deprecated_member_use
   for (final v in manager.getInheritedConcreteMap(element.thisType).values) {
     assert(v is! FieldElement);
     if (_dartCoreObjectChecker.isExactly(v.enclosingElement)) {

--- a/json_serializable/lib/src/shared_checkers.dart
+++ b/json_serializable/lib/src/shared_checkers.dart
@@ -38,13 +38,13 @@ const simpleJsonTypeChecker = TypeChecker.any([
 ]);
 
 String asStatement(DartType type) {
-  if (type.isDynamic || type.isObject) {
+  if (isObjectOrDynamic(type)) {
     return '';
   }
 
   if (coreIterableTypeChecker.isAssignableFromType(type)) {
     final itemType = coreIterableGenericType(type);
-    if (itemType.isDynamic || itemType.isObject) {
+    if (isObjectOrDynamic(itemType)) {
       return ' as List';
     }
   }
@@ -53,7 +53,7 @@ String asStatement(DartType type) {
     final args = typeArgumentsOf(type, coreMapTypeChecker);
     assert(args.length == 2);
 
-    if (args.every((dt) => dt.isDynamic || dt.isObject)) {
+    if (args.every(isObjectOrDynamic)) {
       return ' as Map';
     }
   }
@@ -61,6 +61,9 @@ String asStatement(DartType type) {
   final typeCode = typeToCode(type);
   return ' as $typeCode';
 }
+
+// ignore: deprecated_member_use
+bool isObjectOrDynamic(DartType type) => type.isObject || type.isDynamic;
 
 /// Returns all of the [DartType] types that [type] implements, mixes-in, and
 /// extends, starting with [type] itself.

--- a/json_serializable/lib/src/type_helpers/map_helper.dart
+++ b/json_serializable/lib/src/type_helpers/map_helper.dart
@@ -60,13 +60,13 @@ class MapHelper extends TypeHelper<TypeHelperContextWithConfig> {
 
     _checkSafeKeyType(expression, keyArg);
 
-    final valueArgIsAny = _isObjectOrDynamic(valueArg);
+    final valueArgIsAny = isObjectOrDynamic(valueArg);
     final isKeyStringable = _isKeyStringable(keyArg);
 
     if (!isKeyStringable) {
       if (valueArgIsAny) {
         if (context.config.anyMap) {
-          if (_isObjectOrDynamic(keyArg)) {
+          if (isObjectOrDynamic(keyArg)) {
             return '$expression as Map';
           }
         } else {
@@ -97,7 +97,7 @@ class MapHelper extends TypeHelper<TypeHelperContextWithConfig> {
     String keyUsage;
     if (isEnum(keyArg)) {
       keyUsage = context.deserialize(keyArg, _keyParam).toString();
-    } else if (context.config.anyMap && !_isObjectOrDynamic(keyArg)) {
+    } else if (context.config.anyMap && !isObjectOrDynamic(keyArg)) {
       keyUsage = '$_keyParam as String';
     } else {
       keyUsage = _keyParam;
@@ -127,8 +127,6 @@ final _instances = [
 ToFromStringHelper _forType(DartType type) =>
     _instances.singleWhere((i) => i.matches(type), orElse: () => null);
 
-bool _isObjectOrDynamic(DartType type) => type.isObject || type.isDynamic;
-
 /// Returns `true` if [keyType] can be automatically converted to/from String –
 /// and is therefor usable as a key in a [Map].
 bool _isKeyStringable(DartType keyType) =>
@@ -137,7 +135,7 @@ bool _isKeyStringable(DartType keyType) =>
 void _checkSafeKeyType(String expression, DartType keyArg) {
   // We're not going to handle converting key types at the moment
   // So the only safe types for key are dynamic/Object/String/enum
-  final safeKey = _isObjectOrDynamic(keyArg) ||
+  final safeKey = isObjectOrDynamic(keyArg) ||
       coreStringTypeChecker.isExactlyType(keyArg) ||
       _isKeyStringable(keyArg);
 

--- a/json_serializable/lib/src/type_helpers/value_helper.dart
+++ b/json_serializable/lib/src/type_helpers/value_helper.dart
@@ -15,8 +15,7 @@ class ValueHelper extends TypeHelper {
   @override
   String serialize(
       DartType targetType, String expression, TypeHelperContext context) {
-    if (targetType.isDynamic ||
-        targetType.isObject ||
+    if (isObjectOrDynamic(targetType) ||
         simpleJsonTypeChecker.isAssignableFromType(targetType)) {
       return expression;
     }
@@ -27,7 +26,7 @@ class ValueHelper extends TypeHelper {
   @override
   String deserialize(
       DartType targetType, String expression, TypeHelperContext context) {
-    if (targetType.isDynamic || targetType.isObject) {
+    if (isObjectOrDynamic(targetType)) {
       // just return it as-is. We'll hope it's safe.
       return expression;
     } else if (const TypeChecker.fromUrl('dart:core#double')


### PR DESCRIPTION
DRY up use of type.isObject